### PR TITLE
Remove copyright year

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@ canonifyurls: true
 paginate: 8
 theme: flatcar
 languageCode: en-us
-copyright: © 2018 Kinvolk GmbH
+copyright: © Kinvolk GmbH
 pluralizelisttitles: 'false'
 author:
   name: Chris Kuehl


### PR DESCRIPTION
It's 2020. Is it better to remove the year?

Edit: remove year based on Andy's feedback.