### PR TITLE
layouts: add date for each release

### DIFF
--- a/layouts/releases/single.html
+++ b/layouts/releases/single.html
@@ -26,6 +26,11 @@
               <span class="badge badge-light">{{ index $pkgSorted $i }} -<span class="font-weight-light"> {{ $ver }}</span></span>
               {{ end }}
            </div>
+           <div class="card-footer">
+             <span class="badge badge-light">
+               {{ $chan.current.github_release.published_at }}
+             </span>
+           </div>
        </div>
        {{ end }}
     </div>


### PR DESCRIPTION
So far Flatcar Linux documents didn't have a date field for each release.

Add a simple row for release date.

