### PR TITLE
Add JSON release files

### DIFF
--- a/static/releases-json/releases-alpha.json
+++ b/static/releases-json/releases-alpha.json
@@ -1,0 +1,1508 @@
+{
+  "1745.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-04-25 14:36:35 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.0"
+      ],
+      "ignition": [
+        "0.24.0"
+      ],
+      "kernel": [
+        "4.15.15"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nInitial Flatcar release.\n\nNotes:\n- Previous test images have been removed from the release servers. This is due to a new update key being generated using our updated security policy which we [included](https://github.com/flatcar-linux/coreos-overlay/pull/6) in the first public image.\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1745.0.0):\n\nSecurity fixes:\n- Fix curl out of bounds read ([CVE-2018-1000005](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000005))\n- Fix curl authentication data leak ([CVE-2018-1000007](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000007))\n- Fix curl buffer overflow ([CVE-2018-1000120](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000120))\n- Fix glibc integer overflow in libcidn ([CVE-2017-14062](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14062))\n- Fix glibc memory issues in `glob()` with `~` ([CVE-2017-15670](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15670), [CVE-2017-15671](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15671), [CVE-2017-15804](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15804))\n- Fix glibc mishandling RPATHs with `$ORIGIN` on setuid binaries ([CVE-2017-16997](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-16997))\n- Fix glibc buffer underflow in `realpath()` ([CVE-2018-1000001](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000001))\n- Fix glibc integer overflow and heap corruption in `memalign()` ([CVE-2018-6485](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-6485))\n\nBug fixes:\n- Fix GRUB crash at boot ([#2284](https://github.com/coreos/bugs/issues/2284))\n\nUpdates:\n- curl [7.59.0](https://curl.haxx.se/changes.html#7_59_0)\n- etcd-wrapper [3.3.3](https://github.com/coreos/etcd/releases/tag/v3.3.3)\n- etcdctl [3.3.3](https://github.com/coreos/etcd/releases/tag/v3.3.3)\n- glibc [2.25](https://www.sourceware.org/ml/libc-alpha/2017-02/msg00079.html)\n- Ignition [0.24.0](https://github.com/coreos/ignition/releases/tag/v0.24.0)\n- Linux [4.15.15](https://lwn.net/Articles/750656/)\n- Update Engine [0.4.6](https://github.com/coreos/update_engine/releases/tag/v0.4.6)"
+  },
+  "1758.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-04-26 09:58:53 +0000",
+    "major_software": {
+      "docker": [
+        "18.04.0"
+      ],
+      "ignition": [
+        "0.24.0"
+      ],
+      "kernel": [
+        "4.16.3"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1758.0.0):\n\nSecurity fixes:\n - Fix ntp clock manipulation from ephemeral connections ([CVE-2016-1549](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1549), [CVE-2018-7170](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7170))\n - Fix ntp denial of service from out of bounds read ([CVE-2018-7182](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7182)) \n - Fix ntp denial of service from packets with timestamp 0 ([CVE-2018-7184](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7184), [CVE-2018-7185](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7185))\n - Fix ntp remote code execution ([CVE-2018-7183](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7183))\n\nBug fixes:\n - Pass `/etc/machine-id` from the host to the kubelet\n - Fix docker2aci tar conversion ([#2402](https://github.com/coreos/bugs/issues/2402))\n - Switch `/boot` from FAT16 to FAT32 ([#2246](https://github.com/coreos/bugs/issues/2246))\n\nChanges:\n - Make Ignition failures more visible on the console\n\nUpdates:\n - containerd [1.0.3](https://github.com/containerd/containerd/releases/tag/v1.0.3)\n - coreos-cloudinit [1.14.0](https://github.com/coreos/coreos-cloudinit/releases/tag/v1.14.0)\n - coreos-metadata [1.0.6](https://github.com/coreos/coreos-metadata/releases/tag/v1.0.6)\n - Docker [18.04.0-ce](https://docs.docker.com/release-notes/docker-ce/#18040-ce-2018-04-10)\n - Go [1.9.5](https://golang.org/doc/devel/release.html#go1.9.minor)\n - Go [1.10.1](https://golang.org/doc/devel/release.html#go1.10.minor)\n - Linux [4.16.3](https://lwn.net/ml/linux-kernel/20180419074956.GA22325@kroah.com/)\n - ntp [4.2.8p11](https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ChangeLog-stable)\n - rkt [1.30.0](https://github.com/rkt/rkt/releases/tag/v1.30.0)\n - Rust [1.25.0](https://blog.rust-lang.org/2018/03/29/Rust-1.25.html)\n - torcx [0.1.3](https://github.com/coreos/torcx/releases/tag/v0.1.3)\n - update-ssh-keys [0.1.2](https://github.com/coreos/update-ssh-keys/releases/tag/v0.1.2)"
+  },
+  "1772.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-05-11 11:45:29 +0000",
+    "major_software": {
+      "docker": [
+        "18.04.0"
+      ],
+      "ignition": [
+        "0.24.0"
+      ],
+      "kernel": [
+        "4.16.7"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1772.0.0):\n\nBug fixes:\n- Fix GRUB free magic error on existing systems ([#2400](https://github.com/coreos/bugs/issues/2400))\n\nChanges:\n- Support storing sudoers in SSSD and LDAP\n- No longer publish Oracle Cloud release images\n\nUpdates:\n- audit [2.7.1](https://github.com/linux-audit/audit-userspace/blob/60aa3f2bc5f6483654599af4cb91731714079e26/ChangeLog)\n- coreutils [8.28](https://git.savannah.gnu.org/cgit/coreutils.git/tree/NEWS?h=v8.28)\n- etcd-wrapper [3.3.4](https://github.com/coreos/etcd/releases/tag/v3.3.4)\n- etcdctl [3.3.4](https://github.com/coreos/etcd/releases/tag/v3.3.4)\n- Go [1.9.6](https://golang.org/doc/devel/release.html#go1.9.minor)\n- Go [1.10.2](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Linux [4.16.7](https://lwn.net/Articles/753348/)\n- sudo [1.8.23](https://www.sudo.ws/stable.html#1.8.23)\n- Update Engine [0.4.7](https://github.com/coreos/update_engine/releases/tag/v0.4.7)\n- wa-linux-agent [2.2.25](https://github.com/Azure/WALinuxAgent/releases/tag/v2.2.25)"
+  },
+  "1786.0.1": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-05-26 15:29:50 +0000",
+    "major_software": {
+      "docker": [
+        "18.05.0"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.16.10"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1786.0.1):\n\nSecurity fixes:\n\n- Fix ncurses denial of service and arbitrary code execution ([CVE-2017-10684](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-10684), [CVE-2017-10685](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-10685), [CVE-2017-11112](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11112), [CVE-2017-11113](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11113), [CVE-2017-13728](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-13728), [CVE-2017-13729](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-13729), [CVE-2017-13730](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-13730), [CVE-2017-13731](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-13731), [CVE-2017-13732](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-13732), [CVE-2017-13733](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-13733), [CVE-2017-13734](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-13734), [CVE-2017-16879](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-16879))\n- Fix rsync arbitrary command execution ([CVE-2018-5764](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-5764))\n- Fix wget cookie injection ([CVE-2018-0494](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0494))\n\nChanges:\n- Enable QLogic FCoE offload support ([#2367](https://github.com/coreos/bugs/issues/2367))\n- Enable hardware RNG kernel drivers ([#2430](https://github.com/coreos/bugs/issues/2430))\n- Add `notrap` to ntpd default access restrictions ([#2220](https://github.com/coreos/bugs/issues/2220))\n- Allow booting default GRUB menu entry if GRUB password is enabled ([#1597](https://github.com/coreos/bugs/issues/1597))\n- `coreos-install -i` no longer modifies `grub.cfg` ([#2291](https://github.com/coreos/bugs/issues/2291))\n- QEMU wrapper script now enables VirtIO RNG device\n\nUpdates:\n- bind-tools [9.11.2-P1](https://kb.isc.org/article/AA-01550/0/BIND-9.11.2-P1-Release-Notes.html)\n- Docker [18.05.0-ce](https://github.com/docker/docker-ce/releases/tag/v18.05.0-ce)\n- etcd-wrapper [3.3.5](https://github.com/coreos/etcd/releases/tag/v3.3.5)\n- etcdctl [3.3.5](https://github.com/coreos/etcd/releases/tag/v3.3.5)\n- GnuPG [2.2.7](https://lists.gnupg.org/pipermail/gnupg-announce/2018q2/000424.html)\n- GPT fdisk [1.0.3](https://sourceforge.net/p/gptfdisk/code/ci/f1f6236fb44392bfe5673bc3889a2b17b1696b90/tree/NEWS)\n- Ignition [0.25.1](https://github.com/coreos/ignition/releases/tag/v0.25.1)\n- Less [529](http://www.greenwoodsoftware.com/less/news.529.html)\n- Linux [4.16.10](https://lwn.net/Articles/754971/)\n- rsync [3.1.3](https://download.samba.org/pub/rsync/src/rsync-3.1.3-NEWS)\n- Rust [1.26](https://blog.rust-lang.org/2018/05/10/Rust-1.26.html)\n- util-linux [2.32](https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.32/v2.32-ReleaseNotes)\n- vim [8.0.1298](http://ftp.vim.org/pub/vim/patches/8.0/README)\n- wget [1.19.5](https://git.savannah.gnu.org/cgit/wget.git/tree/NEWS?h=v1.19.5&id=15a39093b8751596fe87a6c1f143dff6b6a818ee)"
+  },
+  "1786.1.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-05-27 09:02:47 +0000",
+    "major_software": {
+      "docker": [
+        "18.05.0"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.16.10"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1786.1.0):\n\nBug fixes:\n- Fix inadvertent change of network interface names ([#2437](https://github.com/coreos/bugs/issues/2437))\n- Fix Docker bind mounts from root filesystem ([#2440](https://github.com/coreos/bugs/issues/2440))\n"
+  },
+  "1786.2.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-01 13:23:42 +0000",
+    "major_software": {
+      "docker": [
+        "18.05.0"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.16.13"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1786.2.0):\n\nSecurity fixes:\n- Fix Git arbitrary code execution when cloning untrusted repositories ([CVE-2018-11235](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11235))\n\nBug fixes:\n- Fix failure to set network interface MTU ([#2443](https://github.com/coreos/bugs/issues/2443))\n\nUpdates:\n- Git [2.16.4](https://raw.githubusercontent.com/git/git/v2.16.4/Documentation/RelNotes/2.16.4.txt)\n- Linux [4.16.13](https://lwn.net/Articles/755961/)"
+  },
+  "1800.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-12 10:15:01 +0000",
+    "major_software": {
+      "docker": [
+        "18.05.0"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.16.14"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1800.0.0):\n\nSecurity fixes:\n - Fix multiple procps vulnerabilities ([CVE-2018-1120](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1120), [CVE-2018-1121](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1121), [CVE-2018-1122](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1122), [CVE-2018-1123](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1123), [CVE-2018-1124](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1124), [CVE-2018-1125](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1125), [CVE-2018-1126](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1126), [CVE-2018-1120](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1120), [CVE-2018-1121](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1121), [CVE-2018-1122](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1122), [CVE-2018-1123](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1123), [CVE-2018-1124](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1124), [CVE-2018-1126](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1126))\n - Fix shadow privilege escalation ([CVE-2018-7169](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7169))\n - Fix samba man-in-the-middle attack ([CVE-2016-2119](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2119))\n - Fix Git arbitrary code execution when cloning untrusted repositories ([CVE-2018-11235](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11235))\n\nBug fixes:\n- Fix failure to set network interface MTU ([#2443](https://github.com/coreos/bugs/issues/2443))\n- Fix inadvertent change of network interface names ([#2437](https://github.com/coreos/bugs/issues/2437))\n- Fix Docker bind mounts from root filesystem ([#2440](https://github.com/coreos/bugs/issues/2440))\n\nChanges:\n - Update VMware virtual hardware version to 11 (ESXi > 6.0)\n\nUpdates:\n - etcd [3.3.6](https://github.com/coreos/etcd/releases/tag/v3.3.6)\n - etcdctl [3.3.6](https://github.com/coreos/etcd/releases/tag/v3.3.6)\n - Git [2.16.4](https://raw.githubusercontent.com/git/git/v2.16.4/Documentation/RelNotes/2.16.4.txt)\n - Linux [4.16.14](https://lwn.net/Articles/756651/)\n - open-vm-tools [10.2.5](https://docs.vmware.com/en/VMware-Tools/10.2/rn/vmware-tools-1025-release-notes.html)\n - procps [3.3.15](https://gitlab.com/procps-ng/procps/tags/v3.3.15)\n - samba [4.5.16](https://www.samba.org/samba/history/samba-4.5.16.html)\n - shadow [4.6](https://github.com/shadow-maint/shadow/releases/tag/4.6)"
+  },
+  "1800.1.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-13 13:23:42 +0000",
+    "major_software": {
+      "docker": [
+        "18.05.0"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.16.14"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1800.1.0):\n\nBug fixes:\n- Fix Hyper-V network driver regression ([#2454](https://github.com/coreos/bugs/issues/2454))"
+  },
+  "1814.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-22 10:18:59 +0000",
+    "major_software": {
+      "docker": [
+        "18.05.0"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.16.16"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1814.0.0):\n\nBug fixes:\n- Fix Hyper-V network driver regression ([#2454](https://github.com/coreos/bugs/issues/2454))\n\nChanges:\n- [Drop obsolete `cros_sdk` method of entering SDK](https://groups.google.com/d/topic/coreos-dev/JV3s-j51Tcw/discussion)\n\nUpdates:\n- etcd [3.3.7](https://github.com/coreos/etcd/releases/tag/v3.3.7)\n- etcdctl [3.3.7](https://github.com/coreos/etcd/releases/tag/v3.3.7)\n- Go [1.9.7](https://golang.org/doc/devel/release.html#go1.9.minor)\n- Go [1.10.3](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Ignition [0.26.0](https://github.com/coreos/ignition/releases/tag/v0.26.0)\n- Linux [4.16.16](https://lwn.net/Articles/757679/)\n- torcx [0.2.0](https://github.com/coreos/torcx/releases/tag/v0.2.0)"
+  },
+  "1828.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-07-05 13:56:54 +0000",
+    "major_software": {
+      "docker": [
+        "18.05.0"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.17.3"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1828.0.0):\n\nSecurity fixes:\n- Fix curl buffer overflows ([CVE-2018-1000300](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000300), [CVE-2018-1000301](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000301))\n- Fix Linux random seed during early boot ([CVE-2018-1108](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1108))\n\nChanges:\n- Reads of `/dev/urandom` early in boot will block until entropy pool is fully initialized\n- Support friendly AWS EBS NVMe device names ([#2399](https://github.com/coreos/bugs/issues/2399))\n\nUpdates:\n- cryptsetup [1.7.5](https://mirrors.edge.kernel.org/pub/linux/utils/cryptsetup/v1.7/v1.7.5-ReleaseNotes)\n- curl [7.60.0](https://curl.haxx.se/changes.html#7_60_0)\n- etcd-wrapper [3.3.8](https://github.com/coreos/etcd/releases/tag/v3.3.8)\n- etcdctl [3.3.8](https://github.com/coreos/etcd/releases/tag/v3.3.8)\n- intel-microcode [20180616](https://downloadcenter.intel.com/download/27776/Linux-Processor-Microcode-Data-File)\n- kmod [25](https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git/tree/NEWS?h=v25)\n- Linux [4.17.3](https://lwn.net/Articles/758268/)\n- linux-firmware [20180606](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/log/?id=d1147327232ec4616a66ab898df84f9700c816c1)\n- Locksmith [0.6.2](https://github.com/coreos/locksmith/releases/tag/v0.6.2)\n- OpenSSL [1.0.2o](https://www.openssl.org/news/openssl-1.0.2-notes.html)"
+  },
+  "1849.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-07-26 09:41:44 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.0"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.17.9"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1849.0.0):\n\nChanges:\n- Add torcx remotes support\n\nUpdates:\n- containerd [1.1.1](https://github.com/containerd/containerd/releases/tag/v1.1.1)\n- Docker [18.06.0-ce](https://github.com/docker/docker-ce/releases/tag/v18.06.0-ce)\n- intel-microcode [20180703](https://downloadcenter.intel.com/download/27945/Linux-Processor-Microcode-Data-File)\n- Linux [4.17.9](https://lwn.net/Articles/760499/)\n- Update Engine [0.4.9](https://github.com/coreos/update_engine/releases/tag/v0.4.9)\n"
+  },
+  "1855.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-07-31 09:15:59 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.0"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.17.11"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1855.0.0):\n\nChanges:\n- [Remove ARM64 architecture](https://groups.google.com/d/topic/coreos-user/3Z2S6bKNF5E/discussion)\n- [Remove developer image from SDK](https://groups.google.com/d/topic/coreos-dev/JNU-UDYprMo/discussion)\n\nUpdates:\n- etcd [3.3.9](https://github.com/coreos/etcd/releases/tag/v3.3.9)\n- etcdctl [3.3.9](https://github.com/coreos/etcd/releases/tag/v3.3.9)\n- Linux [4.17.11](https://lwn.net/Articles/761179/)"
+  },
+  "1855.1.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-08-08 10:49:49 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.0"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.17.12"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1855.1.0):\n\nSecurity fixes:\n- Fix Linux local denial of service as Xen PV guest ([CVE-2018-14678](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14678))\n\nBug fixes:\n- Fix failure to mount large ext4 filesystems ([#2485](https://github.com/coreos/bugs/issues/2485))\n\nUpdates:\n- Linux [4.17.12](https://lwn.net/Articles/761766/)"
+  },
+  "1871.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-08-17 12:11:12 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.0"
+      ],
+      "ignition": [
+        "0.27.0"
+      ],
+      "kernel": [
+        "4.17.15"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1871.0.0):\n\nSecurity fixes:\n- Fix Linux remote denial of service ([FragmentSmack](https://access.redhat.com/security/cve/cve-2018-5391), [CVE-2018-5391](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-5391))\n- Fix Linux privileged memory access via speculative execution ([L1TF/Foreshadow](https://foreshadowattack.eu/), [CVE-2018-3620](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3620), [CVE-2018-3646](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3646))\n- Fix curl SMTP buffer overflow ([CVE-2018-0500](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0500))\n\nBug fixes:\n- Fix PXE systems attempting to mount an ESP ([#2491](https://github.com/coreos/bugs/issues/2491))\n\nUpdates:\n- coreos-metadata [2.0.0](https://github.com/coreos/coreos-metadata/releases/tag/v2.0.0)\n- curl [7.61.0](https://curl.haxx.se/changes.html#7_61_0)\n- Ignition [0.27.0](https://github.com/coreos/ignition/releases/tag/v0.27.0)\n- Linux [4.17.15](https://lwn.net/Articles/762807/)\n- update-ssh-keys [0.2.1](https://github.com/coreos/update-ssh-keys/releases/tag/v0.2.1)"
+  },
+  "1883.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-08-29 17:07:21 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.18.5"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1883.0.0):\n\nChanges:\n- Add CIFS userspace utilities ([#571](https://github.com/coreos/bugs/issues/571))\n- Drop AWS PV images from regions which do not support PV\n\nUpdates:\n- containerd [1.1.2](https://github.com/containerd/containerd/releases/tag/v1.1.2)\n- Docker [18.06.1-ce](https://github.com/docker/docker-ce/releases/tag/v18.06.1-ce)\n- Ignition [0.28.0](https://github.com/coreos/ignition/releases/tag/v0.28.0)\n- Linux [4.18.5](https://lwn.net/Articles/763431/)\n- Rust [1.28.0](https://blog.rust-lang.org/2018/08/02/Rust-1.28.html)"
+  },
+  "1897.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-09-14 13:25:22 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.18.7"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1897.0.0):\n\nBug fixes:\n- Fix Docker mounting named volumes ([#2497](https://github.com/coreos/bugs/issues/2497))\n- Fix Azure disk detection in Ignition ([#2481](https://github.com/coreos/bugs/issues/2481))\n\nChanges:\n- Add support for Google Compute Engine OS Login\n- Enable support for Mellanox Ethernet switches\n\nUpdates:\n- coreos-metadata [3.0.0](https://github.com/coreos/coreos-metadata/releases/tag/v3.0.0)\n- Go [1.10.4](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Go [1.11](https://golang.org/doc/go1.11)\n- intel-microcode [20180807a](https://downloadcenter.intel.com/download/28087)\n- Linux [4.18.7](https://lwn.net/Articles/764459/)\n- update-ssh-keys [0.3.0](https://github.com/coreos/update-ssh-keys/releases/tag/v0.3.0)"
+  },
+  "1911.0.2": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-10-01 17:46:23 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.18.9"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1911.0.2):\n\nBug fixes:\n- Fix Google Compute Engine OS Login activation ([#2503](https://github.com/coreos/bugs/issues/2503))\n\nUpdates:\n- Linux [4.18.9](https://lwn.net/Articles/765657/)"
+  },
+  "1925.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-10-11 13:18:48 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.18.12"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nChanges:\n\n* Add new image signing subkey to `flatcar-install` ([flatcar-linux/init#4](https://github.com/flatcar-linux/init/pull/4))\n\nBug fixes:\n\n* Fix `/usr/lib/coreos` symlink for Container Linux compatibility ([flatcar-linux/coreos-overlay#8](https://github.com/flatcar-linux/coreos-overlay/pull/8))\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1925.0.0):\n\nUpdates:\n- glibc [2.26](https://sourceware.org/ml/libc-alpha/2017-08/msg00010.html)\n- Go [1.11.1](https://golang.org/doc/devel/release.html#go1.11.minor)\n- Linux [4.18.12](https://lwn.net/Articles/767627/)\n- nfs-utils [2.3.1](https://lwn.net/Articles/741961/)\n- open-vm-tools [10.3.0](https://github.com/vmware/open-vm-tools/blob/stable-10.3.0/ReleaseNotes.md)"
+  },
+  "1939.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-10-26 10:15:37 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.19.0"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1939.0.0):\n\nSecurity fixes:\n- Fix Git remote code execution during recursive clone ([CVE-2018-17456](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17456))\n- Fix OpenSSH user enumeration ([CVE-2018-15473](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15473))\n- Fix Rust standard library integer overflow ([CVE-2018-1000810](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000810))\n\nBug fixes:\n- Fix missing kernel headers ([#2505](https://github.com/coreos/bugs/issues/2505))\n\nUpdates:\n- coreos-metadata [3.0.1](https://github.com/coreos/coreos-metadata/releases/tag/v3.0.1)\n- etcd-wrapper [3.3.10](https://github.com/etcd-io/etcd/releases/tag/v3.3.10)\n- etcdctl [3.3.10](https://github.com/etcd-io/etcd/releases/tag/v3.3.10)\n- Git [2.18.1](https://raw.githubusercontent.com/git/git/v2.18.1/Documentation/RelNotes/2.18.1.txt)\n- Linux [4.19](https://lwn.net/Articles/769110/)\n- linux-firmware [20181001](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/log/?id=7c81f23ad903f72e87e2102d8f52408305c0f7a2)\n- OpenSSH [7.7p1](https://www.openssh.com/txt/release-7.7)\n- Rust [1.29.1](https://blog.rust-lang.org/2018/09/25/Rust-1.29.1.html)"
+  },
+  "1953.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-11-08 16:14:40 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.19.1"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1953.0.0):\n\nSecurity fixes:\n- Fix systemd re-executing with arbitrary supplied state ([CVE-2018-15686](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15686))\n- Fix systemd race allowing changing file permissions ([CVE-2018-15687](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15687))\n- Fix systemd-networkd buffer overflow in the dhcp6 client ([CVE-2018-15688](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15688))\n\nBug fixes:\n- Add AWS and GCE disk aliases in the initramfs for Ignition ([#2481](https://github.com/coreos/bugs/issues/2481))\n- Add compatibility `nf_conntrack_ipv4` kernel module to fix kube-proxy IPVS on Linux 4.19 ([#2518](https://github.com/coreos/bugs/issues/2518))\n\nUpdates:\n- IANA timezone database [2018e](https://mm.icann.org/pipermail/tz-announce/2018-May/000050.html)\n- kexec-tools [2.0.17](https://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git/log/?h=v2.0.17)\n- Linux [4.19.1](https://lwn.net/Articles/770746/)"
+  },
+  "1967.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-11-21 10:58:39 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.19.2"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1967.0.0):\n\nSecurity fixes:\n- Disable containerd CRI plugin to stop it from listening on a TCP port ([#2524](https://github.com/coreos/bugs/issues/2524))\n- Fix curl buffer overrun in NTLM authentication code ([CVE-2018-14618](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14618))\n- Fix OpenSSL TLS client denial of service ([CVE-2018-0732](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0732))\n- Fix OpenSSL timing side channel in DSA signature generation ([CVE-2018-0734](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0734))\n- Fix OpenSSL timing side channel via SMT port contention ([CVE-2018-5407](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-5407))\n\nUpdates:\n- coreos-metadata [3.0.2](https://github.com/coreos/coreos-metadata/releases/tag/v3.0.2)\n- curl [7.61.1](https://curl.haxx.se/changes.html#7_61_1)\n- Go [1.10.5](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Go [1.11.2](https://golang.org/doc/devel/release.html#go1.11.minor)\n- Linux [4.19.2](https://lwn.net/Articles/771883/)\n- OpenSSL [1.0.2p](https://www.openssl.org/news/openssl-1.0.2-notes.html)\n- Rust [1.30.1](https://blog.rust-lang.org/2018/11/08/Rust-1.30.1.html)"
+  },
+  "1981.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-12-06 09:45:28 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.19.6"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1981.0.0):\n\nUpdates:\n - Linux [4.19.6](https://lwn.net/Articles/773528/)\n - iptables [1.6.2](https://www.netfilter.org/projects/iptables/files/changes-iptables-1.6.2.txt)"
+  },
+  "1995.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-12-21 09:09:39 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.29.1"
+      ],
+      "kernel": [
+        "4.19.9"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1995.0.0):\n\nSecurity fixes:\n- Fix Go CPU denial of service in X.509 verification ([CVE-2018-16875](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16875))\n- Fix PolicyKit always authorizing UIDs greater than `INT_MAX` ([CVE-2018-19788](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-19788))\n\nBug fixes:\n- Fix AWS, Azure, and GCE disk aliases in the initramfs for Ignition ([#2531](https://github.com/coreos/bugs/issues/2531))\n\nUpdates:\n- Go [1.10.6](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Go [1.11.3](https://golang.org/doc/devel/release.html#go1.11.minor)\n- Ignition [0.29.1](https://github.com/coreos/ignition/releases/tag/v0.29.1)\n- Linux [4.19.9](https://lwn.net/Articles/774847/)\n- Rust [1.31.0](https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html)\n- wa-linux-agent [2.2.32](https://github.com/Azure/WALinuxAgent/releases/tag/v2.2.32)"
+  },
+  "2016.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-01-18 09:11:32 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.13"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2016.0.0):\n\nBug fixes:\n\n- Fix monitoring process events over netlink ([#2537](https://github.com/coreos/bugs/issues/2537))\n\nUpdates:\n- Ignition [0.30.0](https://github.com/coreos/ignition/releases/tag/v0.30.0)\n- Go [1.10.7](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Go [1.11.4](https://golang.org/doc/devel/release.html#go1.11.minor)\n- Linux [4.19.13](https://lwn.net/Articles/775720/)"
+  },
+  "2023.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-01-18 14:03:21 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.15"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2023.0.0):\n\nSecurity fixes:\n - Fix systemd-journald privilege escalation ([CVE-2018-16864](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16864), [CVE-2018-16865](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16865))\n - Fix systemd-journald out of bounds read ([CVE-2018-16866](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16866))\n - Fix ntpq, ntpdc buffer overflow ([CVE-2018-12327](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12327))\n - Fix etcd improper authentication with RBAC and client certs ([CVE-2018-16886](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16886))\n\nChanges:\n - Add `ip_vs_mh` kernel module ([#2542](https://github.com/coreos/bugs/issues/2542))\n\nUpdates:\n - etcd [3.3.11](https://github.com/etcd-io/etcd/releases/tag/v3.3.11)\n - etcdctl [3.3.11](https://github.com/etcd-io/etcd/releases/tag/v3.3.11)\n - Linux [4.19.15](https://lwn.net/Articles/776607/)\n - ntp [4.2.8p12](https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ChangeLog-stable)\n - sudo [1.8.25p1](https://www.sudo.ws/stable.html#1.8.25p1)\n"
+  },
+  "2037.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-01-30 13:45:27 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.18"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2037.0.0):\n\nSecurity fixes:\n- Fix Go CPU denial of service in ECC ([CVE-2019-6486](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6486))\n\nUpdates:\n- btrfs-progs [4.19](https://git.kernel.org/pub/scm/linux/kernel/git/kdave/btrfs-progs.git/plain/CHANGES?h=v4.19)\n- e2fsprogs [1.44.5](http://e2fsprogs.sourceforge.net/e2fsprogs-release.html#1.44.5)\n- glibc [2.27](https://www.sourceware.org/ml/libc-alpha/2018-02/msg00054.html)\n- Go [1.10.8](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Go [1.11.5](https://golang.org/doc/devel/release.html#go1.11.minor)\n- Linux [4.19.18](https://lwn.net/Articles/777580/)\n- Rust [1.32.0](https://blog.rust-lang.org/2019/01/17/Rust-1.32.0.html)\n- util-linux [2.33](https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.33/v2.33-ReleaseNotes)\n- xfsprogs [4.17.0](https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/plain/doc/CHANGES?id=v4.17.0)"
+  },
+  "2051.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-02-14 10:32:06 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.20"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2051.0.0):\n\nSecurity fixes:\n - Fix runc container breakout ([CVE-2019-5736](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5736))\n\nChanges:\n - Revert `/sys/bus/rbd/add` to Linux 4.14 behavior ([#2544](https://github.com/coreos/bugs/issues/2544))\n - Add a new subkey for signing release images\n\nUpdates:\n - etcd [3.3.12](https://github.com/etcd-io/etcd/releases/tag/v3.3.12)\n - etcdctl [3.3.12](https://github.com/etcd-io/etcd/releases/tag/v3.3.12)\n - flannel [0.11.0](https://github.com/coreos/flannel/releases/tag/v0.11.0)\n - Linux [4.19.20](https://lwn.net/Articles/779132/)\n"
+  },
+  "2065.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-02-27 08:55:30 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.25"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2065.0.0):\n\nSecurity fixes:\n- Fix curl vulnerabilities ([CVE-2018-16839](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16839), [CVE-2018-16840](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16840), [CVE-2018-16842](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16842), [CVE-2018-16890](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16890), [CVE-2019-3822](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3822), [CVE-2019-3823](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3823))\n- Fix Linux use-after-free in `sockfs_setattr` ([CVE-2019-8912](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-8912))\n- Fix systemd crash from a specially-crafted D-Bus message ([CVE-2019-6454](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6454))\n\nUpdates:\n- curl [7.64.0](https://curl.haxx.se/changes.html#7_64_0)\n- Docker [18.06.3-ce](https://github.com/docker/docker-ce/releases/tag/v18.06.3-ce)\n- Ignition [0.31.0](https://github.com/coreos/ignition/releases/tag/v0.31.0)\n- Linux [4.19.25](https://lwn.net/Articles/780611/)\n"
+  },
+  "2079.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-03-12 14:38:05 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.28"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2079.0.0):\n\nSecurity fixes:\n- Fix tar local denial of service with `--sparse` option ([CVE-2018-20482](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20482))\n- Fix wget local information leak ([CVE-2018-20483](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20483))\n\nBug fixes:\n- Fix systemd-journald memory leak ([#2564](https://github.com/coreos/bugs/issues/2564))\n\nChanges:\n- Enable `vhost_vsock` kernel module ([#2563](https://github.com/coreos/bugs/issues/2563))\n\nUpdates:\n- Go [1.12](https://golang.org/doc/go1.12)\n- Linux [4.19.28](https://lwn.net/Articles/782719/)\n- Rust [1.33.0](https://blog.rust-lang.org/2019/02/28/Rust-1.33.0.html)\n- systemd [241](https://github.com/systemd/systemd/blob/v241/NEWS)\n- tar [1.31](https://lists.gnu.org/archive/html/info-gnu/2019-01/msg00001.html)\n- wget [1.20.1](https://git.savannah.gnu.org/cgit/wget.git/tree/NEWS?h=v1.20.1)"
+  },
+  "2093.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-03-26 13:08:56 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.31"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2093.0.0):\n\nSecurity fixes:\n- Fix OpenSSH `scp` allowing remote servers to change target directory permissions ([CVE-2018-20685](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20685))\n- Fix OpenSSH outputting ANSI control codes from remote servers ([CVE-2019-6109](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6109), [CVE-2019-6110](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6110))\n- Fix OpenSSH `scp` allowing remote servers to overwrite arbitrary files ([CVE-2019-6111](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6111))\n- Fix OpenSSL side-channel timing attack ([CVE-2018-5407](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-5407))\n- Fix OpenSSL padding oracle attack in misbehaving applications ([CVE-2019-1559](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1559))\n- Fix ntp `ntpd` denial of service by authenticated user ([CVE-2019-8936](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-8936))\n- Fix ntp buffer overflow in `ntpq` and `ntpdc` ([CVE-2018-12327](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12327))\n\nBug fixes:\n- Fix systemd presets incorrectly handling escaped unit names ([#2569](https://github.com/coreos/bugs/issues/2569))\n\nUpdates:\n- GCC [8.2.0](https://gcc.gnu.org/gcc-8/changes.html#GCC8.2)\n- Go [1.12.1](https://golang.org/doc/devel/release.html#go1.12.minor)\n- IANA timezone database [2018i](https://mm.icann.org/pipermail/tz-announce/2018-December/000054.html)\n- Linux [4.19.31](https://lwn.net/Articles/783858/)\n- ntp [4.2.8p13](https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ChangeLog-stable)\n- OpenSSH [7.9p1](https://www.openssh.com/txt/release-7.9)\n- OpenSSL [1.0.2r](https://www.openssl.org/news/openssl-1.0.2-notes.html)\n- Update Engine [0.4.10](https://github.com/coreos/update_engine/releases/tag/v0.4.10)\n"
+  },
+  "2107.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-09 13:24:31 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.34"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2107.0.0):\n\nSecurity fixes:\n- Fix libmspack vulnerabilities in the VMware agent for new installs ([CVE-2018-14679](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14679), [CVE-2018-14680](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14680), [CVE-2018-14681](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14681), [CVE-2018-14682](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14682), [CVE-2018-18584](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-18584), [CVE-2018-18585](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-18585), [CVE-2018-18586](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-18586))\n\nUpdates:\n- Afterburn (formerly coreos-metadata) [4.0.0](https://github.com/coreos/afterburn/releases/tag/v4.0.0)\n- Git [2.21.0](https://raw.githubusercontent.com/git/git/v2.21.0/Documentation/RelNotes/2.21.0.txt)\n- Go [1.12.2](https://golang.org/doc/devel/release.html#go1.12.minor)\n- Linux [4.19.34](https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.19.34)\n"
+  },
+  "2121.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-03 10:42:07 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.36"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2121.0.0):\n\nSecurity fixes:\n - Fix libseccomp privilege escalation ([CVE-2019-9893](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9893))\n\nBug fixes:\n - Disable new sticky directory protections for backward compatibility ([#2577](https://github.com/coreos/bugs/issues/2577))\n\nChanges:\n - Enable `atlantic` kernel module ([#2576](https://github.com/coreos/bugs/issues/2576))\n\nUpdates:\n - Go [1.12.4](https://golang.org/doc/devel/release.html#go1.12.minor)\n - Ignition [0.32.0](https://github.com/coreos/ignition/releases/tag/v0.32.0)\n - libseccomp [2.4.0](https://github.com/seccomp/libseccomp/releases/tag/v2.4.0)\n - Linux [4.19.36](https://lwn.net/Articles/786361/)\n - Rust [1.34.0](https://blog.rust-lang.org/2019/04/11/Rust-1.34.0.html)\n - tini [0.18.0](https://github.com/krallin/tini/releases/tag/v0.18.0)"
+  },
+  "2135.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-08 07:08:56 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.37"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2135.0.0):\n\nSecurity fixes:\n\n- Fix SQLite remote code execution ([CVE-2018-20346](https://nvd.nist.gov/vuln/detail/CVE-2018-20346))\n- Fix GLib [multiple vulnerabilities](https://www.openwall.com/lists/oss-security/2018/10/23/5)\n\nBug fixes:\n\n- Fix systemd `MountFlags=shared` option ([#2579](https://github.com/coreos/bugs/issues/2579))\n\nChanges:\n\n- Use Amazon's recommended NVMe timeout for new EC2 installs ([#2484](https://github.com/coreos/bugs/issues/2484))\n- Pin network interface naming to systemd v238 scheme ([#2578](https://github.com/coreos/bugs/issues/2578))\n- Enable XDP sockets ([#2580](https://github.com/coreos/bugs/issues/2580))\n\nUpdates:\n\n- Linux [4.19.37](https://lwn.net/Articles/786953/)\n- Rust [1.34.1](https://blog.rust-lang.org/2019/04/25/Rust-1.34.1.html)"
+  },
+  "2135.1.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-16 10:57:13 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.43"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2135.1.0):\n\nSecurity fixes:\n- Fix Intel CPU disclosure of memory to user process.  Complete mitigation requires [manually disabling SMT](https://docs.flatcar-linux.org/os/disabling-smt/) on affected processors. ([CVE-2019-11091](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11091), [CVE-2018-12126](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12126), [CVE-2018-12127](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12127), [CVE-2018-12130](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12130), [MDS](https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00233.html))\n\nUpdates:\n- intel-microcode [20190514](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190514/releasenote)\n- Linux [4.19.43](https://lwn.net/Articles/788388/)"
+  },
+  "2149.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-21 20:29:23 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.44"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2149.0.0):\n\nUpdates:\n- etcd [3.3.13](https://github.com/etcd-io/etcd/releases/tag/v3.3.13)\n- etcdctl [3.3.13](https://github.com/etcd-io/etcd/releases/tag/v3.3.13)\n- Go [1.12.5](https://golang.org/doc/devel/release.html#go1.12.minor)\n- intel-microcode [20190514](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190514/releasenote)\n- Linux [4.19.44](https://lwn.net/Articles/788778/)"
+  },
+  "2163.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-06-06 08:50:58 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.47"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2163.0.0):\n\nSecurity fixes:\n\n- Fix curl TFTP buffer overflow with non-default block size ([CVE-2019-5436](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5436))\n\nUpdates:\n\n- coreutils [8.30](https://git.savannah.gnu.org/cgit/coreutils.git/tree/NEWS?h=v8.30)\n- curl [7.65.0](https://curl.haxx.se/changes.html#7_65_0)\n- GCC [8.3.0](https://gcc.gnu.org/gcc-8/changes.html#GCC8.3)\n- glibc [2.29](https://sourceware.org/ml/libc-announce/2019/msg00000.html)\n- Linux [4.19.47](https://lwn.net/Articles/790017/)\n- Rust [1.35.0](https://blog.rust-lang.org/2019/05/23/Rust-1.35.0.html)"
+  },
+  "2163.1.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-06-12 13:24:21 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.47"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2163.1.0):\nBug fixes:\n- Temporarily revert bunzip2 change in 2163.0.0 causing decompression failures for invalid archives created by older versions of lbzip2, including Container Linux release images ([#2589](https://github.com/coreos/bugs/issues/2589))"
+  },
+  "2163.2.1": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-06-19 08:17:08 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.50"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2163.2.1):\n\nSecurity fixes:\n\n- Fix Linux TCP remotely-triggerable kernel panic and excessive resource consumption ([CVE-2019-11477](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11477), [CVE-2019-11478](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11478), [CVE-2019-11479](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11479))\n\nUpdates:\n\n- Linux [4.19.50](https://lwn.net/Articles/790878/)"
+  },
+  "2184.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-01 10:43:29 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.55"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2184.0.0):\nBug fixes:\n\n- Temporarily revert bunzip2 change in 2163.0.0 causing decompression failures for invalid archives created by older versions of lbzip2, including Container Linux release images ([#2589](https://github.com/coreos/bugs/issues/2589))\n\nUpdates:\n\n- intel-microcode [20190618](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190618/releasenote)\n- Linux [4.19.55](https://lwn.net/Articles/791755/)"
+  },
+  "2191.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-03 08:03:08 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.56"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2191.0.0):\n\nSecurity fixes:\n\n * Fix libexpat denial of service ([CVE-2018-20843](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20843))\n\nBug fixes:\n\n * Fix Ignition panic when no `guestinfo.(coreos|ignition).config` parameters are specified on VMware (coreos/ignition#821)\n\nUpdates:\n\n * expat [2.2.7](https://github.com/libexpat/libexpat/releases/tag/R_2_2_7)\n * Ignition [0.33.0](https://github.com/coreos/ignition/releases/tag/v0.33.0)\n * Linux [4.19.56](https://lwn.net/Articles/792009/)"
+  },
+  "2205.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-17 13:53:28 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.58"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2205.0.0):\n\nBug fixes:\n\n - Fix Docker `device or resource busy` error when creating overlay mounts, introduced in 2191.0.0\n\nUpdates: \n\n - Linux [4.19.58](https://lwn.net/Articles/793363/)"
+  },
+  "2219.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-01 09:17:22 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.62"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2219.0.0):\nBug fixes:\n- Fix Ignition fetching from S3 URLs when network is slow to start ([ignition#826](https://github.com/coreos/ignition/issues/826))\n\nUpdates:\n- Linux [4.19.62](https://lwn.net/Articles/794807/)"
+  },
+  "2219.1.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-08 08:19:15 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.65"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2219.1.0):\n\nSecurity fixes:\n- Fix Linux information leak attack vector via speculative side channel ([CVE-2019-1125](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1125))\n\nUpdates:\n- Linux [4.19.65](https://lwn.net/Articles/795525/)\n\n## Flatcar updates\n\nChanges:\n- Add \"-s\" flag in flatcar-install to install to smallest disk (https://github.com/flatcar-linux/init/pull/7)"
+  },
+  "2234.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-16 09:46:07 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.65"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2234.0.0):\n\nSecurity fixes:\n- Use secure_getenv to fix a vulnerability around XDG_SEAT in pam_systemd (https://github.com/coreos/systemd/pull/118) ([CVE-2019-3842](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3842))\n\nUpdates:\n- Linux [4.19.65](https://lwn.net/Articles/795525/)\n\n## Flatcar updates\n\nBug fixes:\n- Fix wrong key name for fw_cfg in ignition with QEMU (https://github.com/flatcar-linux/ignition/issues/2)\n- Get SELinux context included in torcx tarballs (https://github.com/flatcar-linux/scripts/pull/16)\n- Enable XattrPrivileged for untar to fix SELinux issue (https://github.com/flatcar-linux/torcx/pull/1)\n"
+  },
+  "2247.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-30 07:38:30 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.68"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2247.0.0):\n\nSecurity fixes:\n- Fix libarchive out of bounds reads ([CVE-2017-14166](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14166), [CVE-2017-14501](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14501), [CVE-2017-14502](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14502), [CVE-2017-14503](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14503))\n- Fix pam_systemd bug allowing authenticated remote users to perform polkit actions as if locally logged in ([CVE-2019-3842](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3842))\n- Fix polkit information disclosure and denial of service ([CVE-2018-1116](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1116))\n- Fix SQLite multiple vulnerabilities, the worst of which allows code execution ([CVE-2019-5018](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5018), [CVE-2019-9936](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9936), [CVE-2019-9937](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9937))\n- Fix wget buffer overflow allowing arbitrary code execution ([CVE-2019-5953](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5953))\n\nUpdates:\n- etcd [3.3.15](https://github.com/etcd-io/etcd/releases/tag/v3.3.15)\n- etcdctl [3.3.15](https://github.com/etcd-io/etcd/releases/tag/v3.3.15)\n- Go [1.12.7](https://golang.org/doc/devel/release.html#go1.12.minor)\n- Linux [4.19.68](https://lwn.net/Articles/797250/)\n- wget [1.20.3](http://git.savannah.gnu.org/cgit/wget.git/tree/NEWS?h=v1.20.3&id=a220ead43505bc3e0ea8efb1572919111dbbf6dc#n8)"
+  },
+  "2247.1.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-09-05 08:53:55 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.69"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2247.1.0):\n\nSecurity fixes:\n\n- Fix systemd-resolved bug allowing unprivileged users to change DNS settings ([CVE-2019-15718](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15718))\n\nBug fixes:\n\n- Fix GCE agent crash loop in new installs ([#2608](https://github.com/coreos/bugs/issues/2608))\n\nUpdates:\n\n- Linux [4.19.69](https://lwn.net/Articles/797815/)"
+  },
+  "2261.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-09-13 10:54:40 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.71"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2261.0.0):\n\nSecurity fixes:\n\n- Fix systemd-resolved bug allowing unprivileged users to change DNS settings ([CVE-2019-15718](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15718))\n\nBug fixes:\n\n- Fix GCE agent crash loop in new installs ([#2608](https://github.com/coreos/bugs/issues/2608))\n\nUpdates:\n\n- Linux [4.19.71](https://lwn.net/Articles/798627/)\n"
+  },
+  "2275.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-09-25 09:33:48 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.75"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2275.0.0):\n\nSecurity fixes:\n\n- Fix dbus authentication bypass in non-default configurations ([CVE-2019-12749](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-12749))\n- Fix kernel KVM guest escape ([CVE-2019-14835](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14835))\n- Fix race condition in Intel microprocessors ([CVE-2019-11184](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11184))\n\nUpdates:\n\n- intel-microcode [20190918](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190918/releasenote)\n- Linux [4.19.75](https://lwn.net/Articles/800247/)"
+  },
+  "2275.1.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-10-16 15:09:02 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.78"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2275.1.0):\n\nBug fixes:\n- Fix kernel crash with CephFS mounts, introduced in 2275.0.0 ([#2616](https://github.com/coreos/bugs/issues/2616))\n\nUpdates:\n- Linux [4.19.78](https://lwn.net/Articles/801700/)"
+  },
+  "2296.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-10-17 18:54:10 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.79"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2296.0.0):\n\nSecurity fixes:\n- Fix sudo allowing a user to run commands as root if configured to permit the user to run commands as everyone other than root ([CVE-2019-14287](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14287))\n\nBug fixes:\n- Fix kernel crash with CephFS mounts, introduced in 2275.0.0 ([#2616](https://github.com/coreos/bugs/issues/2616))\n\nUpdates:\n- etcd [3.3.17](https://github.com/etcd-io/etcd/releases/tag/v3.3.17)\n- etcdctl [3.3.17](https://github.com/etcd-io/etcd/releases/tag/v3.3.17)\n- Go [1.12.9](https://golang.org/doc/devel/release.html#go1.12.minor)\n- Linux [4.19.79](https://lwn.net/Articles/802169/)\n- sudo [1.8.28](https://www.sudo.ws/stable.html#1.8.28)"
+  },
+  "2303.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-10-23 12:33:00 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.80"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2303.0.0):\n\nChanges:\n- Pin rkt to Go 1.12\n\nUpdates:\n- Go [1.12.10](https://golang.org/doc/devel/release.html#go1.12.minor)\n- Go [1.13.2](https://golang.org/doc/devel/release.html#go1.13.minor)\n- Linux [4.19.80](https://lwn.net/Articles/802628/)"
+  },
+  "2317.0.1": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-11-11 14:14:00 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.81"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2317.0.1):\n\nBug fixes:\n\n- Fix CFS scheduler throttling highly-threaded I/O-bound applications ([#2623](https://github.com/coreos/bugs/issues/2623))\n- Fix time zone for Brazil ([#2627](https://github.com/coreos/bugs/issues/2627))\n\nUpdates:\n\n- Linux [4.19.81](https://lwn.net/Articles/803384/)\n- timezone-data [2019c](http://mm.icann.org/pipermail/tz-announce/2019-September/000057.html)"
+  },
+  "2331.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-11-25 12:07:57 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.84"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix Intel CPU disclosure of memory to user process. Complete mitigation requires [manually disabling TSX or SMT](https://docs.flatcar-linux.org/os/disabling-smt/) on affected processors. ([CVE-2019-11135](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11135), [TAA](https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00270.html))\n- Fix Intel CPU denial of service by a malicious guest VM ([CVE-2018-12207](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12207))\n- Fix curl Kerberos FTP double free ([CVE-2019-5481](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5481))\n - Fix curl TFTP buffer overflow with non-default block size ([CVE-2019-5482](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5482))\n - Fix OpenSSL key extraction attacks under non-default conditions ([CVE-2019-1563](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1563), [CVE-2019-1547](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1547))\n- Fix panic caused by invalid DSA public keys in Go 1.12 and 1.13 ([CVE-2019-17596](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-17596))\n\nBug fixes:\n\n- Fix CFS scheduler throttling highly-threaded I/O-bound applications ([#2623](https://github.com/coreos/bugs/issues/2623))\n- Fix time zone for Brazil ([#2627](https://github.com/coreos/bugs/issues/2627))\n\nUpdates:\n\n- Go [1.12.12](https://go.googlesource.com/go/+/refs/tags/go1.12.12) and [1.13.3](https://go.googlesource.com/go/+/refs/tags/go1.13.3)\n- curl [7.66.0](https://curl.haxx.se/mail/archive-2019-09/0002.html)\n- intel-microcode [20191115](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20191115/releasenote)\n- Linux [4.19.84](https://lwn.net/Articles/804465/)\n- OpenSSL [1.0.2t](https://www.openssl.org/news/cl102.txt)\n- timezone-data [2019c](http://mm.icann.org/pipermail/tz-announce/2019-September/000057.html)\n"
+  },
+  "2345.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-12-05 06:35:19 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.87"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix heap-based buffer over-read in libexpat ([CVE-2019-15903](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15903))\n- Fix code injection around dynamic libraries in docker ([CVE-2019-14271](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14271))\n\nBug fixes:\n\n- Fix cross-build issues in rust by storing shell scripts under the source directory (https://github.com/flatcar-linux/coreos-overlay/pull/125)\n- Fix bug in dealing with xattrs when unpacking torcx tarballs (https://github.com/flatcar-linux/torcx/pull/2)\n\nUpdates:\n\n- Linux [4.19.87](https://lwn.net/Articles/805923/)\n- docker [19.03.5](https://docs.docker.com/engine/release-notes/#19035)\n- etcd [3.3.18](https://github.com/etcd-io/etcd/releases/tag/v3.3.18)\n- expat [2.2.8](https://github.com/libexpat/libexpat/releases/tag/R_2_2_8)\n"
+  },
+  "2345.0.1": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2019-12-09 10:28:08 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.87"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nIt is the first release done for both amd64 and arm64.\n\nBug fixes:\n\n- Fix cross-build issues around WAF by creating wrappers (https://github.com/flatcar-linux/coreos-overlay/pull/137 https://github.com/flatcar-linux/coreos-overlay/pull/139)\n\nUpdates:\n\n- ldb [1.3.6](https://gitlab.com/samba-team/samba/-/tags/ldb-1.3.6)\n- samba [4.8.6](https://gitlab.com/samba-team/samba/-/tags/samba-4.8.6)\n- talloc [2.1.11](https://gitlab.com/samba-team/samba/-/tags/talloc-2.1.11)\n- tdb [1.3.15](https://gitlab.com/samba-team/samba/-/tags/tdb-1.3.15)\n- tevent [0.9.37](https://gitlab.com/samba-team/samba/-/tags/tevent-0.9.37)\n"
+  },
+  "2345.0.2": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2019-12-20 09:27:31 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.89"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix a denial-of-service issue via malicious access to `/dev/kvm` ([CVE-2019-19332](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19332))\n\nBug fixes:\n\n- Fix a bug when creating RAID0 arrays by setting the default layout (https://github.com/flatcar-linux/baselayout/pull/2)\n\nUpdates:\n\n- Linux [4.19.89](https://lwn.net/Articles/807416/)"
+  },
+  "2387.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2020-01-21 12:54:35 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.34.0"
+      ],
+      "kernel": [
+        "4.19.97"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2387.0.0):\n\nSecurity fixes:\n\n- Fix multiple Git [vulnerabilities](https://marc.info/?l=git&m=157600115215285&w=2) ([CVE-2019-1348](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1348), [CVE-2019-1349](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1349), [CVE-2019-1350](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1350), [CVE-2019-1351](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1351), [CVE-2019-1352](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1352), [CVE-2019-1353](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1353), [CVE-2019-1354](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1354), [CVE-2019-1387](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1387), [CVE-2019-19604](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19604))\n\nUpdates:\n\n- Git [2.24.1](https://github.com/git/git/blob/master/Documentation/RelNotes/2.24.1.txt)\n- Ignition [0.34.0](https://github.com/coreos/ignition/releases/tag/v0.34.0)\n\n## Flatcar updates\n- Linux [4.19.97](https://lwn.net/Articles/809961/)\n"
+  },
+  "2411.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2020-02-17 16:40:26 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.34.0"
+      ],
+      "kernel": [
+        "4.19.102"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix stack-based buffer overflow in sudo ([CVE-2019-18634](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18634))\n- Fix incorrect access control leading to privileges escalation in runc ([CVE-2019-19921](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19921))\n- Fix systemd use-after-free upon receiving crafted D-Bus message from local unprivileged attacker ([CVE-2020-1712](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1712))\n\nBug fixes:\n\n- Fix DNS resolution for the GCE metadata server (https://github.com/flatcar-linux/coreos-overlay/pull/160)\n- Use correct URLs for flatcar-linux in emerge-gitclone and scripts (https://github.com/flatcar-linux/dev-util/pull/1) (https://github.com/flatcar-linux/scripts/pull/50)\n- Fix a wrong profile reference in torcx (https://github.com/flatcar-linux/coreos-overlay/pull/162)\n- Create symlink for /run/metadata/coreos (https://github.com/flatcar-linux/coreos-overlay/pull/166)\n- Create symlink for flatcar-install (https://github.com/flatcar-linux/init/pull/14)\n- Fix backwards compatibility issues for users to migrate from CoreOS Container Linux (https://github.com/flatcar-linux/Flatcar/issues/16 https://github.com/flatcar-linux/afterburn/pull/7 https://github.com/flatcar-linux/bootengine/pull/7 https://github.com/flatcar-linux/bootengine/pull/8 https://github.com/flatcar-linux/init/pull/16 https://github.com/flatcar-linux/init/pull/17 https://github.com/flatcar-linux/ignition/pull/8)\n\nChanges:\n\n- Build Flatcar tarballs to be used by containers (https://github.com/flatcar-linux/scripts/pull/51)\n- Enable qede kernel module\n\nUpdates:\n\n- Linux [4.19.102](https://lwn.net/Articles/811638/)\n- runc [1.0.0-rc10](https://github.com/opencontainers/runc/releases/tag/v1.0.0-rc10)\n- sudo [1.8.31](https://www.sudo.ws/stable.html#1.8.31)\n"
+  },
+  "2430.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2020-03-05 10:26:46 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.34.0"
+      ],
+      "kernel": [
+        "4.19.106"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n- Enable persistent network interface names already in the initramfs to fix https://github.com/coreos/bugs/issues/1767\n- Do not error out in runc if SELinux is disabled on the system (https://github.com/flatcar-linux/coreos-overlay/pull/189)\n- Bring back runc 1.0-rc2 for Docker 17.03 (https://github.com/flatcar-linux/coreos-overlay/pull/191)\n- Use correct branch name format in developer container tools (https://github.com/flatcar-linux/dev-util/pull/2)\n\nUpdates:\n\n- Linux [4.19.106](https://lwn.net/Articles/813157/)"
+  },
+  "current": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2020-03-05 10:26:46 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.34.0"
+      ],
+      "kernel": [
+        "4.19.106"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n- Enable persistent network interface names already in the initramfs to fix https://github.com/coreos/bugs/issues/1767\n- Do not error out in runc if SELinux is disabled on the system (https://github.com/flatcar-linux/coreos-overlay/pull/189)\n- Bring back runc 1.0-rc2 for Docker 17.03 (https://github.com/flatcar-linux/coreos-overlay/pull/191)\n- Use correct branch name format in developer container tools (https://github.com/flatcar-linux/dev-util/pull/2)\n\nUpdates:\n\n- Linux [4.19.106](https://lwn.net/Articles/813157/)"
+  }
+}

--- a/static/releases-json/releases-beta.json
+++ b/static/releases-json/releases-beta.json
@@ -1,0 +1,1352 @@
+{
+  "1722.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-04-25 14:36:40 +0000",
+    "major_software": {
+      "docker": [
+        "17.12.1"
+      ],
+      "ignition": [
+        "0.23.0"
+      ],
+      "kernel": [
+        "4.14.30"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "237"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nInitial Flatcar release.\n\nBug fixes:\n- Fix GRUB crash at boot ([#2284](https://github.com/coreos/bugs/issues/2284))\n- Fix [poweroff problems](https://groups.google.com/forum/#!topic/coreos-user/YcGkRHU9SvQ) ([#8080](https://github.com/systemd/systemd/pull/8080))\n\nNotes:\n- Previous test images have been removed from the release servers. This is due to a new update key being generated using our updated security policy which we [included](https://github.com/flatcar-linux/coreos-overlay/pull/6) in the first public image.\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1722.2.0):\n\nBug fixes:\n- Fix kernel panic with vxlan ([#2382](https://github.com/coreos/bugs/issues/2382))"
+  },
+  "1745.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-04-26 09:58:55 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.0"
+      ],
+      "ignition": [
+        "0.24.0"
+      ],
+      "kernel": [
+        "4.14.35"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1745.1.0):\n\nBug fixes:\n - Fix docker2aci tar conversion ([#2402](https://github.com/coreos/bugs/issues/2402))\n\nChanges:\n - Switch to the LTS Linux version [4.14.35](https://lwn.net/Articles/752328/) for the beta channel"
+  },
+  "1745.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-05-11 11:40:35 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.0"
+      ],
+      "kernel": [
+        "4.14.39"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1745.2.0):\n\nSecurity fixes:\n - Fix ntp clock manipulation from ephemeral connections ([CVE-2016-1549](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1549), [CVE-2018-7170](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7170))\n - Fix ntp denial of service from out of bounds read ([CVE-2018-7182](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7182)) \n -  Fix ntp denial of service from packets with timestamp 0 ([CVE-2018-7184](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7184), [CVE-2018-7185](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7185))\n - Fix ntp remote code execution ([CVE-2018-7183](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7183))\n\nUpdates:\n - containerd [1.0.3](https://github.com/containerd/containerd/releases/tag/v1.0.3)\n - Docker [18.03.1-ce](https://github.com/docker/docker-ce/releases/tag/v18.03.1-ce)\n - Linux [4.14.39](https://lwn.net/Articles/753349/)\n - ntp [4.2.8p11](https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ChangeLog-stable)\n"
+  },
+  "1772.1.1": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-05-26 15:29:49 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.1"
+      ],
+      "kernel": [
+        "4.14.42"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1772.1.1):\n\nChanges:\n- Switch to the LTS Docker version [18.03.1-ce](https://github.com/docker/docker-ce/releases/tag/v18.03.1-ce) for the beta channel\n- Switch to the LTS Linux version [4.14.42](https://lwn.net/Articles/754972/) for the beta channel\n\nUpdates:\n- Ignition [0.24.1](https://github.com/coreos/ignition/releases/tag/v0.24.1)"
+  },
+  "1772.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-01 13:23:43 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.1"
+      ],
+      "kernel": [
+        "4.14.47"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1772.2.0):\n\nSecurity fixes:\n- Fix Git arbitrary code execution when cloning untrusted repositories ([CVE-2018-11235](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11235))\n\nBug fixes:\n- Fix inadvertent change of network interface names ([#2437](https://github.com/coreos/bugs/issues/2437))\n- Fix failure to set network interface MTU ([#2443](https://github.com/coreos/bugs/issues/2443))\n\nUpdates:\n- Git [2.16.4](https://raw.githubusercontent.com/git/git/v2.16.4/Documentation/RelNotes/2.16.4.txt)\n- Linux [4.14.47](https://lwn.net/Articles/756055/)"
+  },
+  "1772.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-13 13:22:40 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.1"
+      ],
+      "kernel": [
+        "4.14.48"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1772.3.0):\n\nBug fixes:\n- Fix Hyper-V network driver regression ([#2454](https://github.com/coreos/bugs/issues/2454))\n\nUpdates:\n- Linux [4.14.48](https://lwn.net/Articles/756652/)"
+  },
+  "1772.4.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-15 14:51:22 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.1"
+      ],
+      "kernel": [
+        "4.14.49"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1772.4.0):\n\nBug fixes:\n- Fix TCP connection stalls ([#2457](https://github.com/coreos/bugs/issues/2457))\n\nUpdates:\n- Linux [4.14.49](https://lwn.net/Articles/757308/)"
+  },
+  "1800.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-22 10:17:31 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.14.50"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1800.2.0):\n\nChanges:\n- Switch to the LTS Docker version [18.03.1-ce](https://github.com/docker/docker-ce/releases/tag/v18.03.1-ce) for the beta channel\n- Switch to the LTS Linux version [4.14.50](https://lwn.net/Articles/757680/) for the beta channel"
+  },
+  "1800.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-07-13 15:43:19 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.14.55"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1800.3.0):\n\nUpdates:\n- Linux [4.14.55](https://lwn.net/Articles/759535/)"
+  },
+  "1828.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-07-26 09:40:11 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.14.57"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1828.1.0):\n\nChanges:\n- Switch to the LTS Docker version [18.03.1-ce](https://github.com/docker/docker-ce/releases/tag/v18.03.1-ce) for the beta channel\n- Switch to the LTS Linux version [4.14.57](https://lwn.net/Articles/760500/) for the beta channel\n"
+  },
+  "1828.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-07-31 09:16:00 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.14.59"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1828.2.0):\n\nBug fixes:\n- Fix kernel CIFS client ([#2480](https://github.com/coreos/bugs/issues/2480))\n\nUpdates:\n- Linux [4.14.59](https://lwn.net/Articles/761180/)"
+  },
+  "1828.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-08-08 10:49:50 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.14.60"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1828.3.0):\n\nSecurity fixes:\n- Fix Linux local denial of service as Xen PV guest ([CVE-2018-14678](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14678))\n\nBug fixes:\n- Fix failure to mount large ext4 filesystems ([#2485](https://github.com/coreos/bugs/issues/2485))\n\nUpdates:\n- Linux [4.14.60](https://lwn.net/Articles/761767/)"
+  },
+  "1855.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-08-17 12:09:29 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.0"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.14.63"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1855.2.0):\n\nSecurity fixes:\n- Fix Linux remote denial of service ([FragmentSmack](https://access.redhat.com/security/cve/cve-2018-5391), [CVE-2018-5391](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-5391))\n- Fix Linux privileged memory access via speculative execution ([L1TF/Foreshadow](https://foreshadowattack.eu/), [CVE-2018-3620](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3620), [CVE-2018-3646](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3646))\n\nBug fixes:\n- Fix PXE systems attempting to mount an ESP ([#2491](https://github.com/coreos/bugs/issues/2491))\n\nChanges:\n- Switch to the LTS Linux version [4.14.63](https://lwn.net/Articles/762808/) for the beta channel"
+  },
+  "1855.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-09-05 08:43:19 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.14.67"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1855.3.0):\n\nChanges:\n- Drop AWS PV images from regions which do not support PV\n\nUpdates:\n- containerd [1.1.2](https://github.com/containerd/containerd/releases/tag/v1.1.2)\n- Docker [18.06.1-ce](https://github.com/docker/docker-ce/releases/tag/v18.06.1-ce)\n- intel-microcode [20180807a](https://downloadcenter.intel.com/download/28087/Linux-Processor-Microcode-Data-File)\n- Linux [4.14.67](https://lwn.net/Articles/763433/)"
+  },
+  "1883.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-09-14 09:59:48 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.69"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1883.1.0):\n\nBug fixes:\n- Fix Docker mounting named volumes ([#2497](https://github.com/coreos/bugs/issues/2497))\n\nChanges:\n- Switch to the LTS Linux version [4.14.69](https://lwn.net/Articles/764513/) for the beta channel\n\nUpdates:\n- intel-microcode [20180807a](https://downloadcenter.intel.com/download/28087)"
+  },
+  "1911.1.1": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-10-11 13:18:49 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.74"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nChanges:\n\n* Add new image signing subkey to `flatcar-install` ([flatcar-linux/init#4](https://github.com/flatcar-linux/init/pull/4))\n\nBug fixes:\n\n* Fix `/usr/lib/coreos` symlink for Container Linux compatibility ([flatcar-linux/coreos-overlay#8](https://github.com/flatcar-linux/coreos-overlay/pull/8))\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1911.1.1):\n\nChanges:\n- Switch to the LTS Linux version [4.14.74](https://lwn.net/Articles/767628/) for the beta channel\n"
+  },
+  "1911.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-10-26 10:14:36 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.78"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1911.2.0):\n\nSecurity fixes:\n- Fix Git remote code execution during recursive clone ([CVE-2018-17456](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17456))\n\nBug fixes:\n- Fix missing kernel headers ([#2505](https://github.com/coreos/bugs/issues/2505))\n\nUpdates:\n- Git [2.16.5](https://raw.githubusercontent.com/git/git/v2.16.5/Documentation/RelNotes/2.16.5.txt)\n- Linux [4.14.78](https://lwn.net/Articles/769051/)"
+  },
+  "1939.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-11-08 16:14:38 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.79"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1939.1.0):\n\nSecurity fixes:\n- Fix systemd re-executing with arbitrary supplied state ([CVE-2018-15686](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15686))\n- Fix systemd race allowing changing file permissions ([CVE-2018-15687](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15687))\n- Fix systemd-networkd buffer overflow in the dhcp6 client ([CVE-2018-15688](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15688))\n\nChanges:\n- Switch to the LTS Linux version [4.14.79](https://lwn.net/Articles/770749/) for the beta channel"
+  },
+  "1939.2.1": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-11-21 10:57:13 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.81"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1939.2.1):\n\nSecurity fixes:\n- Disable containerd CRI plugin to stop it from listening on a TCP port ([#2524](https://github.com/coreos/bugs/issues/2524))\n\nUpdates:\n- Linux [4.14.81](https://lwn.net/Articles/771885/)"
+  },
+  "1967.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-12-06 09:43:43 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.84"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1967.1.0):\n\nChanges:\n - Switch to the LTS Linux version [4.14.84](https://lwn.net/Articles/773114/) for the beta channel"
+  },
+  "1967.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-12-21 09:08:43 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.88"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1967.2.0):\n\nSecurity fixes:\n- Fix Go CPU denial of service in X.509 verification ([CVE-2018-16875](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16875))\n- Fix PolicyKit always authorizing UIDs greater than `INT_MAX` ([CVE-2018-19788](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-19788))\n\nUpdates:\n- Go [1.10.6](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Go [1.11.3](https://golang.org/doc/devel/release.html#go1.11.minor)\n- Linux [4.14.88](https://lwn.net/Articles/774848/)"
+  },
+  "1995.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-01-18 09:10:26 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.29.1"
+      ],
+      "kernel": [
+        "4.19.13"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1995.1.0):\n\nUpdates:\n- Linux [4.19.13](https://lwn.net/Articles/775720/)"
+  },
+  "2023.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-01-30 13:45:28 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.18"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2023.1.0):\n\nSecurity fixes:\n- Fix Go CPU denial of service in ECC ([CVE-2019-6486](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6486))\n\nUpdates:\n- Go [1.10.8](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Go [1.11.5](https://golang.org/doc/devel/release.html#go1.11.minor)\n- Linux [4.19.18](https://lwn.net/Articles/777580/)"
+  },
+  "2023.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-02-14 10:31:00 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.20"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2023.2.0):\nSecurity fixes:\n - Fix runc container breakout ([CVE-2019-5736](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5736))\n\nChanges:\n - Revert `/sys/bus/rbd/add` to Linux 4.14 behavior ([#2544](https://github.com/coreos/bugs/issues/2544))\n\nUpdates:\n - etcd [3.3.12](https://github.com/etcd-io/etcd/releases/tag/v3.3.12)\n - etcdctl [3.3.12](https://github.com/etcd-io/etcd/releases/tag/v3.3.12)\n - Linux [4.19.20](https://lwn.net/Articles/779132/)\n"
+  },
+  "2023.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-02-21 08:41:36 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.23"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2023.3.0):\n\nUpdates:\n- Linux [4.19.23](https://lwn.net/Articles/779940/)"
+  },
+  "2051.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-02-27 08:53:46 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.25"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2051.1.0):\n\nSecurity fixes:\n- Fix Linux use-after-free in `sockfs_setattr` ([CVE-2019-8912](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-8912))\n- Fix systemd crash from a specially-crafted D-Bus message ([CVE-2019-6454](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6454))\n\nUpdates:\n- Linux [4.19.25](https://lwn.net/Articles/780611/)"
+  },
+  "2051.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-03-12 14:37:08 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.28"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2051.2.0):\n\nBug fixes:\n- Fix systemd-journald memory leak ([#2564](https://github.com/coreos/bugs/issues/2564))\n\nUpdates:\n- Linux [4.19.28](https://lwn.net/Articles/782719/)"
+  },
+  "2079.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-03-26 13:08:57 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.31"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2079.1.0):\n\nBug fixes:\n- Fix systemd presets incorrectly handling escaped unit names ([#2569](https://github.com/coreos/bugs/issues/2569))\n\nUpdates:\n- Linux [4.19.31](https://lwn.net/Articles/783858/)\n"
+  },
+  "2079.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-17 07:53:14 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.34"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2079.2.0):\n\nBug fixes:\n- Disable new sticky directory protections for backwards compatibility ([#2577](https://github.com/coreos/bugs/issues/2577))\n\nChanges:\n- Enable `atlantic` kernel module ([#2576](https://github.com/coreos/bugs/issues/2576))\n\nUpdates:\n- Linux [4.19.34](https://lwn.net/Articles/786050/)"
+  },
+  "2107.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-24 10:01:19 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.36"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2107.1.0):\n\nBug fixes:\n - Disable new sticky directory protections for backward compatibility ([#2577](https://github.com/coreos/bugs/issues/2577))\n\nChanges:\n - Enable `atlantic` kernel module ([#2576](https://github.com/coreos/bugs/issues/2576))\n\nUpdates:\n - Linux [4.19.36](https://lwn.net/Articles/786361/)"
+  },
+  "2107.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-08 07:07:32 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.36"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2107.2.0):\n\nBug fixes:\n\n- Fix systemd `MountFlags=shared` option ([#2579](https://github.com/coreos/bugs/issues/2579))\n\nChanges:\n\n- Pin network interface naming to systemd v238 scheme ([#2578](https://github.com/coreos/bugs/issues/2578))"
+  },
+  "2107.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-16 10:57:15 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.43"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2107.3.0):\n\nSecurity fixes:\n- Fix Intel CPU disclosure of memory to user process.  Complete mitigation requires [manually disabling SMT](https://docs.flatcar-linux.org/os/disabling-smt/) on affected processors. ([CVE-2019-11091](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11091), [CVE-2018-12126](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12126), [CVE-2018-12127](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12127), [CVE-2018-12130](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12130), [MDS](https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00233.html))\n\nUpdates:\n- intel-microcode [20190514](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190514/releasenote)\n- Linux [4.19.43](https://lwn.net/Articles/788388/)"
+  },
+  "2135.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-21 20:28:25 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.44"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2135.2.0):\n\nUpdates:\n- Linux [4.19.44](https://lwn.net/Articles/788778/)"
+  },
+  "2135.3.1": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-06-19 08:16:10 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.50"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2135.3.1):\n\nSecurity fixes:\n\n- Fix Linux TCP remotely-triggerable kernel panic and excessive resource consumption ([CVE-2019-11477](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11477), [CVE-2019-11478](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11478), [CVE-2019-11479](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11479))\n\nBug fixes:\n\n- Fix invalid bzip2 compression of Container Linux release images ([#2589](https://github.com/coreos/bugs/issues/2589))\n\nUpdates:\n\n- Linux [4.19.50](https://lwn.net/Articles/790878/)"
+  },
+  "2163.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-01 10:45:57 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.55"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2163.3.0):\n\nUpdates:\n\n- Linux [4.19.53](https://lwn.net/Articles/791468/)\n"
+  },
+  "2163.4.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-03 08:02:30 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.55"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2163.4.0):\n\nBug fixes:\n\n * Fix Ignition panic when no `guestinfo.(coreos|ignition).config` parameters are specified on VMware (coreos/ignition#821)\n\nUpdates:\n\n * Ignition [0.33.0](https://github.com/coreos/ignition/releases/tag/v0.33.0)"
+  },
+  "2191.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-17 13:51:51 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.56"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2191.1.0):\n\nNo changes for beta promotion"
+  },
+  "2191.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-01 09:15:48 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.62"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2191.2.0):\n- Linux [4.19.62](https://lwn.net/Articles/794807/)"
+  },
+  "2191.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-08 08:18:09 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.65"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2191.3.0):\n\nSecurity fixes:\n- Fix Linux information leak attack vector via speculative side channel ([CVE-2019-1125](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1125))\n\nUpdates:\n- Linux [4.19.65](https://lwn.net/Articles/795525/)\n\n## Flatcar updates\n\nChanges:\n- Add \"-s\" flag in flatcar-install to install to smallest disk (https://github.com/flatcar-linux/init/pull/7)"
+  },
+  "2219.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-16 09:44:16 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.65"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2219.2.0):\n\nSecurity fixes:\n- Use secure_getenv to fix a vulnerability around XDG_SEAT in pam_systemd (https://github.com/coreos/systemd/pull/118) ([CVE-2019-3842](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3842))\n\nUpdates:\n- Linux [4.19.65](https://lwn.net/Articles/795525/)\n\n## Flatcar updates\n\nBug fixes:\n- Fix wrong key name for fw_cfg in ignition with QEMU (https://github.com/flatcar-linux/ignition/issues/2)\n- Get SELinux context included in torcx tarballs (https://github.com/flatcar-linux/scripts/pull/16)\n- Enable XattrPrivileged for untar to fix SELinux issue (https://github.com/flatcar-linux/torcx/pull/1)\n"
+  },
+  "2219.2.1": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-30 07:37:15 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.68"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2219.2.1):\n\nSecurity fixes:\n- Fix wget buffer overflow allowing arbitrary code execution ([CVE-2019-5953](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5953))\n\nUpdates:\n- Linux [4.19.68](https://lwn.net/Articles/797250/)\n- wget [1.20.3](http://git.savannah.gnu.org/cgit/wget.git/tree/NEWS?h=v1.20.3&id=a220ead43505bc3e0ea8efb1572919111dbbf6dc#n8)"
+  },
+  "2219.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-09-05 08:53:14 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.69"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2219.3.0):\n\nSecurity fixes:\n\n- Fix pam_systemd bug allowing authenticated remote users to perform polkit actions as if locally logged in ([CVE-2019-3842](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3842))\n- Fix systemd-resolved bug allowing unprivileged users to change DNS settings ([CVE-2019-15718](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15718))\n\nBug fixes:\n\n- Fix GCE agent crash loop in new installs ([#2608](https://github.com/coreos/bugs/issues/2608))\n\nUpdates:\n\n- Linux [4.19.69](https://lwn.net/Articles/797815/)"
+  },
+  "2247.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-09-13 10:53:37 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.71"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2247.2.0):\n\nUpdates:\n\n- Linux [4.19.71](https://lwn.net/Articles/798627/)\n"
+  },
+  "2247.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-09-25 09:32:22 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.75"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2247.3.0):\n\nSecurity fixes:\n\n- Fix kernel KVM guest escape ([CVE-2019-14835](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14835))\n- Fix race condition in Intel microprocessors ([CVE-2019-11184](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11184))\n\nUpdates:\n\n- intel-microcode [20190918](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190918/releasenote)\n- Linux [4.19.75](https://lwn.net/Articles/800247/)"
+  },
+  "2247.4.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-10-16 15:09:03 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.78"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2247.4.0):\n\nBug fixes:\n- Fix kernel crash with CephFS mounts, introduced in 2247.3.0 ([#2616](https://github.com/coreos/bugs/issues/2616))\n\nUpdates:\n- Linux [4.19.78](https://lwn.net/Articles/801700/)"
+  },
+  "2275.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-10-17 18:54:07 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.79"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2275.2.0):\n\nUpdates:\n- Linux [4.19.79](https://lwn.net/Articles/802169/)"
+  },
+  "2303.1.1": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-11-11 14:13:02 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.81"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2303.1.1):\n\nBug fixes:\n\n- Fix time zone for Brazil ([#2627](https://github.com/coreos/bugs/issues/2627))\n\nUpdates:\n\n- Linux [4.19.81](https://lwn.net/Articles/803384/)\n- timezone-data [2019c](http://mm.icann.org/pipermail/tz-announce/2019-September/000057.html)"
+  },
+  "2303.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-11-21 09:28:13 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.84"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2303.2.0):\n\nSecurity fixes:\n\n- Fix Intel CPU disclosure of memory to user process. Complete mitigation requires [manually disabling TSX or SMT](https://docs.flatcar-linux.org/os/disabling-smt/) on affected processors. ([CVE-2019-11135](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11135), [TAA](https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00270.html))\n- Fix Intel CPU denial of service by a malicious guest VM ([CVE-2018-12207](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12207))\n\nBug fixes:\n\n- Fix CFS scheduler throttling highly-threaded I/O-bound applications ([#2623](https://github.com/coreos/bugs/issues/2623))\n\nUpdates:\n\n- intel-microcode [20191115](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20191115/releasenote)\n- Linux [4.19.84](https://lwn.net/Articles/804465/)"
+  },
+  "2331.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-12-05 06:34:11 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.87"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2331.1.0):\n\nUpdates:\n  - Linux [4.19.87](https://lwn.net/Articles/805923/)"
+  },
+  "2331.1.1": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-12-18 09:49:53 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.87"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n- Fix a bug when creating RAID0 arrays by setting the default layout (https://github.com/flatcar-linux/baselayout/pull/2)\n- Fix bug of unpacking tarballs failing when xattr is not supported (https://github.com/flatcar-linux/torcx/pull/2)\n\nUpdates:\n\n- ldb [1.3.6](https://gitlab.com/samba-team/samba/-/tags/ldb-1.3.6)\n- samba [4.8.6](https://gitlab.com/samba-team/samba/-/tags/samba-4.8.6)\n- talloc [2.1.11](https://gitlab.com/samba-team/samba/-/tags/talloc-2.1.11)\n- tdb [1.3.15](https://gitlab.com/samba-team/samba/-/tags/tdb-1.3.15)\n- tevent [0.9.37](https://gitlab.com/samba-team/samba/-/tags/tevent-0.9.37)"
+  },
+  "2345.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2020-01-17 13:33:11 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.95"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2345.1.0):\n\nSecurity fixes:\n\n- Fix multiple Git [vulnerabilities](https://marc.info/?l=git&m=157600115215285&w=2) ([CVE-2019-1348](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1348), [CVE-2019-1349](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1349), [CVE-2019-1350](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1350), [CVE-2019-1351](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1351), [CVE-2019-1352](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1352), [CVE-2019-1353](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1353), [CVE-2019-1354](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1354), [CVE-2019-1387](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1387), [CVE-2019-19604](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19604))\n\nUpdates:\n\n- Git [2.24.1](https://github.com/git/git/blob/master/Documentation/RelNotes/2.24.1.txt)\n- Linux [4.19.95](https://lwn.net/Articles/809258/)\n"
+  },
+  "2345.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2020-02-10 11:11:29 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.102"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n- Fix DNS resolution for the GCE metadata server (https://github.com/flatcar-linux/coreos-overlay/pull/160)\n- Create symlink for /run/metadata/coreos (https://github.com/flatcar-linux/coreos-overlay/pull/166)\n- Create symlink for flatcar-install (https://github.com/flatcar-linux/init/pull/14)\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2345.2.0):\n\nSecurity fixes:\n- Fix systemd use-after-free upon receiving crafted D-Bus message from local unprivileged attacker ([CVE-2020-1712](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1712))\n\nChanges:\n- Enable `qede` kernel module\n\nUpdates:\n- Linux [4.19.102](https://lwn.net/Articles/811638/)"
+  },
+  "2411.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2020-03-02 11:57:48 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.34.0"
+      ],
+      "kernel": [
+        "4.19.106"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\nBug fixes:\n- Enable persistent network interface names already in the initramfs to fix https://github.com/coreos/bugs/issues/1767\n- Fix backwards compatibility issues for users to migrate from CoreOS Container Linux. Support the kernel command line parameters `coreos.oem.*`, `coreos.autologin`, `coreos.first_boot`, and the QEMU firmware config path `opt/com.coreos/config` (https://github.com/flatcar-linux/Flatcar/issues/16 https://github.com/flatcar-linux/afterburn/pull/7 https://github.com/flatcar-linux/bootengine/pull/7 https://github.com/flatcar-linux/bootengine/pull/8 https://github.com/flatcar-linux/init/pull/16 https://github.com/flatcar-linux/init/pull/17 https://github.com/flatcar-linux/ignition/pull/8)\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2411.1.0)\nUpdates:\n- Linux [4.19.106](https://lwn.net/Articles/813157/)\n"
+  },
+  "current": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2020-03-02 11:57:48 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.34.0"
+      ],
+      "kernel": [
+        "4.19.106"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\nBug fixes:\n- Enable persistent network interface names already in the initramfs to fix https://github.com/coreos/bugs/issues/1767\n- Fix backwards compatibility issues for users to migrate from CoreOS Container Linux. Support the kernel command line parameters `coreos.oem.*`, `coreos.autologin`, `coreos.first_boot`, and the QEMU firmware config path `opt/com.coreos/config` (https://github.com/flatcar-linux/Flatcar/issues/16 https://github.com/flatcar-linux/afterburn/pull/7 https://github.com/flatcar-linux/bootengine/pull/7 https://github.com/flatcar-linux/bootengine/pull/8 https://github.com/flatcar-linux/init/pull/16 https://github.com/flatcar-linux/init/pull/17 https://github.com/flatcar-linux/ignition/pull/8)\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2411.1.0)\nUpdates:\n- Linux [4.19.106](https://lwn.net/Articles/813157/)\n"
+  }
+}

--- a/static/releases-json/releases-edge.json
+++ b/static/releases-json/releases-edge.json
@@ -1,0 +1,683 @@
+{
+  "2051.99.1": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-26 13:59:39 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.20"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nChanges:\n\n* enable cgroup v2 via kernel command line (https://github.com/flatcar-linux/scripts/commit/271ec2423bc99c9d23faf4ab6ae722726f955966)\n* make docker and containerd support cgroup v2 (https://github.com/flatcar-linux/coreos-overlay/commit/8184af2518634c115dd6ef623959da5948be4cca)\n"
+  },
+  "2051.99.2": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-26 14:00:54 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.20"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n* Add missing OEM changes for cloud providers to enable cgroup v2 (https://github.com/flatcar-linux/coreos-overlay/commit/f4dde83caf457fc5b480edbbb54d550632c92cf3)\n"
+  },
+  "2079.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-26 14:01:27 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "5.0.1"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nUpdates:\n\n* Linux [5.0.1](https://lwn.net/Articles/782717/)"
+  },
+  "2107.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-26 14:02:24 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "5.0.7"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nChanges:\n\n* add cgroupid and patch runc for OCI hooks (https://github.com/flatcar-linux/coreos-overlay/pull/23)\n* add bpftool (https://github.com/flatcar-linux/coreos-overlay/pull/24)\n\nUpdates:\n\n* Linux [5.0.7](https://lwn.net/Articles/786049/)"
+  },
+  "2121.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-29 19:25:05 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "5.0.9"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nChanges:\n\n* add a new package cri-o (https://github.com/flatcar-linux/coreos-overlay/pull/29)\n* add CFLAGS to prevent the Spectre v2 (https://github.com/flatcar-linux/coreos-overlay/pull/28)\n\nUpdates:\n\n* Linux [5.0.9](https://lwn.net/Articles/786360/)"
+  },
+  "2135.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-15 13:42:10 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "5.1.0"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Initial release\n\nThis is the first release meant to be used by the public so all the Edge changes are listed.\n\n## Flatcar updates\n\nChanges:\n\n* Add bpftool (https://github.com/flatcar-linux/coreos-overlay/pull/24)\n* Add [wireguard](https://www.wireguard.com/) (https://github.com/flatcar-linux/coreos-overlay/pull/32)\n* Add a new package cri-o (https://github.com/flatcar-linux/coreos-overlay/pull/29)\n* Add cgroupid and patch runc for OCI hooks (https://github.com/flatcar-linux/coreos-overlay/pull/23)\n* Enable cgroup v2 via kernel command line (https://github.com/flatcar-linux/scripts/commit/271ec2423bc99c9d23faf4ab6ae722726f955966)\n* Add missing OEM changes for cloud providers to enable cgroup v2 (https://github.com/flatcar-linux/coreos-overlay/commit/f4dde83caf457fc5b480edbbb54d550632c92cf3)\n* Make docker and containerd support cgroup v2 (https://github.com/flatcar-linux/coreos-overlay/commit/8184af2518634c115dd6ef623959da5948be4cca)\n* Add CFLAGS to prevent the Spectre v2 (https://github.com/flatcar-linux/coreos-overlay/pull/28)\n\nUpdates:\n\n* Linux [5.1.0](https://lwn.net/Articles/787556/)"
+  },
+  "2149.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-28 08:35:24 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "5.1.5"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n- Fix Intel CPU disclosure of memory to user process.  Complete mitigation requires [manually disabling SMT](https://docs.flatcar-linux.org/os/disabling-smt/) on affected processors. ([CVE-2019-11091](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11091), [CVE-2018-12126](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12126), [CVE-2018-12127](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12127), [CVE-2018-12130](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12130), [MDS](https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00233.html))\n\nBug fixes:\n- Fix kernel build path issues to build coreos-firmware (https://github.com/flatcar-linux/coreos-overlay/pull/36) (https://github.com/flatcar-linux/coreos-overlay/pull/31)\n\nUpdates:\n- intel-microcode [20190514](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190514/releasenote)\n- Linux [5.1.5](https://lwn.net/Articles/789418/)"
+  },
+  "2163.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-06-21 14:11:23 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "5.1.11"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n- Fix Linux TCP remotely-triggerable kernel panic and excessive resource consumption ([CVE-2019-11477](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11477), [CVE-2019-11478](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11478), [CVE-2019-11479](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11479))\n\nUpdates:\n\n- Linux [5.1.11](https://lwn.net/Articles/791290/)\n- cri-o [1.14.4](https://github.com/flatcar-linux/coreos-overlay/pull/40)"
+  },
+  "2191.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-04 08:25:18 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.1.15"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2191.0.0):\n\nSecurity fixes:\n\n * Fix libexpat denial of service ([CVE-2018-20843](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20843))\n\nBug fixes:\n\n * Fix Ignition panic when no `guestinfo.(coreos|ignition).config` parameters are specified on VMware (https://github.com/coreos/ignition/issues/821)\n\nUpdates:\n\n * expat [2.2.7](https://github.com/libexpat/libexpat/releases/tag/R_2_2_7)\n * Ignition [0.33.0](https://github.com/coreos/ignition/releases/tag/v0.33.0)\n\n## Flatcar updates\n\nBug fixes:\n\n- make containerd listen on localhost (https://github.com/flatcar-linux/coreos-overlay/pull/41)\n\nUpdates:\n\n- Linux [5.1.15](https://lwn.net/Articles/792008/)\n- cri-tools [1.14.0](https://github.com/flatcar-linux/coreos-overlay/pull/42)\n\nChanges:\n\n- Fix installation prefix of conmon in a cri-o example config (https://github.com/flatcar-linux/coreos-overlay/pull/43)\n"
+  },
+  "2191.99.1": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-09 13:00:37 +0000",
+    "major_software": {
+      "docker": [
+        "18.09.7"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.2.0"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n- Fix a bug in systemd not being able to activate netlink (https://github.com/flatcar-linux/coreos-overlay/pull/49)\n\nUpdates:\n\n- Linux [5.2](https://lwn.net/Articles/792995/)\n- docker [18.09.7](https://github.com/flatcar-linux/coreos-overlay/pull/46)\n- wireguard [0.0.20190702](https://github.com/flatcar-linux/coreos-overlay/pull/48/commits/0af0437c3dc14e4ac8763a9a335b799e739f4f3b)\n- coreos-firmware [20190620](https://github.com/flatcar-linux/coreos-overlay/pull/48/commits/e0e285c0bf7a6953fafbe10a5539bc8c84dbf48f)\n"
+  },
+  "2205.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-17 13:54:57 +0000",
+    "major_software": {
+      "docker": [
+        "18.09.7"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.2.1"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2205.0.0):\n\nBug fixes:\n\n - Fix Docker `device or resource busy` error when creating overlay mounts, introduced in 2191.99.0\n\n## Flatcar updates\n\nUpdates: \n\n - Linux [5.2.1](https://lwn.net/Articles/793683/)"
+  },
+  "2205.99.1": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-29 09:39:34 +0000",
+    "major_software": {
+      "docker": [
+        "18.09.7"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.2.1"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n - [Temporary workaround for runc on Flatcar: disable SELinux for runc v1.0.0-rc8](https://github.com/flatcar-linux/coreos-overlay/pull/53)\n - [Fix a bug in bind mount options in systemd](https://github.com/flatcar-linux/coreos-overlay/pull/52)\n\nUpdates: \n\n - [Upgrade runc to 1.0.0-rc8](https://github.com/flatcar-linux/coreos-overlay/pull/51)\n"
+  },
+  "2219.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-05 09:06:39 +0000",
+    "major_software": {
+      "docker": [
+        "18.09.7"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.2.5"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2219.0.0):\n\nBug fixes:\n- Fix Ignition fetching from S3 URLs when network is slow to start ([ignition#826](https://github.com/coreos/ignition/issues/826))\n\n## Flatcar updates\n\nBug fixes:\n\n - Fix cgroup v2 path for systemd hybrid mode in runc (https://github.com/flatcar-linux/coreos-overlay/pull/58)\n - Fix issue of rsyslog not running with root directory in systemd (https://github.com/flatcar-linux/systemd/pull/3)\n\nUpdates: \n\n - Linux [5.2.5](https://lwn.net/Articles/795009/)\n\nChanges:\n - Enable SELinux for tar and coreutils for SDK profile (https://github.com/flatcar-linux/coreos-overlay/pull/55)\n"
+  },
+  "2219.99.1": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-09 17:41:16 +0000",
+    "major_software": {
+      "docker": [
+        "18.09.7"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.2.7"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2219.1.0):\n\nSecurity fixes:\n- Fix Linux information leak attack vector via speculative side channel ([CVE-2019-1125](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1125))\n\n## Flatcar updates\n\nSecurity fixes:\n- Use secure_getenv to fix a vulnerability around XDG_SEAT in pam_systemd (https://github.com/flatcar-linux/coreos-overlay/pull/61) ([CVE-2019-3842](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3842)) \n\nBug fixes:\n- Get SELinux context included in torcx tarballs (https://github.com/flatcar-linux/scripts/pull/16)\n- Enable XattrPrivileged for untar to fix SELinux issue (https://github.com/flatcar-linux/torcx/pull/1)\n\nUpdates:\n- Linux [5.2.7](https://lwn.net/Articles/795524/)\n- cri-o [1.15.0](https://github.com/flatcar-linux/coreos-overlay/pull/59)\n\nChanges:\n- Add \"-s\" flag in flatcar-install to install to smallest disk (https://github.com/flatcar-linux/init/pull/7)\n"
+  },
+  "2234.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-28 15:11:00 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.1"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.2.9"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n - Fix denial of service in HTTP/2 implementations written in Go ([CVE-2019-9512](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9512) [CVE-2019-9514](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9514) [CVE-2019-14809](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14809) )\n - Fix arbitrary execution of code in libarchive ( [CVE-2017-14166](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14166) [CVE-2017-14501](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14501) [CVE-2017-14502](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14502) [CVE-2017-14503](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14503) )\n - Fix privilege escalation issues in polkit ([CVE-2018-1116](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1116) [CVE-2018-19788](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-19788) ) \n - Fix arbitrary execution of SQL statements in sqlite ( [CVE-2019-5018](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5018) [CVE-2019-9936](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9936) [CVE-2019-9937](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9937) )\n - Fix arbitrary execution of code in wget ( [CVE-2019-5953](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5953) )\n - Fix issues of secret leakage and nsswitch based config in Docker ( [CVE-2019-13509](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-13509) [CVE-2019-14271](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14271) )\n\nBug fixes:\n\n - Remove unnecessary dependency on Go 1.6 from cgroupid (https://github.com/flatcar-linux/coreos-overlay/commit/20f24ed14daf747e9b6923ee6baf2aa3635589e8)\n\nUpdates: \n\n - Linux [5.2.9](https://lwn.net/Articles/796462/)\n - Binutils [2.32-r1](https://github.com/flatcar-linux/portage-stable/commit/6124ccfbdf9b42b43f3bcc54331b1a590a09c142)\n - Docker [19.03.1](https://github.com/flatcar-linux/coreos-overlay/pull/62)\n - Go [1.12.9](https://github.com/golang/go/releases/tag/go1.12.9)\n - Libarchive [3.3.3](https://github.com/libarchive/libarchive/releases/tag/v3.3.3)\n - Patch [2.7.6-r4](https://github.com/flatcar-linux/portage-stable/commit/54a7e341d741c4dab4ac8df3bda7665c49700a12)\n - Polkit [0.113-r5](https://github.com/flatcar-linux/coreos-overlay/commit/a42f51d3714ae96577392293d0a683c324a4f6ee)\n - Rust [1.37.0](https://github.com/rust-lang/rust/releases/tag/1.37.0)\n - Cargo [1.37.0](https://github.com/rust-lang/rust/releases/tag/1.37.0) (https://github.com/rust-lang/cargo/releases/tag/0.38.0)\n - Sqlite [3.29.0](https://repo.or.cz/sqlite.git/shortlog/refs/tags/version-3.29.0)\n - Wget [1.20.3](http://git.savannah.gnu.org/cgit/wget.git/tag/?h=v1.20.3)\n"
+  },
+  "2247.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-09-03 18:01:18 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.1"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.2.11"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n - Fix secret leakage in libgcrypt ([CVE-2018-6829](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-6829))\n - Fix denial of service in libtasn1 ([CVE-2018-1000654](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000654))\n - Fix bypass of a protection mechanism in libxslt ([CVE-2019-11068](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11068))\n\nBug fixes:\n\n - Fix an issue of oem-gce crashlooping in GCE images (https://github.com/flatcar-linux/coreos-overlay/pull/69)\n\nUpdates: \n\n - Linux [5.2.11](https://lwn.net/Articles/797814/)\n - libgcrypt [1.8.3](https://github.com/gpg/libgcrypt/releases/tag/libgcrypt-1.8.3)\n - libtasn1 [4.13](https://github.com/gnutls/libtasn1/releases/tag/libtasn1_4_13)\n - libxslt [1.1.33](https://github.com/GNOME/libxslt/releases/tag/v1.1.33)\n"
+  },
+  "2261.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-09-19 13:43:42 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.2"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.2.13"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "242"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix systemd-resolved bug allowing unprivileged users to change DNS settings ([CVE-2019-15718](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15718))\n\nBug fixes:\n\n - Fix commit ID to match with Manifest in coreos-firmware (https://github.com/flatcar-linux/coreos-overlay/pull/76)\n - Use mantle/ignition versions which have the `opt/org.flatcar-linux` Ignition variable (https://github.com/flatcar-linux/coreos-overlay/pull/77)\n\nUpdates: \n\n - Linux [5.2.13](https://lwn.net/Articles/798626/)\n - systemd [v242](https://github.com/systemd/systemd/releases/tag/v242) (https://github.com/flatcar-linux/coreos-overlay/pull/71)\n - containerd [1.2.8](https://github.com/containerd/containerd/releases/tag/v1.2.8)\n - cri-o [1.15.1](https://github.com/cri-o/cri-o/releases/tag/v1.15.1)\n - docker [19.03.2](https://docs.docker.com/engine/release-notes/#19032)"
+  },
+  "2275.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-10-14 08:54:42 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.2"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.3.1"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "242"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix dbus authentication bypass in non-default configurations ([CVE-2019-12749](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-12749))\n- Fix kernel KVM guest escape ([CVE-2019-14835](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14835))\n- Fix race condition in Intel microprocessors ([CVE-2019-11184](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11184))\n- Fix invalid HTTP/1.1 handling in net/http of Go ([CVE-2019-16276](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16276))\n\nBug fixes:\n\n- Fix path prefix in crio-wipe.service in cri-o (https://github.com/flatcar-linux/coreos-overlay/pull/91)\n- Fix ListenPort= in WireGuard section in systemd (https://github.com/flatcar-linux/systemd/pull/5)\n\nUpdates: \n\n - Linux [5.3.1](https://lwn.net/Articles/800245/)\n - Go [1.12.10](https://go.googlesource.com/go/+/refs/tags/go1.12.10)\n - coreos-firmware [20190815](https://github.com/flatcar-linux/coreos-overlay/pull/93/commits/3c63b3d592960030b32ddabac7a1f6cba61b18ab) (https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/tag/?h=20190815)\n - cri-o [1.15.2](https://github.com/cri-o/cri-o/releases/tag/v1.15.2)\n - cri-tools [1.16.1](https://github.com/kubernetes-sigs/cri-tools/releases/tag/v1.16.1)\n - intel-microcode [20190918](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190918/releasenote)\n"
+  },
+  "2296.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-10-23 08:54:42 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.2"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.3.7"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "242"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix panic caused by invalid DSA public keys in Go 1.12 and 1.13 ([CVE-2019-17596](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-17596))\n- Fix AppArmor restriction bypass issue in runc 1.0.0-rc8 or older ([CVE-2019-16884](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16884))\n- Fix bypass of certain policy blacklists and session PAM modules in sudo 1.8.27 or older ([CVE-2019-14287](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14287))\n\nBug fixes:\n\n- Fix rkt fetch issue that does not work without docker:// prefix in URLs (https://github.com/flatcar-linux/coreos-overlay/pull/96)\n- Multiple bug fixes from the upstream systemd-stable repo (https://github.com/flatcar-linux/coreos-overlay/pull/97)\n\nUpdates: \n\n- Linux [5.3.7](https://lwn.net/Articles/802627/)\n- Go [1.12.12](https://go.googlesource.com/go/+/refs/tags/go1.12.12) and [1.13.3](https://go.googlesource.com/go/+/refs/tags/go1.13.3)\n- runc [1.0.0-rc9](https://github.com/opencontainers/runc/releases/tag/v1.0.0-rc9)\n- sudo [1.8.28](https://www.sudo.ws/stable.html#1.8.28)"
+  },
+  "2303.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-10-28 09:51:36 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.2"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.3.7"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "242"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n- Fix issue of missing patches in grub (https://github.com/flatcar-linux/grub/pull/1)\n- Fix issue of wrong commit IDs for repos like [init](https://github.com/flatcar-linux/init)"
+  },
+  "2303.99.1": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-11-01 16:45:14 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.4"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.3.7"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "242"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n- Fix wrong CROS_WORKON_COMMIT values (https://github.com/flatcar-linux/coreos-overlay/pull/101)\n- Fix bug of unpacking tarballs failing when xattr is not supported (https://github.com/flatcar-linux/torcx/pull/3)\n\nChanges:\n\n- Replace rkt with docker in scripts like kubelet-wrapper (https://github.com/flatcar-linux/coreos-overlay/pull/103)\n\nUpdates:\n\n- docker [19.03.4](https://docs.docker.com/engine/release-notes/#19034)\n- containerd [1.3.0](https://github.com/containerd/containerd/releases/tag/v1.3.0)"
+  },
+  "2345.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2019-12-10 09:21:56 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.4.2"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "242"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nThis release is done for both amd64 and arm64.\n\nSecurity fixes:\n\n- Fix Intel CPU disclosure of memory to user process. Complete mitigation requires [manually disabling TSX or SMT](https://docs.flatcar-linux.org/os/disabling-smt/) on affected processors. ([CVE-2019-11135](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11135), [TAA](https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00270.html))\n- Fix Intel CPU denial of service by a malicious guest VM ([CVE-2018-12207](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12207))\n- Fix curl Kerberos FTP double free ([CVE-2019-5481](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5481))\n- Fix curl TFTP buffer overflow with non-default block size ([CVE-2019-5482](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5482))\n- Fix openssl key extraction attacks under non-default conditions ([CVE-2019-1563](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1563), [CVE-2019-1547](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1547))\n- Fix heap-based buffer over-read in libexpat ([CVE-2019-15903](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15903))\n\nBug fixes:\n\n- Fix cross-build issues around WAF by creating wrappers (https://github.com/flatcar-linux/coreos-overlay/pull/138)\n- Fix rust-related issues around cross toolchains (https://github.com/flatcar-linux/scripts/pull/34)\n- Fix time zone for Brazil (https://github.com/flatcar-linux/coreos-overlay/pull/118)\n\nChanges:\n\n- Support cross-builds for ARM64 (https://github.com/flatcar-linux/coreos-overlay/pull/122)\n\nUpdates:\n\n- Linux [5.4.2](https://lwn.net/Articles/806394/)\n- curl [7.66.0](https://curl.haxx.se/mail/archive-2019-09/0002.html)\n- docker [19.03.5](https://docs.docker.com/engine/release-notes/#19035)\n- etcd [3.3.18](https://github.com/etcd-io/etcd/releases/tag/v3.3.18)\n- expat [2.2.8](https://github.com/libexpat/libexpat/releases/tag/R_2_2_8)\n- intel-microcode [20191115](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20191115/releasenote)\n- ldb [1.3.6](https://gitlab.com/samba-team/samba/-/tags/ldb-1.3.6)\n- openssl [1.0.2t](https://www.openssl.org/news/cl102.txt)\n- samba [4.8.6](https://gitlab.com/samba-team/samba/-/tags/samba-4.8.6)\n- talloc [2.1.11](https://gitlab.com/samba-team/samba/-/tags/talloc-2.1.11)\n- tdb [1.3.15](https://gitlab.com/samba-team/samba/-/tags/tdb-1.3.15)\n- tevent [0.9.37](https://gitlab.com/samba-team/samba/-/tags/tevent-0.9.37)\n- timezone-data [2019c](http://mm.icann.org/pipermail/tz-announce/2019-September/000057.html)"
+  },
+  "2345.99.1": {
+    "channel": "edge",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2019-12-20 09:28:45 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.4.4"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "242"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix a denial-of-service issue via malicious access to `/dev/kvm` ([CVE-2019-19332](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19332))\n\nBug fixes:\n\n- Fix a bug when creating RAID0 arrays by setting the default layout (https://github.com/flatcar-linux/baselayout/pull/2)\n- Use rkt instead of docker in kubelet-wrapper (https://github.com/flatcar-linux/coreos-overlay/pull/148)\n\nChanges:\n\n- Support the default layout feature in mdadm (https://github.com/flatcar-linux/coreos-overlay/pull/146)\n\nUpdates:\n\n- Linux [5.4.4](https://lwn.net/Articles/807611/)\n- containerd [1.3.2](https://github.com/containerd/containerd/releases/tag/v1.3.2)\n- mdadm [4.1](https://git.kernel.org/pub/scm/utils/mdadm/mdadm.git/tag/?h=mdadm-4.1)\n- wireguard [20191212](https://git.zx2c4.com/WireGuard/tag/?h=0.0.20191212)"
+  },
+  "2387.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2020-02-06 13:20:48 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.4.16"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "242"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix stack-based buffer overflow in sudo ([CVE-2019-18634](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18634))\n\nBug fixes:\n\n- Fix DNS resolution for the GCE metadata server (https://github.com/flatcar-linux/coreos-overlay/pull/160)\n- Use correct URLs for flatcar-linux in emerge-gitclone and scripts (https://github.com/flatcar-linux/dev-util/pull/1) (https://github.com/flatcar-linux/scripts/pull/50)\n- Fix a wrong profile reference in torcx (https://github.com/flatcar-linux/coreos-overlay/pull/162)\n- Use rkt again instead of docker in wrappers (https://github.com/flatcar-linux/coreos-overlay/pull/163)\n- Create symlink for /run/metadata/coreos (https://github.com/flatcar-linux/coreos-overlay/pull/166)\n- Create symlink for flatcar-install (https://github.com/flatcar-linux/init/pull/14)\n- Build static libraries for elfutils (https://github.com/flatcar-linux/coreos-overlay/pull/169)\n\nUpdates:\n\n- Linux [5.4.16](https://lwn.net/Articles/811027/)\n- dwarves [1.16](https://git.kernel.org/pub/scm/devel/pahole/pahole.git/tag/?h=v1.16)\n- elfutils [0.178](https://sourceware.org/git/?p=elfutils.git;a=tag;h=refs/tags/elfutils-0.178)\n- sudo [1.8.31](https://www.sudo.ws/stable.html#1.8.31)\n- wireguard [20200128](https://git.zx2c4.com/wireguard-linux-compat/tag/?h=v0.0.20200128)"
+  },
+  "2411.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2020-02-17 16:41:29 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.34.0"
+      ],
+      "kernel": [
+        "5.5.2"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "242"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix incorrect access control leading to privileges escalation in runc ([CVE-2019-19921](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19921))\n- Fix systemd use-after-free upon receiving crafted D-Bus message from local unprivileged attacker ([CVE-2020-1712](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1712))\n\nBug fixes:\n\n- Fix backwards compatibility issues for users to migrate from CoreOS Container Linux (https://github.com/flatcar-linux/Flatcar/issues/16 https://github.com/flatcar-linux/afterburn/pull/7 https://github.com/flatcar-linux/bootengine/pull/7 https://github.com/flatcar-linux/bootengine/pull/8 https://github.com/flatcar-linux/init/pull/16 https://github.com/flatcar-linux/init/pull/17 https://github.com/flatcar-linux/ignition/pull/8)\n\nChanges:\n\n- Build Flatcar tarballs to be used by containers (https://github.com/flatcar-linux/scripts/pull/51)\n- Enable qede kernel module\n- Enable kernel config for BTF (BPF Type Format)\n\nUpdates:\n\n- Linux [5.5.2](https://lwn.net/Articles/811599/)\n- coreos-firmware [20200122](https://github.com/flatcar-linux/coreos-overlay/pull/175/commits/8751b200031ca9d9b52a6ff060640b77f21b9504) (https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/tag/?h=20200122)\n- runc [1.0.0-rc10](https://github.com/opencontainers/runc/releases/tag/v1.0.0-rc10)\n"
+  },
+  "2430.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2020-03-05 10:27:05 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.34.0"
+      ],
+      "kernel": [
+        "5.5.6"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "243"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n- Enable persistent network interface names already in the initramfs to fix https://github.com/coreos/bugs/issues/1767\n- Make systemd-hostnamed work again by updating systemd to v243 (https://github.com/flatcar-linux/systemd/pull/7)\n- Use correct branch name format in developer container tools (https://github.com/flatcar-linux/dev-util/pull/2)\n\nUpdates:\n\n- Linux [5.5.6](https://lwn.net/Articles/813155/)\n- systemd [243](https://github.com/systemd/systemd/releases/tag/v243)"
+  },
+  "current": {
+    "channel": "edge",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2020-03-05 10:27:05 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.34.0"
+      ],
+      "kernel": [
+        "5.5.6"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "243"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n- Enable persistent network interface names already in the initramfs to fix https://github.com/coreos/bugs/issues/1767\n- Make systemd-hostnamed work again by updating systemd to v243 (https://github.com/flatcar-linux/systemd/pull/7)\n- Use correct branch name format in developer container tools (https://github.com/flatcar-linux/dev-util/pull/2)\n\nUpdates:\n\n- Linux [5.5.6](https://lwn.net/Articles/813155/)\n- systemd [243](https://github.com/systemd/systemd/releases/tag/v243)"
+  }
+}

--- a/static/releases-json/releases-stable.json
+++ b/static/releases-json/releases-stable.json
@@ -1,0 +1,1077 @@
+{
+  "1688.5.3": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-04-25 14:36:41 +0000",
+    "major_software": {
+      "docker": [
+        "17.12.1"
+      ],
+      "ignition": [
+        "0.22.0"
+      ],
+      "kernel": [
+        "4.14.32"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "237"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nInitial Flatcar release.\n\nBug fixes:\n- Fix GRUB crash at boot ([#2284](https://github.com/coreos/bugs/issues/2284))\n- Fix [poweroff problems](https://groups.google.com/forum/#!topic/coreos-user/YcGkRHU9SvQ) ([#8080](https://github.com/systemd/systemd/pull/8080))\n\nNotes:\n- Previous test images have been removed from the release servers. This is due to a new update key being generated using our updated security policy which we [included](https://github.com/flatcar-linux/coreos-overlay/pull/6) in the first public image.\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1688.5.3):\n\nBug fixes:\n- ~~Avoid GRUB crash at boot ([#2284](https://github.com/coreos/bugs/issues/2284))~~ We've included the [real fix for this](https://github.com/flatcar-linux/grub/commit/8281b03be34552e744fd08aae78b38704e2562b5).\n- Fix kernel panic with vxlan ([#2382](https://github.com/coreos/bugs/issues/2382))"
+  },
+  "1745.3.1": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-05-26 15:29:48 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.1"
+      ],
+      "kernel": [
+        "4.14.42"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1745.3.1):\n\nUpdates:\n- Ignition [0.24.1](https://github.com/coreos/ignition/releases/tag/v0.24.1)\n- Linux [4.14.42](https://lwn.net/Articles/754972/)"
+  },
+  "1745.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-05-27 09:02:48 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.1"
+      ],
+      "kernel": [
+        "4.14.42"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1745.4.0):\n\nBug fixes:\n- Fix inadvertent change of network interface names ([#2437](https://github.com/coreos/bugs/issues/2437))"
+  },
+  "1745.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-01 13:23:44 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.1"
+      ],
+      "kernel": [
+        "4.14.44"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1745.5.0):\n\nSecurity fixes:\n- Fix Git arbitrary code execution when cloning untrusted repositories ([CVE-2018-11235](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11235))\n\nBug fixes:\n- Fix failure to set network interface MTU ([#2443](https://github.com/coreos/bugs/issues/2443))\n\nUpdates:\n- Git [2.16.4](https://raw.githubusercontent.com/git/git/v2.16.4/Documentation/RelNotes/2.16.4.txt)\n- Linux [4.14.44](https://lwn.net/Articles/755717/)"
+  },
+  "1745.6.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-13 13:21:16 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.1"
+      ],
+      "kernel": [
+        "4.14.48"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1745.6.0):\n\nBug fixes:\n- Fix Hyper-V network driver regression ([#2454](https://github.com/coreos/bugs/issues/2454))\n\nUpdates:\n- Linux [4.14.48](https://lwn.net/Articles/756652/)"
+  },
+  "1745.7.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-15 14:51:25 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.1"
+      ],
+      "kernel": [
+        "4.14.48"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1745.7.0):\n\nBug fixes:\n- Fix TCP connection stalls ([#2457](https://github.com/coreos/bugs/issues/2457))"
+  },
+  "1800.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-07-26 09:38:46 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.14.55"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1800.4.0):\n\nNo changes for stable promotion"
+  },
+  "1800.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-07-31 09:16:01 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.14.59"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1800.5.0):\n\nBug fixes:\n- Fix kernel CIFS client ([#2480](https://github.com/coreos/bugs/issues/2480))\n\nUpdates:\n- Linux [4.14.59](https://lwn.net/Articles/761180/)"
+  },
+  "1800.6.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-08-08 10:49:51 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.14.59"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1800.6.0):\n\nSecurity fixes:\n- Fix Linux local denial of service as Xen PV guest ([CVE-2018-14678](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14678))\n\nBug fixes:\n- Fix failure to mount large ext4 filesystems ([#2485](https://github.com/coreos/bugs/issues/2485))"
+  },
+  "1800.7.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-08-17 12:07:54 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.14.63"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1800.7.0):\n\nSecurity fixes:\n- Fix Linux remote denial of service ([FragmentSmack](https://access.redhat.com/security/cve/cve-2018-5391), [CVE-2018-5391](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-5391))\n- Fix Linux privileged memory access via speculative execution ([L1TF/Foreshadow](https://foreshadowattack.eu/), [CVE-2018-3620](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3620), [CVE-2018-3646](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3646))\n\nUpdates:\n- intel-microcode [20180703](https://downloadcenter.intel.com/download/27945/Linux-Processor-Microcode-Data-File)\n- Linux [4.14.63](https://lwn.net/Articles/762808/)"
+  },
+  "1855.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-09-14 09:59:47 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.14.67"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1855.4.0):\n\nBug fixes:\n- Fix Docker mounting named volumes ([#2497](https://github.com/coreos/bugs/issues/2497))\n"
+  },
+  "1855.4.2": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-10-11 20:17:03 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.14.67"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nChanges:\n\n* Add new image signing subkey to `flatcar-install` ([flatcar-linux/init#4](https://github.com/flatcar-linux/init/pull/4))\n"
+  },
+  "1855.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-10-26 10:13:33 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.14.74"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1855.5.0):\n\nSecurity fixes:\n- Fix Git remote code execution during recursive clone ([CVE-2018-17456](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17456))\n\nUpdates:\n- Git [2.16.5](https://raw.githubusercontent.com/git/git/v2.16.5/Documentation/RelNotes/2.16.5.txt)\n- Linux [4.14.74](https://lwn.net/Articles/767628/)"
+  },
+  "1911.3.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-11-08 16:14:37 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.78"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1911.3.0):\n\nSecurity fixes:\n- Fix systemd re-executing with arbitrary supplied state ([CVE-2018-15686](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15686))\n- Fix systemd race allowing changing file permissions ([CVE-2018-15687](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15687))\n- Fix systemd-networkd buffer overflow in the dhcp6 client ([CVE-2018-15688](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15688))"
+  },
+  "1911.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-11-27 14:54:50 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.81"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1911.4.0):\n\nSecurity fixes:\n- Disable containerd CRI plugin to stop it from listening on a TCP port ([#2524](https://github.com/coreos/bugs/issues/2524))\n\nUpdates:\n- Linux [4.14.81](https://lwn.net/Articles/771885/)"
+  },
+  "1911.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-12-21 09:08:00 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.84"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1911.5.0):\n\nSecurity fixes:\n- Fix Go CPU denial of service in X.509 verification ([CVE-2018-16875](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16875))\n- Fix PolicyKit always authorizing UIDs greater than `INT_MAX` ([CVE-2018-19788](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-19788))\n\nUpdates:\n- Go [1.10.6](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Go [1.11.3](https://golang.org/doc/devel/release.html#go1.11.minor)\n- Linux [4.14.84](https://lwn.net/Articles/773114/)"
+  },
+  "1967.3.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-01-28 11:05:20 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.88"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1967.3.0):\n\nNo changes for stable promotion"
+  },
+  "1967.3.1": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-01-28 10:32:57 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.88"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1967.3.0):\n\nNo changes for stable promotion\n\n## Flatcar updates\n\nChanges:\n- [Fix the previous update of Flatcar](https://github.com/flatcar-linux/coreos-overlay/blob/build-1967.3.1/coreos-base/coreos-init/coreos-init-9999.ebuild#L13) where instead of https://github.com/flatcar-linux/init the upstream coreos-init package was referenced and used accidentally."
+  },
+  "1967.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-01-30 13:45:29 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.96"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1967.4.0):\n\nUpdates:\n- Linux [4.14.96](https://lwn.net/Articles/777581/)"
+  },
+  "1967.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-02-14 10:29:38 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.96"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1967.5.0):\nSecurity fixes:\n - Fix runc container breakout ([CVE-2019-5736](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5736))"
+  },
+  "1967.6.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-02-21 08:40:53 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.96"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1967.6.0):\n\nBug fixes:\n- Fix kernel POSIX timer rearming ([#2549](https://github.com/coreos/bugs/issues/2549))"
+  },
+  "2023.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-02-27 08:52:33 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.23"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2023.4.0):\n\nSecurity fixes:\n- Fix Linux use-after-free in `sockfs_setattr` ([CVE-2019-8912](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-8912))"
+  },
+  "2023.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-03-12 14:35:58 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.25"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2023.5.0):\n\nSecurity fixes:\n- Fix systemd crash from a specially-crafted D-Bus message ([CVE-2019-6454](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6454))\n\nBug fixes:\n- Fix systemd-journald memory leak ([#2564](https://github.com/coreos/bugs/issues/2564))\n\nUpdates:\n- Linux [4.19.25](https://lwn.net/Articles/780611/)"
+  },
+  "2079.3.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-24 10:00:10 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.34"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2079.3.0):\n\nNo changes for stable promotion"
+  },
+  "2079.3.1": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-25 10:05:40 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.34"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n* Fix a wrong vendor-specific string in [CMDLINE_OEM_FLAG](https://github.com/flatcar-linux/afterburn/blob/f4f0adc6a96a1ba77a0f87b612ecdf21782aa8c6/src/main.rs#L60) in [afterburn](https://github.com/flatcar-linux/afterburn) \n\n"
+  },
+  "2079.3.2": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-26 07:43:52 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.34"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n* Fix a regression from the latest hotfix builds, about [CROS_WORKON_COMMIT](https://github.com/flatcar-linux/coreos-overlay/blob/60e44f23a1a5527cfa6bcbc978b1ffdef74e2e3f/coreos-base/coreos-metadata/coreos-metadata-9999.ebuild#L13) in [coreos-overlay](https://github.com/flatcar-linux/coreos-overlay) \n"
+  },
+  "2079.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-16 10:57:17 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.43"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2079.4.0):\n\nSecurity fixes:\n- Fix Intel CPU disclosure of memory to user process.  Complete mitigation requires [manually disabling SMT](https://docs.flatcar-linux.org/os/disabling-smt/) on affected processors. ([CVE-2019-11091](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11091), [CVE-2018-12126](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12126), [CVE-2018-12127](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12127), [CVE-2018-12130](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12130), [MDS](https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00233.html))\n\nUpdates:\n- intel-microcode [20190514](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190514/releasenote)\n- Linux [4.19.43](https://lwn.net/Articles/788388/)"
+  },
+  "2079.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-06-06 08:49:52 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.43"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2079.5.0):\n\nBug fixes:\n- Fix systemd `MountFlags=shared` option ([#2579](https://github.com/coreos/bugs/issues/2579))\n\nChanges:\n- Pin network interface naming to systemd v238 scheme ([#2578](https://github.com/coreos/bugs/issues/2578))"
+  },
+  "2079.6.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-06-19 08:15:07 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.43"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2079.6.0):\n\nSecurity fixes:\n\n- Fix Linux TCP remotely-triggerable kernel panic and excessive resource consumption ([CVE-2019-11477](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11477), [CVE-2019-11478](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11478), [CVE-2019-11479](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11479))\n\nBug fixes:\n\n- Fix invalid bzip2 compression of Container Linux release images ([#2589](https://github.com/coreos/bugs/issues/2589))"
+  },
+  "2135.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-01 10:47:02 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.50"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2135.4.0):\n\nNo changes for stable promotion\n"
+  },
+  "2135.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-03 08:01:54 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.50"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2135.5.0):\n\nBug fixes:\n\n * Fix Ignition panic when no `guestinfo.(coreos|ignition).config` parameters are specified on VMware (coreos/ignition#821)\n\nUpdates:\n\n * Ignition [0.33.0](https://github.com/coreos/ignition/releases/tag/v0.33.0)\n"
+  },
+  "2135.6.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-01 09:14:26 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.56"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2135.6.0):\n\n- intel-microcode [20190618](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190618/releasenote)\n- Linux [4.19.56](https://lwn.net/Articles/792009/)"
+  },
+  "2191.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-16 09:42:56 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.65"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2191.4.0):\n\nSecurity fixes:\n- Use secure_getenv to fix a vulnerability around XDG_SEAT in pam_systemd (https://github.com/coreos/systemd/pull/118) ([CVE-2019-3842](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3842))\n\nUpdates:\n- Linux [4.19.65](https://lwn.net/Articles/795525/)\n\n## Flatcar updates\n\nBug fixes:\n- Fix wrong key name for fw_cfg in ignition with QEMU (https://github.com/flatcar-linux/ignition/issues/2)\n- Get SELinux context included in torcx tarballs (https://github.com/flatcar-linux/scripts/pull/16)\n- Enable XattrPrivileged for untar to fix SELinux issue (https://github.com/flatcar-linux/torcx/pull/1)\n\nChanges:\n- Add \"-s\" flag in flatcar-install to install to smallest disk (https://github.com/flatcar-linux/init/pull/7)"
+  },
+  "2191.4.1": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-30 07:36:13 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.66"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2191.4.1):\n\nSecurity fixes:\n- Fix wget buffer overflow allowing arbitrary code execution ([CVE-2019-5953](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5953))\n\nUpdates:\n- Linux [4.19.66](https://lwn.net/Articles/795843/)\n- wget [1.20.3](http://git.savannah.gnu.org/cgit/wget.git/tree/NEWS?h=v1.20.3&id=a220ead43505bc3e0ea8efb1572919111dbbf6dc#n8)"
+  },
+  "2191.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-09-05 08:52:34 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.68"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2191.5.0):\n\nSecurity fixes:\n\n- Fix pam_systemd bug allowing authenticated remote users to perform polkit actions as if locally logged in ([CVE-2019-3842](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3842))\n- Fix systemd-resolved bug allowing unprivileged users to change DNS settings ([CVE-2019-15718](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15718))\n\nBug fixes:\n\n- Fix GCE agent crash loop in new installs ([#2608](https://github.com/coreos/bugs/issues/2608))\n\nUpdates:\n\n- Linux [4.19.68](https://lwn.net/Articles/797250/)"
+  },
+  "2247.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-10-17 18:54:06 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.78"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2247.5.0):\n\nNo changes for stable promotion"
+  },
+  "2247.6.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-11-11 14:11:52 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.78"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2247.6.0):\n\nBug fixes:\n\n- Fix time zone for Brazil ([#2627](https://github.com/coreos/bugs/issues/2627))\n\nUpdates:\n\n- timezone-data [2019c](http://mm.icann.org/pipermail/tz-announce/2019-September/000057.html)"
+  },
+  "2247.7.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-11-21 09:27:14 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.84"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2247.7.0):\n\nSecurity fixes:\n\n- Fix Intel CPU disclosure of memory to user process. Complete mitigation requires [manually disabling TSX or SMT](https://docs.flatcar-linux.org/os/disabling-smt/) on affected processors. ([CVE-2019-11135](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11135), [TAA](https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00270.html))\n- Fix Intel CPU denial of service by a malicious guest VM ([CVE-2018-12207](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12207))\n\nBug fixes:\n\n- Fix CFS scheduler throttling highly-threaded I/O-bound applications ([#2623](https://github.com/coreos/bugs/issues/2623))\n\nUpdates:\n\n- intel-microcode [20191115](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20191115/releasenote)\n- Linux [4.19.84](https://lwn.net/Articles/804465/)"
+  },
+  "2303.3.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-12-05 06:33:04 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.86"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2303.3.0):\n\nUpdates:\n  - Linux [4.19.86](https://lwn.net/Articles/805531/)"
+  },
+  "2303.3.1": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-12-18 09:49:23 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.86"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n- Fix a bug when creating RAID0 arrays by setting the default layout (https://github.com/flatcar-linux/baselayout/pull/2)\n- Fix bug of unpacking tarballs failing when xattr is not supported (https://github.com/flatcar-linux/torcx/pull/2)\n\nUpdates:\n\n- ldb [1.3.6](https://gitlab.com/samba-team/samba/-/tags/ldb-1.3.6)\n- samba [4.8.6](https://gitlab.com/samba-team/samba/-/tags/samba-4.8.6)\n- talloc [2.1.11](https://gitlab.com/samba-team/samba/-/tags/talloc-2.1.11)\n- tdb [1.3.15](https://gitlab.com/samba-team/samba/-/tags/tdb-1.3.15)\n- tevent [0.9.37](https://gitlab.com/samba-team/samba/-/tags/tevent-0.9.37)"
+  },
+  "2303.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2020-02-10 11:10:47 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.95"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n- Fix DNS resolution for the GCE metadata server (https://github.com/flatcar-linux/coreos-overlay/pull/160)\n- Create symlink for /run/metadata/coreos (https://github.com/flatcar-linux/coreos-overlay/pull/166)\n- Create symlink for flatcar-install (https://github.com/flatcar-linux/init/pull/14)\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2303.4.0):\n\nUpdates:\n- Linux [4.19.95](https://lwn.net/Articles/809258/)"
+  },
+  "2345.3.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2020-03-02 14:03:06 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.106"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\nBug fixes:\n- Enable persistent network interface names already in the initramfs to fix https://github.com/coreos/bugs/issues/1767\n- Fix backwards compatibility issues for users to migrate from CoreOS Container Linux. Support the kernel command line parameters `coreos.oem.*`, `coreos.autologin`, `coreos.first_boot`, and the QEMU firmware config path `opt/com.coreos/config` (https://github.com/flatcar-linux/Flatcar/issues/16 https://github.com/flatcar-linux/afterburn/pull/7 https://github.com/flatcar-linux/bootengine/pull/7 https://github.com/flatcar-linux/bootengine/pull/8 https://github.com/flatcar-linux/init/pull/16 https://github.com/flatcar-linux/init/pull/17 https://github.com/flatcar-linux/ignition/pull/8)\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2345.3.0)\nSecurity fixes:\n- Fix systemd use-after-free upon receiving crafted D-Bus message from local unprivileged attacker [CVE-2020-1712](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1712)\n- Fix heap-based buffer over-read in libexpat ([CVE-2019-15903](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15903))\n- Fix multiple Git [vulnerabilities](https://marc.info/?l=git&m=157600115215285&w=2) ([CVE-2019-1348](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1348), [CVE-2019-1349](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1349), [CVE-2019-1350](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1350), [CVE-2019-1351](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1351), [CVE-2019-1352](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1352), [CVE-2019-1353](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1353), [CVE-2019-1354](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1354), [CVE-2019-1387](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1387), [CVE-2019-19604](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19604))\n- Fix curl Kerberos FTP double free ([CVE-2019-5481](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5481))\n - Fix curl TFTP buffer overflow with non-default block size ([CVE-2019-5482](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5482))\n - Fix OpenSSL key extraction attacks under non-default conditions ([CVE-2019-1563](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1563), [CVE-2019-1547](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1547))\n\nUpdates:\n\n- Git [2.24.1](https://github.com/git/git/blob/master/Documentation/RelNotes/2.24.1.txt)\n- Linux [4.19.106](https://lwn.net/Articles/813157/)\n- OpenSSL [1.0.2t](https://www.openssl.org/news/cl102.txt)\n- curl [7.66.0](https://curl.haxx.se/mail/archive-2019-09/0002.html)\n- etcd [3.3.18](https://github.com/etcd-io/etcd/releases/tag/v3.3.18)\n- expat [2.2.8](https://github.com/libexpat/libexpat/releases/tag/R_2_2_8)\n"
+  },
+  "current": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2020-03-02 14:03:06 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.106"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\nBug fixes:\n- Enable persistent network interface names already in the initramfs to fix https://github.com/coreos/bugs/issues/1767\n- Fix backwards compatibility issues for users to migrate from CoreOS Container Linux. Support the kernel command line parameters `coreos.oem.*`, `coreos.autologin`, `coreos.first_boot`, and the QEMU firmware config path `opt/com.coreos/config` (https://github.com/flatcar-linux/Flatcar/issues/16 https://github.com/flatcar-linux/afterburn/pull/7 https://github.com/flatcar-linux/bootengine/pull/7 https://github.com/flatcar-linux/bootengine/pull/8 https://github.com/flatcar-linux/init/pull/16 https://github.com/flatcar-linux/init/pull/17 https://github.com/flatcar-linux/ignition/pull/8)\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2345.3.0)\nSecurity fixes:\n- Fix systemd use-after-free upon receiving crafted D-Bus message from local unprivileged attacker [CVE-2020-1712](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1712)\n- Fix heap-based buffer over-read in libexpat ([CVE-2019-15903](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15903))\n- Fix multiple Git [vulnerabilities](https://marc.info/?l=git&m=157600115215285&w=2) ([CVE-2019-1348](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1348), [CVE-2019-1349](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1349), [CVE-2019-1350](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1350), [CVE-2019-1351](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1351), [CVE-2019-1352](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1352), [CVE-2019-1353](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1353), [CVE-2019-1354](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1354), [CVE-2019-1387](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1387), [CVE-2019-19604](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19604))\n- Fix curl Kerberos FTP double free ([CVE-2019-5481](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5481))\n - Fix curl TFTP buffer overflow with non-default block size ([CVE-2019-5482](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5482))\n - Fix OpenSSL key extraction attacks under non-default conditions ([CVE-2019-1563](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1563), [CVE-2019-1547](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1547))\n\nUpdates:\n\n- Git [2.24.1](https://github.com/git/git/blob/master/Documentation/RelNotes/2.24.1.txt)\n- Linux [4.19.106](https://lwn.net/Articles/813157/)\n- OpenSSL [1.0.2t](https://www.openssl.org/news/cl102.txt)\n- curl [7.66.0](https://curl.haxx.se/mail/archive-2019-09/0002.html)\n- etcd [3.3.18](https://github.com/etcd-io/etcd/releases/tag/v3.3.18)\n- expat [2.2.8](https://github.com/libexpat/libexpat/releases/tag/R_2_2_8)\n"
+  }
+}

--- a/static/releases-json/releases.json
+++ b/static/releases-json/releases.json
@@ -1,0 +1,4537 @@
+{
+  "1745.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-04-25 14:36:35 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.0"
+      ],
+      "ignition": [
+        "0.24.0"
+      ],
+      "kernel": [
+        "4.15.15"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nInitial Flatcar release.\n\nNotes:\n- Previous test images have been removed from the release servers. This is due to a new update key being generated using our updated security policy which we [included](https://github.com/flatcar-linux/coreos-overlay/pull/6) in the first public image.\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1745.0.0):\n\nSecurity fixes:\n- Fix curl out of bounds read ([CVE-2018-1000005](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000005))\n- Fix curl authentication data leak ([CVE-2018-1000007](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000007))\n- Fix curl buffer overflow ([CVE-2018-1000120](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000120))\n- Fix glibc integer overflow in libcidn ([CVE-2017-14062](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14062))\n- Fix glibc memory issues in `glob()` with `~` ([CVE-2017-15670](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15670), [CVE-2017-15671](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15671), [CVE-2017-15804](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15804))\n- Fix glibc mishandling RPATHs with `$ORIGIN` on setuid binaries ([CVE-2017-16997](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-16997))\n- Fix glibc buffer underflow in `realpath()` ([CVE-2018-1000001](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000001))\n- Fix glibc integer overflow and heap corruption in `memalign()` ([CVE-2018-6485](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-6485))\n\nBug fixes:\n- Fix GRUB crash at boot ([#2284](https://github.com/coreos/bugs/issues/2284))\n\nUpdates:\n- curl [7.59.0](https://curl.haxx.se/changes.html#7_59_0)\n- etcd-wrapper [3.3.3](https://github.com/coreos/etcd/releases/tag/v3.3.3)\n- etcdctl [3.3.3](https://github.com/coreos/etcd/releases/tag/v3.3.3)\n- glibc [2.25](https://www.sourceware.org/ml/libc-alpha/2017-02/msg00079.html)\n- Ignition [0.24.0](https://github.com/coreos/ignition/releases/tag/v0.24.0)\n- Linux [4.15.15](https://lwn.net/Articles/750656/)\n- Update Engine [0.4.6](https://github.com/coreos/update_engine/releases/tag/v0.4.6)"
+  },
+  "1758.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-04-26 09:58:53 +0000",
+    "major_software": {
+      "docker": [
+        "18.04.0"
+      ],
+      "ignition": [
+        "0.24.0"
+      ],
+      "kernel": [
+        "4.16.3"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1758.0.0):\n\nSecurity fixes:\n - Fix ntp clock manipulation from ephemeral connections ([CVE-2016-1549](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1549), [CVE-2018-7170](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7170))\n - Fix ntp denial of service from out of bounds read ([CVE-2018-7182](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7182)) \n - Fix ntp denial of service from packets with timestamp 0 ([CVE-2018-7184](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7184), [CVE-2018-7185](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7185))\n - Fix ntp remote code execution ([CVE-2018-7183](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7183))\n\nBug fixes:\n - Pass `/etc/machine-id` from the host to the kubelet\n - Fix docker2aci tar conversion ([#2402](https://github.com/coreos/bugs/issues/2402))\n - Switch `/boot` from FAT16 to FAT32 ([#2246](https://github.com/coreos/bugs/issues/2246))\n\nChanges:\n - Make Ignition failures more visible on the console\n\nUpdates:\n - containerd [1.0.3](https://github.com/containerd/containerd/releases/tag/v1.0.3)\n - coreos-cloudinit [1.14.0](https://github.com/coreos/coreos-cloudinit/releases/tag/v1.14.0)\n - coreos-metadata [1.0.6](https://github.com/coreos/coreos-metadata/releases/tag/v1.0.6)\n - Docker [18.04.0-ce](https://docs.docker.com/release-notes/docker-ce/#18040-ce-2018-04-10)\n - Go [1.9.5](https://golang.org/doc/devel/release.html#go1.9.minor)\n - Go [1.10.1](https://golang.org/doc/devel/release.html#go1.10.minor)\n - Linux [4.16.3](https://lwn.net/ml/linux-kernel/20180419074956.GA22325@kroah.com/)\n - ntp [4.2.8p11](https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ChangeLog-stable)\n - rkt [1.30.0](https://github.com/rkt/rkt/releases/tag/v1.30.0)\n - Rust [1.25.0](https://blog.rust-lang.org/2018/03/29/Rust-1.25.html)\n - torcx [0.1.3](https://github.com/coreos/torcx/releases/tag/v0.1.3)\n - update-ssh-keys [0.1.2](https://github.com/coreos/update-ssh-keys/releases/tag/v0.1.2)"
+  },
+  "1772.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-05-11 11:45:29 +0000",
+    "major_software": {
+      "docker": [
+        "18.04.0"
+      ],
+      "ignition": [
+        "0.24.0"
+      ],
+      "kernel": [
+        "4.16.7"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1772.0.0):\n\nBug fixes:\n- Fix GRUB free magic error on existing systems ([#2400](https://github.com/coreos/bugs/issues/2400))\n\nChanges:\n- Support storing sudoers in SSSD and LDAP\n- No longer publish Oracle Cloud release images\n\nUpdates:\n- audit [2.7.1](https://github.com/linux-audit/audit-userspace/blob/60aa3f2bc5f6483654599af4cb91731714079e26/ChangeLog)\n- coreutils [8.28](https://git.savannah.gnu.org/cgit/coreutils.git/tree/NEWS?h=v8.28)\n- etcd-wrapper [3.3.4](https://github.com/coreos/etcd/releases/tag/v3.3.4)\n- etcdctl [3.3.4](https://github.com/coreos/etcd/releases/tag/v3.3.4)\n- Go [1.9.6](https://golang.org/doc/devel/release.html#go1.9.minor)\n- Go [1.10.2](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Linux [4.16.7](https://lwn.net/Articles/753348/)\n- sudo [1.8.23](https://www.sudo.ws/stable.html#1.8.23)\n- Update Engine [0.4.7](https://github.com/coreos/update_engine/releases/tag/v0.4.7)\n- wa-linux-agent [2.2.25](https://github.com/Azure/WALinuxAgent/releases/tag/v2.2.25)"
+  },
+  "1786.0.1": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-05-26 15:29:50 +0000",
+    "major_software": {
+      "docker": [
+        "18.05.0"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.16.10"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1786.0.1):\n\nSecurity fixes:\n\n- Fix ncurses denial of service and arbitrary code execution ([CVE-2017-10684](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-10684), [CVE-2017-10685](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-10685), [CVE-2017-11112](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11112), [CVE-2017-11113](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-11113), [CVE-2017-13728](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-13728), [CVE-2017-13729](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-13729), [CVE-2017-13730](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-13730), [CVE-2017-13731](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-13731), [CVE-2017-13732](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-13732), [CVE-2017-13733](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-13733), [CVE-2017-13734](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-13734), [CVE-2017-16879](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-16879))\n- Fix rsync arbitrary command execution ([CVE-2018-5764](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-5764))\n- Fix wget cookie injection ([CVE-2018-0494](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0494))\n\nChanges:\n- Enable QLogic FCoE offload support ([#2367](https://github.com/coreos/bugs/issues/2367))\n- Enable hardware RNG kernel drivers ([#2430](https://github.com/coreos/bugs/issues/2430))\n- Add `notrap` to ntpd default access restrictions ([#2220](https://github.com/coreos/bugs/issues/2220))\n- Allow booting default GRUB menu entry if GRUB password is enabled ([#1597](https://github.com/coreos/bugs/issues/1597))\n- `coreos-install -i` no longer modifies `grub.cfg` ([#2291](https://github.com/coreos/bugs/issues/2291))\n- QEMU wrapper script now enables VirtIO RNG device\n\nUpdates:\n- bind-tools [9.11.2-P1](https://kb.isc.org/article/AA-01550/0/BIND-9.11.2-P1-Release-Notes.html)\n- Docker [18.05.0-ce](https://github.com/docker/docker-ce/releases/tag/v18.05.0-ce)\n- etcd-wrapper [3.3.5](https://github.com/coreos/etcd/releases/tag/v3.3.5)\n- etcdctl [3.3.5](https://github.com/coreos/etcd/releases/tag/v3.3.5)\n- GnuPG [2.2.7](https://lists.gnupg.org/pipermail/gnupg-announce/2018q2/000424.html)\n- GPT fdisk [1.0.3](https://sourceforge.net/p/gptfdisk/code/ci/f1f6236fb44392bfe5673bc3889a2b17b1696b90/tree/NEWS)\n- Ignition [0.25.1](https://github.com/coreos/ignition/releases/tag/v0.25.1)\n- Less [529](http://www.greenwoodsoftware.com/less/news.529.html)\n- Linux [4.16.10](https://lwn.net/Articles/754971/)\n- rsync [3.1.3](https://download.samba.org/pub/rsync/src/rsync-3.1.3-NEWS)\n- Rust [1.26](https://blog.rust-lang.org/2018/05/10/Rust-1.26.html)\n- util-linux [2.32](https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.32/v2.32-ReleaseNotes)\n- vim [8.0.1298](http://ftp.vim.org/pub/vim/patches/8.0/README)\n- wget [1.19.5](https://git.savannah.gnu.org/cgit/wget.git/tree/NEWS?h=v1.19.5&id=15a39093b8751596fe87a6c1f143dff6b6a818ee)"
+  },
+  "1786.1.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-05-27 09:02:47 +0000",
+    "major_software": {
+      "docker": [
+        "18.05.0"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.16.10"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1786.1.0):\n\nBug fixes:\n- Fix inadvertent change of network interface names ([#2437](https://github.com/coreos/bugs/issues/2437))\n- Fix Docker bind mounts from root filesystem ([#2440](https://github.com/coreos/bugs/issues/2440))\n"
+  },
+  "1786.2.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-01 13:23:42 +0000",
+    "major_software": {
+      "docker": [
+        "18.05.0"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.16.13"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1786.2.0):\n\nSecurity fixes:\n- Fix Git arbitrary code execution when cloning untrusted repositories ([CVE-2018-11235](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11235))\n\nBug fixes:\n- Fix failure to set network interface MTU ([#2443](https://github.com/coreos/bugs/issues/2443))\n\nUpdates:\n- Git [2.16.4](https://raw.githubusercontent.com/git/git/v2.16.4/Documentation/RelNotes/2.16.4.txt)\n- Linux [4.16.13](https://lwn.net/Articles/755961/)"
+  },
+  "1800.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-12 10:15:01 +0000",
+    "major_software": {
+      "docker": [
+        "18.05.0"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.16.14"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1800.0.0):\n\nSecurity fixes:\n - Fix multiple procps vulnerabilities ([CVE-2018-1120](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1120), [CVE-2018-1121](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1121), [CVE-2018-1122](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1122), [CVE-2018-1123](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1123), [CVE-2018-1124](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1124), [CVE-2018-1125](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1125), [CVE-2018-1126](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1126), [CVE-2018-1120](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1120), [CVE-2018-1121](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1121), [CVE-2018-1122](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1122), [CVE-2018-1123](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1123), [CVE-2018-1124](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1124), [CVE-2018-1126](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1126))\n - Fix shadow privilege escalation ([CVE-2018-7169](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7169))\n - Fix samba man-in-the-middle attack ([CVE-2016-2119](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-2119))\n - Fix Git arbitrary code execution when cloning untrusted repositories ([CVE-2018-11235](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11235))\n\nBug fixes:\n- Fix failure to set network interface MTU ([#2443](https://github.com/coreos/bugs/issues/2443))\n- Fix inadvertent change of network interface names ([#2437](https://github.com/coreos/bugs/issues/2437))\n- Fix Docker bind mounts from root filesystem ([#2440](https://github.com/coreos/bugs/issues/2440))\n\nChanges:\n - Update VMware virtual hardware version to 11 (ESXi > 6.0)\n\nUpdates:\n - etcd [3.3.6](https://github.com/coreos/etcd/releases/tag/v3.3.6)\n - etcdctl [3.3.6](https://github.com/coreos/etcd/releases/tag/v3.3.6)\n - Git [2.16.4](https://raw.githubusercontent.com/git/git/v2.16.4/Documentation/RelNotes/2.16.4.txt)\n - Linux [4.16.14](https://lwn.net/Articles/756651/)\n - open-vm-tools [10.2.5](https://docs.vmware.com/en/VMware-Tools/10.2/rn/vmware-tools-1025-release-notes.html)\n - procps [3.3.15](https://gitlab.com/procps-ng/procps/tags/v3.3.15)\n - samba [4.5.16](https://www.samba.org/samba/history/samba-4.5.16.html)\n - shadow [4.6](https://github.com/shadow-maint/shadow/releases/tag/4.6)"
+  },
+  "1800.1.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-13 13:23:42 +0000",
+    "major_software": {
+      "docker": [
+        "18.05.0"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.16.14"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1800.1.0):\n\nBug fixes:\n- Fix Hyper-V network driver regression ([#2454](https://github.com/coreos/bugs/issues/2454))"
+  },
+  "1814.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-22 10:18:59 +0000",
+    "major_software": {
+      "docker": [
+        "18.05.0"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.16.16"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1814.0.0):\n\nBug fixes:\n- Fix Hyper-V network driver regression ([#2454](https://github.com/coreos/bugs/issues/2454))\n\nChanges:\n- [Drop obsolete `cros_sdk` method of entering SDK](https://groups.google.com/d/topic/coreos-dev/JV3s-j51Tcw/discussion)\n\nUpdates:\n- etcd [3.3.7](https://github.com/coreos/etcd/releases/tag/v3.3.7)\n- etcdctl [3.3.7](https://github.com/coreos/etcd/releases/tag/v3.3.7)\n- Go [1.9.7](https://golang.org/doc/devel/release.html#go1.9.minor)\n- Go [1.10.3](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Ignition [0.26.0](https://github.com/coreos/ignition/releases/tag/v0.26.0)\n- Linux [4.16.16](https://lwn.net/Articles/757679/)\n- torcx [0.2.0](https://github.com/coreos/torcx/releases/tag/v0.2.0)"
+  },
+  "1828.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-07-05 13:56:54 +0000",
+    "major_software": {
+      "docker": [
+        "18.05.0"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.17.3"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1828.0.0):\n\nSecurity fixes:\n- Fix curl buffer overflows ([CVE-2018-1000300](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000300), [CVE-2018-1000301](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000301))\n- Fix Linux random seed during early boot ([CVE-2018-1108](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1108))\n\nChanges:\n- Reads of `/dev/urandom` early in boot will block until entropy pool is fully initialized\n- Support friendly AWS EBS NVMe device names ([#2399](https://github.com/coreos/bugs/issues/2399))\n\nUpdates:\n- cryptsetup [1.7.5](https://mirrors.edge.kernel.org/pub/linux/utils/cryptsetup/v1.7/v1.7.5-ReleaseNotes)\n- curl [7.60.0](https://curl.haxx.se/changes.html#7_60_0)\n- etcd-wrapper [3.3.8](https://github.com/coreos/etcd/releases/tag/v3.3.8)\n- etcdctl [3.3.8](https://github.com/coreos/etcd/releases/tag/v3.3.8)\n- intel-microcode [20180616](https://downloadcenter.intel.com/download/27776/Linux-Processor-Microcode-Data-File)\n- kmod [25](https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git/tree/NEWS?h=v25)\n- Linux [4.17.3](https://lwn.net/Articles/758268/)\n- linux-firmware [20180606](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/log/?id=d1147327232ec4616a66ab898df84f9700c816c1)\n- Locksmith [0.6.2](https://github.com/coreos/locksmith/releases/tag/v0.6.2)\n- OpenSSL [1.0.2o](https://www.openssl.org/news/openssl-1.0.2-notes.html)"
+  },
+  "1849.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-07-26 09:41:44 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.0"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.17.9"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1849.0.0):\n\nChanges:\n- Add torcx remotes support\n\nUpdates:\n- containerd [1.1.1](https://github.com/containerd/containerd/releases/tag/v1.1.1)\n- Docker [18.06.0-ce](https://github.com/docker/docker-ce/releases/tag/v18.06.0-ce)\n- intel-microcode [20180703](https://downloadcenter.intel.com/download/27945/Linux-Processor-Microcode-Data-File)\n- Linux [4.17.9](https://lwn.net/Articles/760499/)\n- Update Engine [0.4.9](https://github.com/coreos/update_engine/releases/tag/v0.4.9)\n"
+  },
+  "1855.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-07-31 09:15:59 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.0"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.17.11"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1855.0.0):\n\nChanges:\n- [Remove ARM64 architecture](https://groups.google.com/d/topic/coreos-user/3Z2S6bKNF5E/discussion)\n- [Remove developer image from SDK](https://groups.google.com/d/topic/coreos-dev/JNU-UDYprMo/discussion)\n\nUpdates:\n- etcd [3.3.9](https://github.com/coreos/etcd/releases/tag/v3.3.9)\n- etcdctl [3.3.9](https://github.com/coreos/etcd/releases/tag/v3.3.9)\n- Linux [4.17.11](https://lwn.net/Articles/761179/)"
+  },
+  "1855.1.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-08-08 10:49:49 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.0"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.17.12"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1855.1.0):\n\nSecurity fixes:\n- Fix Linux local denial of service as Xen PV guest ([CVE-2018-14678](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14678))\n\nBug fixes:\n- Fix failure to mount large ext4 filesystems ([#2485](https://github.com/coreos/bugs/issues/2485))\n\nUpdates:\n- Linux [4.17.12](https://lwn.net/Articles/761766/)"
+  },
+  "1871.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-08-17 12:11:12 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.0"
+      ],
+      "ignition": [
+        "0.27.0"
+      ],
+      "kernel": [
+        "4.17.15"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1871.0.0):\n\nSecurity fixes:\n- Fix Linux remote denial of service ([FragmentSmack](https://access.redhat.com/security/cve/cve-2018-5391), [CVE-2018-5391](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-5391))\n- Fix Linux privileged memory access via speculative execution ([L1TF/Foreshadow](https://foreshadowattack.eu/), [CVE-2018-3620](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3620), [CVE-2018-3646](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3646))\n- Fix curl SMTP buffer overflow ([CVE-2018-0500](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0500))\n\nBug fixes:\n- Fix PXE systems attempting to mount an ESP ([#2491](https://github.com/coreos/bugs/issues/2491))\n\nUpdates:\n- coreos-metadata [2.0.0](https://github.com/coreos/coreos-metadata/releases/tag/v2.0.0)\n- curl [7.61.0](https://curl.haxx.se/changes.html#7_61_0)\n- Ignition [0.27.0](https://github.com/coreos/ignition/releases/tag/v0.27.0)\n- Linux [4.17.15](https://lwn.net/Articles/762807/)\n- update-ssh-keys [0.2.1](https://github.com/coreos/update-ssh-keys/releases/tag/v0.2.1)"
+  },
+  "1883.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-08-29 17:07:21 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.18.5"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1883.0.0):\n\nChanges:\n- Add CIFS userspace utilities ([#571](https://github.com/coreos/bugs/issues/571))\n- Drop AWS PV images from regions which do not support PV\n\nUpdates:\n- containerd [1.1.2](https://github.com/containerd/containerd/releases/tag/v1.1.2)\n- Docker [18.06.1-ce](https://github.com/docker/docker-ce/releases/tag/v18.06.1-ce)\n- Ignition [0.28.0](https://github.com/coreos/ignition/releases/tag/v0.28.0)\n- Linux [4.18.5](https://lwn.net/Articles/763431/)\n- Rust [1.28.0](https://blog.rust-lang.org/2018/08/02/Rust-1.28.html)"
+  },
+  "1897.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-09-14 13:25:22 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.18.7"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1897.0.0):\n\nBug fixes:\n- Fix Docker mounting named volumes ([#2497](https://github.com/coreos/bugs/issues/2497))\n- Fix Azure disk detection in Ignition ([#2481](https://github.com/coreos/bugs/issues/2481))\n\nChanges:\n- Add support for Google Compute Engine OS Login\n- Enable support for Mellanox Ethernet switches\n\nUpdates:\n- coreos-metadata [3.0.0](https://github.com/coreos/coreos-metadata/releases/tag/v3.0.0)\n- Go [1.10.4](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Go [1.11](https://golang.org/doc/go1.11)\n- intel-microcode [20180807a](https://downloadcenter.intel.com/download/28087)\n- Linux [4.18.7](https://lwn.net/Articles/764459/)\n- update-ssh-keys [0.3.0](https://github.com/coreos/update-ssh-keys/releases/tag/v0.3.0)"
+  },
+  "1911.0.2": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-10-01 17:46:23 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.18.9"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1911.0.2):\n\nBug fixes:\n- Fix Google Compute Engine OS Login activation ([#2503](https://github.com/coreos/bugs/issues/2503))\n\nUpdates:\n- Linux [4.18.9](https://lwn.net/Articles/765657/)"
+  },
+  "1925.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-10-11 13:18:48 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.18.12"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nChanges:\n\n* Add new image signing subkey to `flatcar-install` ([flatcar-linux/init#4](https://github.com/flatcar-linux/init/pull/4))\n\nBug fixes:\n\n* Fix `/usr/lib/coreos` symlink for Container Linux compatibility ([flatcar-linux/coreos-overlay#8](https://github.com/flatcar-linux/coreos-overlay/pull/8))\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1925.0.0):\n\nUpdates:\n- glibc [2.26](https://sourceware.org/ml/libc-alpha/2017-08/msg00010.html)\n- Go [1.11.1](https://golang.org/doc/devel/release.html#go1.11.minor)\n- Linux [4.18.12](https://lwn.net/Articles/767627/)\n- nfs-utils [2.3.1](https://lwn.net/Articles/741961/)\n- open-vm-tools [10.3.0](https://github.com/vmware/open-vm-tools/blob/stable-10.3.0/ReleaseNotes.md)"
+  },
+  "1939.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-10-26 10:15:37 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.19.0"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1939.0.0):\n\nSecurity fixes:\n- Fix Git remote code execution during recursive clone ([CVE-2018-17456](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17456))\n- Fix OpenSSH user enumeration ([CVE-2018-15473](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15473))\n- Fix Rust standard library integer overflow ([CVE-2018-1000810](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000810))\n\nBug fixes:\n- Fix missing kernel headers ([#2505](https://github.com/coreos/bugs/issues/2505))\n\nUpdates:\n- coreos-metadata [3.0.1](https://github.com/coreos/coreos-metadata/releases/tag/v3.0.1)\n- etcd-wrapper [3.3.10](https://github.com/etcd-io/etcd/releases/tag/v3.3.10)\n- etcdctl [3.3.10](https://github.com/etcd-io/etcd/releases/tag/v3.3.10)\n- Git [2.18.1](https://raw.githubusercontent.com/git/git/v2.18.1/Documentation/RelNotes/2.18.1.txt)\n- Linux [4.19](https://lwn.net/Articles/769110/)\n- linux-firmware [20181001](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/log/?id=7c81f23ad903f72e87e2102d8f52408305c0f7a2)\n- OpenSSH [7.7p1](https://www.openssh.com/txt/release-7.7)\n- Rust [1.29.1](https://blog.rust-lang.org/2018/09/25/Rust-1.29.1.html)"
+  },
+  "1953.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-11-08 16:14:40 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.19.1"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1953.0.0):\n\nSecurity fixes:\n- Fix systemd re-executing with arbitrary supplied state ([CVE-2018-15686](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15686))\n- Fix systemd race allowing changing file permissions ([CVE-2018-15687](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15687))\n- Fix systemd-networkd buffer overflow in the dhcp6 client ([CVE-2018-15688](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15688))\n\nBug fixes:\n- Add AWS and GCE disk aliases in the initramfs for Ignition ([#2481](https://github.com/coreos/bugs/issues/2481))\n- Add compatibility `nf_conntrack_ipv4` kernel module to fix kube-proxy IPVS on Linux 4.19 ([#2518](https://github.com/coreos/bugs/issues/2518))\n\nUpdates:\n- IANA timezone database [2018e](https://mm.icann.org/pipermail/tz-announce/2018-May/000050.html)\n- kexec-tools [2.0.17](https://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git/log/?h=v2.0.17)\n- Linux [4.19.1](https://lwn.net/Articles/770746/)"
+  },
+  "1967.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-11-21 10:58:39 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.19.2"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1967.0.0):\n\nSecurity fixes:\n- Disable containerd CRI plugin to stop it from listening on a TCP port ([#2524](https://github.com/coreos/bugs/issues/2524))\n- Fix curl buffer overrun in NTLM authentication code ([CVE-2018-14618](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14618))\n- Fix OpenSSL TLS client denial of service ([CVE-2018-0732](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0732))\n- Fix OpenSSL timing side channel in DSA signature generation ([CVE-2018-0734](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-0734))\n- Fix OpenSSL timing side channel via SMT port contention ([CVE-2018-5407](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-5407))\n\nUpdates:\n- coreos-metadata [3.0.2](https://github.com/coreos/coreos-metadata/releases/tag/v3.0.2)\n- curl [7.61.1](https://curl.haxx.se/changes.html#7_61_1)\n- Go [1.10.5](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Go [1.11.2](https://golang.org/doc/devel/release.html#go1.11.minor)\n- Linux [4.19.2](https://lwn.net/Articles/771883/)\n- OpenSSL [1.0.2p](https://www.openssl.org/news/openssl-1.0.2-notes.html)\n- Rust [1.30.1](https://blog.rust-lang.org/2018/11/08/Rust-1.30.1.html)"
+  },
+  "1981.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-12-06 09:45:28 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.19.6"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1981.0.0):\n\nUpdates:\n - Linux [4.19.6](https://lwn.net/Articles/773528/)\n - iptables [1.6.2](https://www.netfilter.org/projects/iptables/files/changes-iptables-1.6.2.txt)"
+  },
+  "1995.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-12-21 09:09:39 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.29.1"
+      ],
+      "kernel": [
+        "4.19.9"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1995.0.0):\n\nSecurity fixes:\n- Fix Go CPU denial of service in X.509 verification ([CVE-2018-16875](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16875))\n- Fix PolicyKit always authorizing UIDs greater than `INT_MAX` ([CVE-2018-19788](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-19788))\n\nBug fixes:\n- Fix AWS, Azure, and GCE disk aliases in the initramfs for Ignition ([#2531](https://github.com/coreos/bugs/issues/2531))\n\nUpdates:\n- Go [1.10.6](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Go [1.11.3](https://golang.org/doc/devel/release.html#go1.11.minor)\n- Ignition [0.29.1](https://github.com/coreos/ignition/releases/tag/v0.29.1)\n- Linux [4.19.9](https://lwn.net/Articles/774847/)\n- Rust [1.31.0](https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html)\n- wa-linux-agent [2.2.32](https://github.com/Azure/WALinuxAgent/releases/tag/v2.2.32)"
+  },
+  "2016.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-01-18 09:11:32 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.13"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2016.0.0):\n\nBug fixes:\n\n- Fix monitoring process events over netlink ([#2537](https://github.com/coreos/bugs/issues/2537))\n\nUpdates:\n- Ignition [0.30.0](https://github.com/coreos/ignition/releases/tag/v0.30.0)\n- Go [1.10.7](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Go [1.11.4](https://golang.org/doc/devel/release.html#go1.11.minor)\n- Linux [4.19.13](https://lwn.net/Articles/775720/)"
+  },
+  "2023.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-01-18 14:03:21 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.15"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2023.0.0):\n\nSecurity fixes:\n - Fix systemd-journald privilege escalation ([CVE-2018-16864](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16864), [CVE-2018-16865](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16865))\n - Fix systemd-journald out of bounds read ([CVE-2018-16866](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16866))\n - Fix ntpq, ntpdc buffer overflow ([CVE-2018-12327](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12327))\n - Fix etcd improper authentication with RBAC and client certs ([CVE-2018-16886](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16886))\n\nChanges:\n - Add `ip_vs_mh` kernel module ([#2542](https://github.com/coreos/bugs/issues/2542))\n\nUpdates:\n - etcd [3.3.11](https://github.com/etcd-io/etcd/releases/tag/v3.3.11)\n - etcdctl [3.3.11](https://github.com/etcd-io/etcd/releases/tag/v3.3.11)\n - Linux [4.19.15](https://lwn.net/Articles/776607/)\n - ntp [4.2.8p12](https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ChangeLog-stable)\n - sudo [1.8.25p1](https://www.sudo.ws/stable.html#1.8.25p1)\n"
+  },
+  "2037.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-01-30 13:45:27 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.18"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2037.0.0):\n\nSecurity fixes:\n- Fix Go CPU denial of service in ECC ([CVE-2019-6486](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6486))\n\nUpdates:\n- btrfs-progs [4.19](https://git.kernel.org/pub/scm/linux/kernel/git/kdave/btrfs-progs.git/plain/CHANGES?h=v4.19)\n- e2fsprogs [1.44.5](http://e2fsprogs.sourceforge.net/e2fsprogs-release.html#1.44.5)\n- glibc [2.27](https://www.sourceware.org/ml/libc-alpha/2018-02/msg00054.html)\n- Go [1.10.8](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Go [1.11.5](https://golang.org/doc/devel/release.html#go1.11.minor)\n- Linux [4.19.18](https://lwn.net/Articles/777580/)\n- Rust [1.32.0](https://blog.rust-lang.org/2019/01/17/Rust-1.32.0.html)\n- util-linux [2.33](https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.33/v2.33-ReleaseNotes)\n- xfsprogs [4.17.0](https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/plain/doc/CHANGES?id=v4.17.0)"
+  },
+  "2051.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-02-14 10:32:06 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.20"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2051.0.0):\n\nSecurity fixes:\n - Fix runc container breakout ([CVE-2019-5736](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5736))\n\nChanges:\n - Revert `/sys/bus/rbd/add` to Linux 4.14 behavior ([#2544](https://github.com/coreos/bugs/issues/2544))\n - Add a new subkey for signing release images\n\nUpdates:\n - etcd [3.3.12](https://github.com/etcd-io/etcd/releases/tag/v3.3.12)\n - etcdctl [3.3.12](https://github.com/etcd-io/etcd/releases/tag/v3.3.12)\n - flannel [0.11.0](https://github.com/coreos/flannel/releases/tag/v0.11.0)\n - Linux [4.19.20](https://lwn.net/Articles/779132/)\n"
+  },
+  "2065.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-02-27 08:55:30 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.25"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2065.0.0):\n\nSecurity fixes:\n- Fix curl vulnerabilities ([CVE-2018-16839](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16839), [CVE-2018-16840](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16840), [CVE-2018-16842](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16842), [CVE-2018-16890](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16890), [CVE-2019-3822](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3822), [CVE-2019-3823](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3823))\n- Fix Linux use-after-free in `sockfs_setattr` ([CVE-2019-8912](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-8912))\n- Fix systemd crash from a specially-crafted D-Bus message ([CVE-2019-6454](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6454))\n\nUpdates:\n- curl [7.64.0](https://curl.haxx.se/changes.html#7_64_0)\n- Docker [18.06.3-ce](https://github.com/docker/docker-ce/releases/tag/v18.06.3-ce)\n- Ignition [0.31.0](https://github.com/coreos/ignition/releases/tag/v0.31.0)\n- Linux [4.19.25](https://lwn.net/Articles/780611/)\n"
+  },
+  "2079.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-03-12 14:38:05 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.28"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2079.0.0):\n\nSecurity fixes:\n- Fix tar local denial of service with `--sparse` option ([CVE-2018-20482](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20482))\n- Fix wget local information leak ([CVE-2018-20483](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20483))\n\nBug fixes:\n- Fix systemd-journald memory leak ([#2564](https://github.com/coreos/bugs/issues/2564))\n\nChanges:\n- Enable `vhost_vsock` kernel module ([#2563](https://github.com/coreos/bugs/issues/2563))\n\nUpdates:\n- Go [1.12](https://golang.org/doc/go1.12)\n- Linux [4.19.28](https://lwn.net/Articles/782719/)\n- Rust [1.33.0](https://blog.rust-lang.org/2019/02/28/Rust-1.33.0.html)\n- systemd [241](https://github.com/systemd/systemd/blob/v241/NEWS)\n- tar [1.31](https://lists.gnu.org/archive/html/info-gnu/2019-01/msg00001.html)\n- wget [1.20.1](https://git.savannah.gnu.org/cgit/wget.git/tree/NEWS?h=v1.20.1)"
+  },
+  "2093.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-03-26 13:08:56 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.31"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2093.0.0):\n\nSecurity fixes:\n- Fix OpenSSH `scp` allowing remote servers to change target directory permissions ([CVE-2018-20685](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20685))\n- Fix OpenSSH outputting ANSI control codes from remote servers ([CVE-2019-6109](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6109), [CVE-2019-6110](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6110))\n- Fix OpenSSH `scp` allowing remote servers to overwrite arbitrary files ([CVE-2019-6111](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6111))\n- Fix OpenSSL side-channel timing attack ([CVE-2018-5407](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-5407))\n- Fix OpenSSL padding oracle attack in misbehaving applications ([CVE-2019-1559](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1559))\n- Fix ntp `ntpd` denial of service by authenticated user ([CVE-2019-8936](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-8936))\n- Fix ntp buffer overflow in `ntpq` and `ntpdc` ([CVE-2018-12327](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12327))\n\nBug fixes:\n- Fix systemd presets incorrectly handling escaped unit names ([#2569](https://github.com/coreos/bugs/issues/2569))\n\nUpdates:\n- GCC [8.2.0](https://gcc.gnu.org/gcc-8/changes.html#GCC8.2)\n- Go [1.12.1](https://golang.org/doc/devel/release.html#go1.12.minor)\n- IANA timezone database [2018i](https://mm.icann.org/pipermail/tz-announce/2018-December/000054.html)\n- Linux [4.19.31](https://lwn.net/Articles/783858/)\n- ntp [4.2.8p13](https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ChangeLog-stable)\n- OpenSSH [7.9p1](https://www.openssh.com/txt/release-7.9)\n- OpenSSL [1.0.2r](https://www.openssl.org/news/openssl-1.0.2-notes.html)\n- Update Engine [0.4.10](https://github.com/coreos/update_engine/releases/tag/v0.4.10)\n"
+  },
+  "2107.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-09 13:24:31 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.34"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2107.0.0):\n\nSecurity fixes:\n- Fix libmspack vulnerabilities in the VMware agent for new installs ([CVE-2018-14679](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14679), [CVE-2018-14680](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14680), [CVE-2018-14681](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14681), [CVE-2018-14682](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14682), [CVE-2018-18584](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-18584), [CVE-2018-18585](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-18585), [CVE-2018-18586](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-18586))\n\nUpdates:\n- Afterburn (formerly coreos-metadata) [4.0.0](https://github.com/coreos/afterburn/releases/tag/v4.0.0)\n- Git [2.21.0](https://raw.githubusercontent.com/git/git/v2.21.0/Documentation/RelNotes/2.21.0.txt)\n- Go [1.12.2](https://golang.org/doc/devel/release.html#go1.12.minor)\n- Linux [4.19.34](https://cdn.kernel.org/pub/linux/kernel/v4.x/ChangeLog-4.19.34)\n"
+  },
+  "2121.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-03 10:42:07 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.36"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2121.0.0):\n\nSecurity fixes:\n - Fix libseccomp privilege escalation ([CVE-2019-9893](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9893))\n\nBug fixes:\n - Disable new sticky directory protections for backward compatibility ([#2577](https://github.com/coreos/bugs/issues/2577))\n\nChanges:\n - Enable `atlantic` kernel module ([#2576](https://github.com/coreos/bugs/issues/2576))\n\nUpdates:\n - Go [1.12.4](https://golang.org/doc/devel/release.html#go1.12.minor)\n - Ignition [0.32.0](https://github.com/coreos/ignition/releases/tag/v0.32.0)\n - libseccomp [2.4.0](https://github.com/seccomp/libseccomp/releases/tag/v2.4.0)\n - Linux [4.19.36](https://lwn.net/Articles/786361/)\n - Rust [1.34.0](https://blog.rust-lang.org/2019/04/11/Rust-1.34.0.html)\n - tini [0.18.0](https://github.com/krallin/tini/releases/tag/v0.18.0)"
+  },
+  "2135.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-08 07:08:56 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.37"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2135.0.0):\n\nSecurity fixes:\n\n- Fix SQLite remote code execution ([CVE-2018-20346](https://nvd.nist.gov/vuln/detail/CVE-2018-20346))\n- Fix GLib [multiple vulnerabilities](https://www.openwall.com/lists/oss-security/2018/10/23/5)\n\nBug fixes:\n\n- Fix systemd `MountFlags=shared` option ([#2579](https://github.com/coreos/bugs/issues/2579))\n\nChanges:\n\n- Use Amazon's recommended NVMe timeout for new EC2 installs ([#2484](https://github.com/coreos/bugs/issues/2484))\n- Pin network interface naming to systemd v238 scheme ([#2578](https://github.com/coreos/bugs/issues/2578))\n- Enable XDP sockets ([#2580](https://github.com/coreos/bugs/issues/2580))\n\nUpdates:\n\n- Linux [4.19.37](https://lwn.net/Articles/786953/)\n- Rust [1.34.1](https://blog.rust-lang.org/2019/04/25/Rust-1.34.1.html)"
+  },
+  "2135.1.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-16 10:57:13 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.43"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2135.1.0):\n\nSecurity fixes:\n- Fix Intel CPU disclosure of memory to user process.  Complete mitigation requires [manually disabling SMT](https://docs.flatcar-linux.org/os/disabling-smt/) on affected processors. ([CVE-2019-11091](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11091), [CVE-2018-12126](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12126), [CVE-2018-12127](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12127), [CVE-2018-12130](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12130), [MDS](https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00233.html))\n\nUpdates:\n- intel-microcode [20190514](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190514/releasenote)\n- Linux [4.19.43](https://lwn.net/Articles/788388/)"
+  },
+  "2149.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-21 20:29:23 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.44"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2149.0.0):\n\nUpdates:\n- etcd [3.3.13](https://github.com/etcd-io/etcd/releases/tag/v3.3.13)\n- etcdctl [3.3.13](https://github.com/etcd-io/etcd/releases/tag/v3.3.13)\n- Go [1.12.5](https://golang.org/doc/devel/release.html#go1.12.minor)\n- intel-microcode [20190514](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190514/releasenote)\n- Linux [4.19.44](https://lwn.net/Articles/788778/)"
+  },
+  "2163.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-06-06 08:50:58 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.47"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2163.0.0):\n\nSecurity fixes:\n\n- Fix curl TFTP buffer overflow with non-default block size ([CVE-2019-5436](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5436))\n\nUpdates:\n\n- coreutils [8.30](https://git.savannah.gnu.org/cgit/coreutils.git/tree/NEWS?h=v8.30)\n- curl [7.65.0](https://curl.haxx.se/changes.html#7_65_0)\n- GCC [8.3.0](https://gcc.gnu.org/gcc-8/changes.html#GCC8.3)\n- glibc [2.29](https://sourceware.org/ml/libc-announce/2019/msg00000.html)\n- Linux [4.19.47](https://lwn.net/Articles/790017/)\n- Rust [1.35.0](https://blog.rust-lang.org/2019/05/23/Rust-1.35.0.html)"
+  },
+  "2163.1.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-06-12 13:24:21 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.47"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2163.1.0):\nBug fixes:\n- Temporarily revert bunzip2 change in 2163.0.0 causing decompression failures for invalid archives created by older versions of lbzip2, including Container Linux release images ([#2589](https://github.com/coreos/bugs/issues/2589))"
+  },
+  "2163.2.1": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-06-19 08:17:08 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.50"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2163.2.1):\n\nSecurity fixes:\n\n- Fix Linux TCP remotely-triggerable kernel panic and excessive resource consumption ([CVE-2019-11477](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11477), [CVE-2019-11478](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11478), [CVE-2019-11479](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11479))\n\nUpdates:\n\n- Linux [4.19.50](https://lwn.net/Articles/790878/)"
+  },
+  "2184.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-01 10:43:29 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.55"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2184.0.0):\nBug fixes:\n\n- Temporarily revert bunzip2 change in 2163.0.0 causing decompression failures for invalid archives created by older versions of lbzip2, including Container Linux release images ([#2589](https://github.com/coreos/bugs/issues/2589))\n\nUpdates:\n\n- intel-microcode [20190618](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190618/releasenote)\n- Linux [4.19.55](https://lwn.net/Articles/791755/)"
+  },
+  "2191.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-03 08:03:08 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.56"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2191.0.0):\n\nSecurity fixes:\n\n * Fix libexpat denial of service ([CVE-2018-20843](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20843))\n\nBug fixes:\n\n * Fix Ignition panic when no `guestinfo.(coreos|ignition).config` parameters are specified on VMware (coreos/ignition#821)\n\nUpdates:\n\n * expat [2.2.7](https://github.com/libexpat/libexpat/releases/tag/R_2_2_7)\n * Ignition [0.33.0](https://github.com/coreos/ignition/releases/tag/v0.33.0)\n * Linux [4.19.56](https://lwn.net/Articles/792009/)"
+  },
+  "2205.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-17 13:53:28 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.58"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2205.0.0):\n\nBug fixes:\n\n - Fix Docker `device or resource busy` error when creating overlay mounts, introduced in 2191.0.0\n\nUpdates: \n\n - Linux [4.19.58](https://lwn.net/Articles/793363/)"
+  },
+  "2219.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-01 09:17:22 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.62"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2219.0.0):\nBug fixes:\n- Fix Ignition fetching from S3 URLs when network is slow to start ([ignition#826](https://github.com/coreos/ignition/issues/826))\n\nUpdates:\n- Linux [4.19.62](https://lwn.net/Articles/794807/)"
+  },
+  "2219.1.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-08 08:19:15 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.65"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2219.1.0):\n\nSecurity fixes:\n- Fix Linux information leak attack vector via speculative side channel ([CVE-2019-1125](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1125))\n\nUpdates:\n- Linux [4.19.65](https://lwn.net/Articles/795525/)\n\n## Flatcar updates\n\nChanges:\n- Add \"-s\" flag in flatcar-install to install to smallest disk (https://github.com/flatcar-linux/init/pull/7)"
+  },
+  "2234.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-16 09:46:07 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.65"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2234.0.0):\n\nSecurity fixes:\n- Use secure_getenv to fix a vulnerability around XDG_SEAT in pam_systemd (https://github.com/coreos/systemd/pull/118) ([CVE-2019-3842](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3842))\n\nUpdates:\n- Linux [4.19.65](https://lwn.net/Articles/795525/)\n\n## Flatcar updates\n\nBug fixes:\n- Fix wrong key name for fw_cfg in ignition with QEMU (https://github.com/flatcar-linux/ignition/issues/2)\n- Get SELinux context included in torcx tarballs (https://github.com/flatcar-linux/scripts/pull/16)\n- Enable XattrPrivileged for untar to fix SELinux issue (https://github.com/flatcar-linux/torcx/pull/1)\n"
+  },
+  "2247.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-30 07:38:30 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.68"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2247.0.0):\n\nSecurity fixes:\n- Fix libarchive out of bounds reads ([CVE-2017-14166](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14166), [CVE-2017-14501](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14501), [CVE-2017-14502](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14502), [CVE-2017-14503](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14503))\n- Fix pam_systemd bug allowing authenticated remote users to perform polkit actions as if locally logged in ([CVE-2019-3842](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3842))\n- Fix polkit information disclosure and denial of service ([CVE-2018-1116](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1116))\n- Fix SQLite multiple vulnerabilities, the worst of which allows code execution ([CVE-2019-5018](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5018), [CVE-2019-9936](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9936), [CVE-2019-9937](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9937))\n- Fix wget buffer overflow allowing arbitrary code execution ([CVE-2019-5953](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5953))\n\nUpdates:\n- etcd [3.3.15](https://github.com/etcd-io/etcd/releases/tag/v3.3.15)\n- etcdctl [3.3.15](https://github.com/etcd-io/etcd/releases/tag/v3.3.15)\n- Go [1.12.7](https://golang.org/doc/devel/release.html#go1.12.minor)\n- Linux [4.19.68](https://lwn.net/Articles/797250/)\n- wget [1.20.3](http://git.savannah.gnu.org/cgit/wget.git/tree/NEWS?h=v1.20.3&id=a220ead43505bc3e0ea8efb1572919111dbbf6dc#n8)"
+  },
+  "2247.1.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-09-05 08:53:55 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.69"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2247.1.0):\n\nSecurity fixes:\n\n- Fix systemd-resolved bug allowing unprivileged users to change DNS settings ([CVE-2019-15718](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15718))\n\nBug fixes:\n\n- Fix GCE agent crash loop in new installs ([#2608](https://github.com/coreos/bugs/issues/2608))\n\nUpdates:\n\n- Linux [4.19.69](https://lwn.net/Articles/797815/)"
+  },
+  "2261.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-09-13 10:54:40 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.71"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2261.0.0):\n\nSecurity fixes:\n\n- Fix systemd-resolved bug allowing unprivileged users to change DNS settings ([CVE-2019-15718](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15718))\n\nBug fixes:\n\n- Fix GCE agent crash loop in new installs ([#2608](https://github.com/coreos/bugs/issues/2608))\n\nUpdates:\n\n- Linux [4.19.71](https://lwn.net/Articles/798627/)\n"
+  },
+  "2275.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-09-25 09:33:48 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.75"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2275.0.0):\n\nSecurity fixes:\n\n- Fix dbus authentication bypass in non-default configurations ([CVE-2019-12749](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-12749))\n- Fix kernel KVM guest escape ([CVE-2019-14835](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14835))\n- Fix race condition in Intel microprocessors ([CVE-2019-11184](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11184))\n\nUpdates:\n\n- intel-microcode [20190918](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190918/releasenote)\n- Linux [4.19.75](https://lwn.net/Articles/800247/)"
+  },
+  "2275.1.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-10-16 15:09:02 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.78"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2275.1.0):\n\nBug fixes:\n- Fix kernel crash with CephFS mounts, introduced in 2275.0.0 ([#2616](https://github.com/coreos/bugs/issues/2616))\n\nUpdates:\n- Linux [4.19.78](https://lwn.net/Articles/801700/)"
+  },
+  "2296.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-10-17 18:54:10 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.79"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2296.0.0):\n\nSecurity fixes:\n- Fix sudo allowing a user to run commands as root if configured to permit the user to run commands as everyone other than root ([CVE-2019-14287](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14287))\n\nBug fixes:\n- Fix kernel crash with CephFS mounts, introduced in 2275.0.0 ([#2616](https://github.com/coreos/bugs/issues/2616))\n\nUpdates:\n- etcd [3.3.17](https://github.com/etcd-io/etcd/releases/tag/v3.3.17)\n- etcdctl [3.3.17](https://github.com/etcd-io/etcd/releases/tag/v3.3.17)\n- Go [1.12.9](https://golang.org/doc/devel/release.html#go1.12.minor)\n- Linux [4.19.79](https://lwn.net/Articles/802169/)\n- sudo [1.8.28](https://www.sudo.ws/stable.html#1.8.28)"
+  },
+  "2303.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-10-23 12:33:00 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.80"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2303.0.0):\n\nChanges:\n- Pin rkt to Go 1.12\n\nUpdates:\n- Go [1.12.10](https://golang.org/doc/devel/release.html#go1.12.minor)\n- Go [1.13.2](https://golang.org/doc/devel/release.html#go1.13.minor)\n- Linux [4.19.80](https://lwn.net/Articles/802628/)"
+  },
+  "2317.0.1": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-11-11 14:14:00 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.81"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2317.0.1):\n\nBug fixes:\n\n- Fix CFS scheduler throttling highly-threaded I/O-bound applications ([#2623](https://github.com/coreos/bugs/issues/2623))\n- Fix time zone for Brazil ([#2627](https://github.com/coreos/bugs/issues/2627))\n\nUpdates:\n\n- Linux [4.19.81](https://lwn.net/Articles/803384/)\n- timezone-data [2019c](http://mm.icann.org/pipermail/tz-announce/2019-September/000057.html)"
+  },
+  "2331.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-11-25 12:07:57 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.84"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix Intel CPU disclosure of memory to user process. Complete mitigation requires [manually disabling TSX or SMT](https://docs.flatcar-linux.org/os/disabling-smt/) on affected processors. ([CVE-2019-11135](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11135), [TAA](https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00270.html))\n- Fix Intel CPU denial of service by a malicious guest VM ([CVE-2018-12207](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12207))\n- Fix curl Kerberos FTP double free ([CVE-2019-5481](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5481))\n - Fix curl TFTP buffer overflow with non-default block size ([CVE-2019-5482](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5482))\n - Fix OpenSSL key extraction attacks under non-default conditions ([CVE-2019-1563](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1563), [CVE-2019-1547](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1547))\n- Fix panic caused by invalid DSA public keys in Go 1.12 and 1.13 ([CVE-2019-17596](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-17596))\n\nBug fixes:\n\n- Fix CFS scheduler throttling highly-threaded I/O-bound applications ([#2623](https://github.com/coreos/bugs/issues/2623))\n- Fix time zone for Brazil ([#2627](https://github.com/coreos/bugs/issues/2627))\n\nUpdates:\n\n- Go [1.12.12](https://go.googlesource.com/go/+/refs/tags/go1.12.12) and [1.13.3](https://go.googlesource.com/go/+/refs/tags/go1.13.3)\n- curl [7.66.0](https://curl.haxx.se/mail/archive-2019-09/0002.html)\n- intel-microcode [20191115](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20191115/releasenote)\n- Linux [4.19.84](https://lwn.net/Articles/804465/)\n- OpenSSL [1.0.2t](https://www.openssl.org/news/cl102.txt)\n- timezone-data [2019c](http://mm.icann.org/pipermail/tz-announce/2019-September/000057.html)\n"
+  },
+  "2345.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-12-05 06:35:19 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.87"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix heap-based buffer over-read in libexpat ([CVE-2019-15903](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15903))\n- Fix code injection around dynamic libraries in docker ([CVE-2019-14271](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14271))\n\nBug fixes:\n\n- Fix cross-build issues in rust by storing shell scripts under the source directory (https://github.com/flatcar-linux/coreos-overlay/pull/125)\n- Fix bug in dealing with xattrs when unpacking torcx tarballs (https://github.com/flatcar-linux/torcx/pull/2)\n\nUpdates:\n\n- Linux [4.19.87](https://lwn.net/Articles/805923/)\n- docker [19.03.5](https://docs.docker.com/engine/release-notes/#19035)\n- etcd [3.3.18](https://github.com/etcd-io/etcd/releases/tag/v3.3.18)\n- expat [2.2.8](https://github.com/libexpat/libexpat/releases/tag/R_2_2_8)\n"
+  },
+  "2345.0.1": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2019-12-09 10:28:08 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.87"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nIt is the first release done for both amd64 and arm64.\n\nBug fixes:\n\n- Fix cross-build issues around WAF by creating wrappers (https://github.com/flatcar-linux/coreos-overlay/pull/137 https://github.com/flatcar-linux/coreos-overlay/pull/139)\n\nUpdates:\n\n- ldb [1.3.6](https://gitlab.com/samba-team/samba/-/tags/ldb-1.3.6)\n- samba [4.8.6](https://gitlab.com/samba-team/samba/-/tags/samba-4.8.6)\n- talloc [2.1.11](https://gitlab.com/samba-team/samba/-/tags/talloc-2.1.11)\n- tdb [1.3.15](https://gitlab.com/samba-team/samba/-/tags/tdb-1.3.15)\n- tevent [0.9.37](https://gitlab.com/samba-team/samba/-/tags/tevent-0.9.37)\n"
+  },
+  "2345.0.2": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2019-12-20 09:27:31 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.89"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix a denial-of-service issue via malicious access to `/dev/kvm` ([CVE-2019-19332](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19332))\n\nBug fixes:\n\n- Fix a bug when creating RAID0 arrays by setting the default layout (https://github.com/flatcar-linux/baselayout/pull/2)\n\nUpdates:\n\n- Linux [4.19.89](https://lwn.net/Articles/807416/)"
+  },
+  "2387.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2020-01-21 12:54:35 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.34.0"
+      ],
+      "kernel": [
+        "4.19.97"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2387.0.0):\n\nSecurity fixes:\n\n- Fix multiple Git [vulnerabilities](https://marc.info/?l=git&m=157600115215285&w=2) ([CVE-2019-1348](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1348), [CVE-2019-1349](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1349), [CVE-2019-1350](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1350), [CVE-2019-1351](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1351), [CVE-2019-1352](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1352), [CVE-2019-1353](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1353), [CVE-2019-1354](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1354), [CVE-2019-1387](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1387), [CVE-2019-19604](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19604))\n\nUpdates:\n\n- Git [2.24.1](https://github.com/git/git/blob/master/Documentation/RelNotes/2.24.1.txt)\n- Ignition [0.34.0](https://github.com/coreos/ignition/releases/tag/v0.34.0)\n\n## Flatcar updates\n- Linux [4.19.97](https://lwn.net/Articles/809961/)\n"
+  },
+  "2411.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2020-02-17 16:40:26 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.34.0"
+      ],
+      "kernel": [
+        "4.19.102"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix stack-based buffer overflow in sudo ([CVE-2019-18634](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18634))\n- Fix incorrect access control leading to privileges escalation in runc ([CVE-2019-19921](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19921))\n- Fix systemd use-after-free upon receiving crafted D-Bus message from local unprivileged attacker ([CVE-2020-1712](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1712))\n\nBug fixes:\n\n- Fix DNS resolution for the GCE metadata server (https://github.com/flatcar-linux/coreos-overlay/pull/160)\n- Use correct URLs for flatcar-linux in emerge-gitclone and scripts (https://github.com/flatcar-linux/dev-util/pull/1) (https://github.com/flatcar-linux/scripts/pull/50)\n- Fix a wrong profile reference in torcx (https://github.com/flatcar-linux/coreos-overlay/pull/162)\n- Create symlink for /run/metadata/coreos (https://github.com/flatcar-linux/coreos-overlay/pull/166)\n- Create symlink for flatcar-install (https://github.com/flatcar-linux/init/pull/14)\n- Fix backwards compatibility issues for users to migrate from CoreOS Container Linux (https://github.com/flatcar-linux/Flatcar/issues/16 https://github.com/flatcar-linux/afterburn/pull/7 https://github.com/flatcar-linux/bootengine/pull/7 https://github.com/flatcar-linux/bootengine/pull/8 https://github.com/flatcar-linux/init/pull/16 https://github.com/flatcar-linux/init/pull/17 https://github.com/flatcar-linux/ignition/pull/8)\n\nChanges:\n\n- Build Flatcar tarballs to be used by containers (https://github.com/flatcar-linux/scripts/pull/51)\n- Enable qede kernel module\n\nUpdates:\n\n- Linux [4.19.102](https://lwn.net/Articles/811638/)\n- runc [1.0.0-rc10](https://github.com/opencontainers/runc/releases/tag/v1.0.0-rc10)\n- sudo [1.8.31](https://www.sudo.ws/stable.html#1.8.31)\n"
+  },
+  "2430.0.0": {
+    "channel": "alpha",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2020-03-05 10:26:46 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.34.0"
+      ],
+      "kernel": [
+        "4.19.106"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n- Enable persistent network interface names already in the initramfs to fix https://github.com/coreos/bugs/issues/1767\n- Do not error out in runc if SELinux is disabled on the system (https://github.com/flatcar-linux/coreos-overlay/pull/189)\n- Bring back runc 1.0-rc2 for Docker 17.03 (https://github.com/flatcar-linux/coreos-overlay/pull/191)\n- Use correct branch name format in developer container tools (https://github.com/flatcar-linux/dev-util/pull/2)\n\nUpdates:\n\n- Linux [4.19.106](https://lwn.net/Articles/813157/)"
+  },
+  "current": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2020-03-02 14:03:06 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.106"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\nBug fixes:\n- Enable persistent network interface names already in the initramfs to fix https://github.com/coreos/bugs/issues/1767\n- Fix backwards compatibility issues for users to migrate from CoreOS Container Linux. Support the kernel command line parameters `coreos.oem.*`, `coreos.autologin`, `coreos.first_boot`, and the QEMU firmware config path `opt/com.coreos/config` (https://github.com/flatcar-linux/Flatcar/issues/16 https://github.com/flatcar-linux/afterburn/pull/7 https://github.com/flatcar-linux/bootengine/pull/7 https://github.com/flatcar-linux/bootengine/pull/8 https://github.com/flatcar-linux/init/pull/16 https://github.com/flatcar-linux/init/pull/17 https://github.com/flatcar-linux/ignition/pull/8)\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2345.3.0)\nSecurity fixes:\n- Fix systemd use-after-free upon receiving crafted D-Bus message from local unprivileged attacker [CVE-2020-1712](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1712)\n- Fix heap-based buffer over-read in libexpat ([CVE-2019-15903](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15903))\n- Fix multiple Git [vulnerabilities](https://marc.info/?l=git&m=157600115215285&w=2) ([CVE-2019-1348](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1348), [CVE-2019-1349](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1349), [CVE-2019-1350](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1350), [CVE-2019-1351](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1351), [CVE-2019-1352](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1352), [CVE-2019-1353](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1353), [CVE-2019-1354](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1354), [CVE-2019-1387](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1387), [CVE-2019-19604](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19604))\n- Fix curl Kerberos FTP double free ([CVE-2019-5481](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5481))\n - Fix curl TFTP buffer overflow with non-default block size ([CVE-2019-5482](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5482))\n - Fix OpenSSL key extraction attacks under non-default conditions ([CVE-2019-1563](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1563), [CVE-2019-1547](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1547))\n\nUpdates:\n\n- Git [2.24.1](https://github.com/git/git/blob/master/Documentation/RelNotes/2.24.1.txt)\n- Linux [4.19.106](https://lwn.net/Articles/813157/)\n- OpenSSL [1.0.2t](https://www.openssl.org/news/cl102.txt)\n- curl [7.66.0](https://curl.haxx.se/mail/archive-2019-09/0002.html)\n- etcd [3.3.18](https://github.com/etcd-io/etcd/releases/tag/v3.3.18)\n- expat [2.2.8](https://github.com/libexpat/libexpat/releases/tag/R_2_2_8)\n"
+  },
+  "1722.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-04-25 14:36:40 +0000",
+    "major_software": {
+      "docker": [
+        "17.12.1"
+      ],
+      "ignition": [
+        "0.23.0"
+      ],
+      "kernel": [
+        "4.14.30"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "237"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nInitial Flatcar release.\n\nBug fixes:\n- Fix GRUB crash at boot ([#2284](https://github.com/coreos/bugs/issues/2284))\n- Fix [poweroff problems](https://groups.google.com/forum/#!topic/coreos-user/YcGkRHU9SvQ) ([#8080](https://github.com/systemd/systemd/pull/8080))\n\nNotes:\n- Previous test images have been removed from the release servers. This is due to a new update key being generated using our updated security policy which we [included](https://github.com/flatcar-linux/coreos-overlay/pull/6) in the first public image.\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1722.2.0):\n\nBug fixes:\n- Fix kernel panic with vxlan ([#2382](https://github.com/coreos/bugs/issues/2382))"
+  },
+  "1745.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-04-26 09:58:55 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.0"
+      ],
+      "ignition": [
+        "0.24.0"
+      ],
+      "kernel": [
+        "4.14.35"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1745.1.0):\n\nBug fixes:\n - Fix docker2aci tar conversion ([#2402](https://github.com/coreos/bugs/issues/2402))\n\nChanges:\n - Switch to the LTS Linux version [4.14.35](https://lwn.net/Articles/752328/) for the beta channel"
+  },
+  "1745.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-05-11 11:40:35 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.0"
+      ],
+      "kernel": [
+        "4.14.39"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1745.2.0):\n\nSecurity fixes:\n - Fix ntp clock manipulation from ephemeral connections ([CVE-2016-1549](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-1549), [CVE-2018-7170](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7170))\n - Fix ntp denial of service from out of bounds read ([CVE-2018-7182](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7182)) \n -  Fix ntp denial of service from packets with timestamp 0 ([CVE-2018-7184](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7184), [CVE-2018-7185](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7185))\n - Fix ntp remote code execution ([CVE-2018-7183](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-7183))\n\nUpdates:\n - containerd [1.0.3](https://github.com/containerd/containerd/releases/tag/v1.0.3)\n - Docker [18.03.1-ce](https://github.com/docker/docker-ce/releases/tag/v18.03.1-ce)\n - Linux [4.14.39](https://lwn.net/Articles/753349/)\n - ntp [4.2.8p11](https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ChangeLog-stable)\n"
+  },
+  "1772.1.1": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-05-26 15:29:49 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.1"
+      ],
+      "kernel": [
+        "4.14.42"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1772.1.1):\n\nChanges:\n- Switch to the LTS Docker version [18.03.1-ce](https://github.com/docker/docker-ce/releases/tag/v18.03.1-ce) for the beta channel\n- Switch to the LTS Linux version [4.14.42](https://lwn.net/Articles/754972/) for the beta channel\n\nUpdates:\n- Ignition [0.24.1](https://github.com/coreos/ignition/releases/tag/v0.24.1)"
+  },
+  "1772.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-01 13:23:43 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.1"
+      ],
+      "kernel": [
+        "4.14.47"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1772.2.0):\n\nSecurity fixes:\n- Fix Git arbitrary code execution when cloning untrusted repositories ([CVE-2018-11235](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11235))\n\nBug fixes:\n- Fix inadvertent change of network interface names ([#2437](https://github.com/coreos/bugs/issues/2437))\n- Fix failure to set network interface MTU ([#2443](https://github.com/coreos/bugs/issues/2443))\n\nUpdates:\n- Git [2.16.4](https://raw.githubusercontent.com/git/git/v2.16.4/Documentation/RelNotes/2.16.4.txt)\n- Linux [4.14.47](https://lwn.net/Articles/756055/)"
+  },
+  "1772.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-13 13:22:40 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.1"
+      ],
+      "kernel": [
+        "4.14.48"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1772.3.0):\n\nBug fixes:\n- Fix Hyper-V network driver regression ([#2454](https://github.com/coreos/bugs/issues/2454))\n\nUpdates:\n- Linux [4.14.48](https://lwn.net/Articles/756652/)"
+  },
+  "1772.4.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-15 14:51:22 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.1"
+      ],
+      "kernel": [
+        "4.14.49"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1772.4.0):\n\nBug fixes:\n- Fix TCP connection stalls ([#2457](https://github.com/coreos/bugs/issues/2457))\n\nUpdates:\n- Linux [4.14.49](https://lwn.net/Articles/757308/)"
+  },
+  "1800.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-22 10:17:31 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.14.50"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1800.2.0):\n\nChanges:\n- Switch to the LTS Docker version [18.03.1-ce](https://github.com/docker/docker-ce/releases/tag/v18.03.1-ce) for the beta channel\n- Switch to the LTS Linux version [4.14.50](https://lwn.net/Articles/757680/) for the beta channel"
+  },
+  "1800.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-07-13 15:43:19 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.14.55"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1800.3.0):\n\nUpdates:\n- Linux [4.14.55](https://lwn.net/Articles/759535/)"
+  },
+  "1828.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-07-26 09:40:11 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.14.57"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1828.1.0):\n\nChanges:\n- Switch to the LTS Docker version [18.03.1-ce](https://github.com/docker/docker-ce/releases/tag/v18.03.1-ce) for the beta channel\n- Switch to the LTS Linux version [4.14.57](https://lwn.net/Articles/760500/) for the beta channel\n"
+  },
+  "1828.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-07-31 09:16:00 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.14.59"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1828.2.0):\n\nBug fixes:\n- Fix kernel CIFS client ([#2480](https://github.com/coreos/bugs/issues/2480))\n\nUpdates:\n- Linux [4.14.59](https://lwn.net/Articles/761180/)"
+  },
+  "1828.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-08-08 10:49:50 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.14.60"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1828.3.0):\n\nSecurity fixes:\n- Fix Linux local denial of service as Xen PV guest ([CVE-2018-14678](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14678))\n\nBug fixes:\n- Fix failure to mount large ext4 filesystems ([#2485](https://github.com/coreos/bugs/issues/2485))\n\nUpdates:\n- Linux [4.14.60](https://lwn.net/Articles/761767/)"
+  },
+  "1855.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-08-17 12:09:29 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.0"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.14.63"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1855.2.0):\n\nSecurity fixes:\n- Fix Linux remote denial of service ([FragmentSmack](https://access.redhat.com/security/cve/cve-2018-5391), [CVE-2018-5391](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-5391))\n- Fix Linux privileged memory access via speculative execution ([L1TF/Foreshadow](https://foreshadowattack.eu/), [CVE-2018-3620](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3620), [CVE-2018-3646](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3646))\n\nBug fixes:\n- Fix PXE systems attempting to mount an ESP ([#2491](https://github.com/coreos/bugs/issues/2491))\n\nChanges:\n- Switch to the LTS Linux version [4.14.63](https://lwn.net/Articles/762808/) for the beta channel"
+  },
+  "1855.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-09-05 08:43:19 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.14.67"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1855.3.0):\n\nChanges:\n- Drop AWS PV images from regions which do not support PV\n\nUpdates:\n- containerd [1.1.2](https://github.com/containerd/containerd/releases/tag/v1.1.2)\n- Docker [18.06.1-ce](https://github.com/docker/docker-ce/releases/tag/v18.06.1-ce)\n- intel-microcode [20180807a](https://downloadcenter.intel.com/download/28087/Linux-Processor-Microcode-Data-File)\n- Linux [4.14.67](https://lwn.net/Articles/763433/)"
+  },
+  "1883.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-09-14 09:59:48 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.69"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1883.1.0):\n\nBug fixes:\n- Fix Docker mounting named volumes ([#2497](https://github.com/coreos/bugs/issues/2497))\n\nChanges:\n- Switch to the LTS Linux version [4.14.69](https://lwn.net/Articles/764513/) for the beta channel\n\nUpdates:\n- intel-microcode [20180807a](https://downloadcenter.intel.com/download/28087)"
+  },
+  "1911.1.1": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-10-11 13:18:49 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.74"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nChanges:\n\n* Add new image signing subkey to `flatcar-install` ([flatcar-linux/init#4](https://github.com/flatcar-linux/init/pull/4))\n\nBug fixes:\n\n* Fix `/usr/lib/coreos` symlink for Container Linux compatibility ([flatcar-linux/coreos-overlay#8](https://github.com/flatcar-linux/coreos-overlay/pull/8))\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1911.1.1):\n\nChanges:\n- Switch to the LTS Linux version [4.14.74](https://lwn.net/Articles/767628/) for the beta channel\n"
+  },
+  "1911.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-10-26 10:14:36 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.78"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1911.2.0):\n\nSecurity fixes:\n- Fix Git remote code execution during recursive clone ([CVE-2018-17456](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17456))\n\nBug fixes:\n- Fix missing kernel headers ([#2505](https://github.com/coreos/bugs/issues/2505))\n\nUpdates:\n- Git [2.16.5](https://raw.githubusercontent.com/git/git/v2.16.5/Documentation/RelNotes/2.16.5.txt)\n- Linux [4.14.78](https://lwn.net/Articles/769051/)"
+  },
+  "1939.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-11-08 16:14:38 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.79"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1939.1.0):\n\nSecurity fixes:\n- Fix systemd re-executing with arbitrary supplied state ([CVE-2018-15686](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15686))\n- Fix systemd race allowing changing file permissions ([CVE-2018-15687](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15687))\n- Fix systemd-networkd buffer overflow in the dhcp6 client ([CVE-2018-15688](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15688))\n\nChanges:\n- Switch to the LTS Linux version [4.14.79](https://lwn.net/Articles/770749/) for the beta channel"
+  },
+  "1939.2.1": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-11-21 10:57:13 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.81"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1939.2.1):\n\nSecurity fixes:\n- Disable containerd CRI plugin to stop it from listening on a TCP port ([#2524](https://github.com/coreos/bugs/issues/2524))\n\nUpdates:\n- Linux [4.14.81](https://lwn.net/Articles/771885/)"
+  },
+  "1967.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-12-06 09:43:43 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.84"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1967.1.0):\n\nChanges:\n - Switch to the LTS Linux version [4.14.84](https://lwn.net/Articles/773114/) for the beta channel"
+  },
+  "1967.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-12-21 09:08:43 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.88"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1967.2.0):\n\nSecurity fixes:\n- Fix Go CPU denial of service in X.509 verification ([CVE-2018-16875](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16875))\n- Fix PolicyKit always authorizing UIDs greater than `INT_MAX` ([CVE-2018-19788](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-19788))\n\nUpdates:\n- Go [1.10.6](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Go [1.11.3](https://golang.org/doc/devel/release.html#go1.11.minor)\n- Linux [4.14.88](https://lwn.net/Articles/774848/)"
+  },
+  "1995.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-01-18 09:10:26 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.29.1"
+      ],
+      "kernel": [
+        "4.19.13"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1995.1.0):\n\nUpdates:\n- Linux [4.19.13](https://lwn.net/Articles/775720/)"
+  },
+  "2023.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-01-30 13:45:28 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.18"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2023.1.0):\n\nSecurity fixes:\n- Fix Go CPU denial of service in ECC ([CVE-2019-6486](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6486))\n\nUpdates:\n- Go [1.10.8](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Go [1.11.5](https://golang.org/doc/devel/release.html#go1.11.minor)\n- Linux [4.19.18](https://lwn.net/Articles/777580/)"
+  },
+  "2023.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-02-14 10:31:00 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.20"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2023.2.0):\nSecurity fixes:\n - Fix runc container breakout ([CVE-2019-5736](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5736))\n\nChanges:\n - Revert `/sys/bus/rbd/add` to Linux 4.14 behavior ([#2544](https://github.com/coreos/bugs/issues/2544))\n\nUpdates:\n - etcd [3.3.12](https://github.com/etcd-io/etcd/releases/tag/v3.3.12)\n - etcdctl [3.3.12](https://github.com/etcd-io/etcd/releases/tag/v3.3.12)\n - Linux [4.19.20](https://lwn.net/Articles/779132/)\n"
+  },
+  "2023.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-02-21 08:41:36 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.23"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2023.3.0):\n\nUpdates:\n- Linux [4.19.23](https://lwn.net/Articles/779940/)"
+  },
+  "2051.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-02-27 08:53:46 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.25"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2051.1.0):\n\nSecurity fixes:\n- Fix Linux use-after-free in `sockfs_setattr` ([CVE-2019-8912](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-8912))\n- Fix systemd crash from a specially-crafted D-Bus message ([CVE-2019-6454](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6454))\n\nUpdates:\n- Linux [4.19.25](https://lwn.net/Articles/780611/)"
+  },
+  "2051.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-03-12 14:37:08 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.28"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2051.2.0):\n\nBug fixes:\n- Fix systemd-journald memory leak ([#2564](https://github.com/coreos/bugs/issues/2564))\n\nUpdates:\n- Linux [4.19.28](https://lwn.net/Articles/782719/)"
+  },
+  "2079.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-03-26 13:08:57 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.31"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2079.1.0):\n\nBug fixes:\n- Fix systemd presets incorrectly handling escaped unit names ([#2569](https://github.com/coreos/bugs/issues/2569))\n\nUpdates:\n- Linux [4.19.31](https://lwn.net/Articles/783858/)\n"
+  },
+  "2079.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-17 07:53:14 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.34"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2079.2.0):\n\nBug fixes:\n- Disable new sticky directory protections for backwards compatibility ([#2577](https://github.com/coreos/bugs/issues/2577))\n\nChanges:\n- Enable `atlantic` kernel module ([#2576](https://github.com/coreos/bugs/issues/2576))\n\nUpdates:\n- Linux [4.19.34](https://lwn.net/Articles/786050/)"
+  },
+  "2107.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-24 10:01:19 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.36"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2107.1.0):\n\nBug fixes:\n - Disable new sticky directory protections for backward compatibility ([#2577](https://github.com/coreos/bugs/issues/2577))\n\nChanges:\n - Enable `atlantic` kernel module ([#2576](https://github.com/coreos/bugs/issues/2576))\n\nUpdates:\n - Linux [4.19.36](https://lwn.net/Articles/786361/)"
+  },
+  "2107.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-08 07:07:32 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.36"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2107.2.0):\n\nBug fixes:\n\n- Fix systemd `MountFlags=shared` option ([#2579](https://github.com/coreos/bugs/issues/2579))\n\nChanges:\n\n- Pin network interface naming to systemd v238 scheme ([#2578](https://github.com/coreos/bugs/issues/2578))"
+  },
+  "2107.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-16 10:57:15 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.43"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2107.3.0):\n\nSecurity fixes:\n- Fix Intel CPU disclosure of memory to user process.  Complete mitigation requires [manually disabling SMT](https://docs.flatcar-linux.org/os/disabling-smt/) on affected processors. ([CVE-2019-11091](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11091), [CVE-2018-12126](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12126), [CVE-2018-12127](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12127), [CVE-2018-12130](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12130), [MDS](https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00233.html))\n\nUpdates:\n- intel-microcode [20190514](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190514/releasenote)\n- Linux [4.19.43](https://lwn.net/Articles/788388/)"
+  },
+  "2135.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-21 20:28:25 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.44"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2135.2.0):\n\nUpdates:\n- Linux [4.19.44](https://lwn.net/Articles/788778/)"
+  },
+  "2135.3.1": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-06-19 08:16:10 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.50"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2135.3.1):\n\nSecurity fixes:\n\n- Fix Linux TCP remotely-triggerable kernel panic and excessive resource consumption ([CVE-2019-11477](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11477), [CVE-2019-11478](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11478), [CVE-2019-11479](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11479))\n\nBug fixes:\n\n- Fix invalid bzip2 compression of Container Linux release images ([#2589](https://github.com/coreos/bugs/issues/2589))\n\nUpdates:\n\n- Linux [4.19.50](https://lwn.net/Articles/790878/)"
+  },
+  "2163.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-01 10:45:57 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.55"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2163.3.0):\n\nUpdates:\n\n- Linux [4.19.53](https://lwn.net/Articles/791468/)\n"
+  },
+  "2163.4.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-03 08:02:30 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.55"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2163.4.0):\n\nBug fixes:\n\n * Fix Ignition panic when no `guestinfo.(coreos|ignition).config` parameters are specified on VMware (coreos/ignition#821)\n\nUpdates:\n\n * Ignition [0.33.0](https://github.com/coreos/ignition/releases/tag/v0.33.0)"
+  },
+  "2191.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-17 13:51:51 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.56"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2191.1.0):\n\nNo changes for beta promotion"
+  },
+  "2191.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-01 09:15:48 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.62"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2191.2.0):\n- Linux [4.19.62](https://lwn.net/Articles/794807/)"
+  },
+  "2191.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-08 08:18:09 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.65"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2191.3.0):\n\nSecurity fixes:\n- Fix Linux information leak attack vector via speculative side channel ([CVE-2019-1125](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1125))\n\nUpdates:\n- Linux [4.19.65](https://lwn.net/Articles/795525/)\n\n## Flatcar updates\n\nChanges:\n- Add \"-s\" flag in flatcar-install to install to smallest disk (https://github.com/flatcar-linux/init/pull/7)"
+  },
+  "2219.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-16 09:44:16 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.65"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2219.2.0):\n\nSecurity fixes:\n- Use secure_getenv to fix a vulnerability around XDG_SEAT in pam_systemd (https://github.com/coreos/systemd/pull/118) ([CVE-2019-3842](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3842))\n\nUpdates:\n- Linux [4.19.65](https://lwn.net/Articles/795525/)\n\n## Flatcar updates\n\nBug fixes:\n- Fix wrong key name for fw_cfg in ignition with QEMU (https://github.com/flatcar-linux/ignition/issues/2)\n- Get SELinux context included in torcx tarballs (https://github.com/flatcar-linux/scripts/pull/16)\n- Enable XattrPrivileged for untar to fix SELinux issue (https://github.com/flatcar-linux/torcx/pull/1)\n"
+  },
+  "2219.2.1": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-30 07:37:15 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.68"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2219.2.1):\n\nSecurity fixes:\n- Fix wget buffer overflow allowing arbitrary code execution ([CVE-2019-5953](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5953))\n\nUpdates:\n- Linux [4.19.68](https://lwn.net/Articles/797250/)\n- wget [1.20.3](http://git.savannah.gnu.org/cgit/wget.git/tree/NEWS?h=v1.20.3&id=a220ead43505bc3e0ea8efb1572919111dbbf6dc#n8)"
+  },
+  "2219.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-09-05 08:53:14 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.69"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2219.3.0):\n\nSecurity fixes:\n\n- Fix pam_systemd bug allowing authenticated remote users to perform polkit actions as if locally logged in ([CVE-2019-3842](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3842))\n- Fix systemd-resolved bug allowing unprivileged users to change DNS settings ([CVE-2019-15718](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15718))\n\nBug fixes:\n\n- Fix GCE agent crash loop in new installs ([#2608](https://github.com/coreos/bugs/issues/2608))\n\nUpdates:\n\n- Linux [4.19.69](https://lwn.net/Articles/797815/)"
+  },
+  "2247.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-09-13 10:53:37 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.71"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2247.2.0):\n\nUpdates:\n\n- Linux [4.19.71](https://lwn.net/Articles/798627/)\n"
+  },
+  "2247.3.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-09-25 09:32:22 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.75"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2247.3.0):\n\nSecurity fixes:\n\n- Fix kernel KVM guest escape ([CVE-2019-14835](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14835))\n- Fix race condition in Intel microprocessors ([CVE-2019-11184](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11184))\n\nUpdates:\n\n- intel-microcode [20190918](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190918/releasenote)\n- Linux [4.19.75](https://lwn.net/Articles/800247/)"
+  },
+  "2247.4.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-10-16 15:09:03 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.78"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2247.4.0):\n\nBug fixes:\n- Fix kernel crash with CephFS mounts, introduced in 2247.3.0 ([#2616](https://github.com/coreos/bugs/issues/2616))\n\nUpdates:\n- Linux [4.19.78](https://lwn.net/Articles/801700/)"
+  },
+  "2275.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-10-17 18:54:07 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.79"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2275.2.0):\n\nUpdates:\n- Linux [4.19.79](https://lwn.net/Articles/802169/)"
+  },
+  "2303.1.1": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-11-11 14:13:02 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.81"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2303.1.1):\n\nBug fixes:\n\n- Fix time zone for Brazil ([#2627](https://github.com/coreos/bugs/issues/2627))\n\nUpdates:\n\n- Linux [4.19.81](https://lwn.net/Articles/803384/)\n- timezone-data [2019c](http://mm.icann.org/pipermail/tz-announce/2019-September/000057.html)"
+  },
+  "2303.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-11-21 09:28:13 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.84"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2303.2.0):\n\nSecurity fixes:\n\n- Fix Intel CPU disclosure of memory to user process. Complete mitigation requires [manually disabling TSX or SMT](https://docs.flatcar-linux.org/os/disabling-smt/) on affected processors. ([CVE-2019-11135](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11135), [TAA](https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00270.html))\n- Fix Intel CPU denial of service by a malicious guest VM ([CVE-2018-12207](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12207))\n\nBug fixes:\n\n- Fix CFS scheduler throttling highly-threaded I/O-bound applications ([#2623](https://github.com/coreos/bugs/issues/2623))\n\nUpdates:\n\n- intel-microcode [20191115](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20191115/releasenote)\n- Linux [4.19.84](https://lwn.net/Articles/804465/)"
+  },
+  "2331.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-12-05 06:34:11 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.87"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2331.1.0):\n\nUpdates:\n  - Linux [4.19.87](https://lwn.net/Articles/805923/)"
+  },
+  "2331.1.1": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-12-18 09:49:53 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.87"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n- Fix a bug when creating RAID0 arrays by setting the default layout (https://github.com/flatcar-linux/baselayout/pull/2)\n- Fix bug of unpacking tarballs failing when xattr is not supported (https://github.com/flatcar-linux/torcx/pull/2)\n\nUpdates:\n\n- ldb [1.3.6](https://gitlab.com/samba-team/samba/-/tags/ldb-1.3.6)\n- samba [4.8.6](https://gitlab.com/samba-team/samba/-/tags/samba-4.8.6)\n- talloc [2.1.11](https://gitlab.com/samba-team/samba/-/tags/talloc-2.1.11)\n- tdb [1.3.15](https://gitlab.com/samba-team/samba/-/tags/tdb-1.3.15)\n- tevent [0.9.37](https://gitlab.com/samba-team/samba/-/tags/tevent-0.9.37)"
+  },
+  "2345.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2020-01-17 13:33:11 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.95"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2345.1.0):\n\nSecurity fixes:\n\n- Fix multiple Git [vulnerabilities](https://marc.info/?l=git&m=157600115215285&w=2) ([CVE-2019-1348](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1348), [CVE-2019-1349](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1349), [CVE-2019-1350](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1350), [CVE-2019-1351](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1351), [CVE-2019-1352](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1352), [CVE-2019-1353](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1353), [CVE-2019-1354](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1354), [CVE-2019-1387](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1387), [CVE-2019-19604](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19604))\n\nUpdates:\n\n- Git [2.24.1](https://github.com/git/git/blob/master/Documentation/RelNotes/2.24.1.txt)\n- Linux [4.19.95](https://lwn.net/Articles/809258/)\n"
+  },
+  "2345.2.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2020-02-10 11:11:29 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.102"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n- Fix DNS resolution for the GCE metadata server (https://github.com/flatcar-linux/coreos-overlay/pull/160)\n- Create symlink for /run/metadata/coreos (https://github.com/flatcar-linux/coreos-overlay/pull/166)\n- Create symlink for flatcar-install (https://github.com/flatcar-linux/init/pull/14)\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2345.2.0):\n\nSecurity fixes:\n- Fix systemd use-after-free upon receiving crafted D-Bus message from local unprivileged attacker ([CVE-2020-1712](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1712))\n\nChanges:\n- Enable `qede` kernel module\n\nUpdates:\n- Linux [4.19.102](https://lwn.net/Articles/811638/)"
+  },
+  "2411.1.0": {
+    "channel": "beta",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2020-03-02 11:57:48 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.34.0"
+      ],
+      "kernel": [
+        "4.19.106"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\nBug fixes:\n- Enable persistent network interface names already in the initramfs to fix https://github.com/coreos/bugs/issues/1767\n- Fix backwards compatibility issues for users to migrate from CoreOS Container Linux. Support the kernel command line parameters `coreos.oem.*`, `coreos.autologin`, `coreos.first_boot`, and the QEMU firmware config path `opt/com.coreos/config` (https://github.com/flatcar-linux/Flatcar/issues/16 https://github.com/flatcar-linux/afterburn/pull/7 https://github.com/flatcar-linux/bootengine/pull/7 https://github.com/flatcar-linux/bootengine/pull/8 https://github.com/flatcar-linux/init/pull/16 https://github.com/flatcar-linux/init/pull/17 https://github.com/flatcar-linux/ignition/pull/8)\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2411.1.0)\nUpdates:\n- Linux [4.19.106](https://lwn.net/Articles/813157/)\n"
+  },
+  "2051.99.1": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-26 13:59:39 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.20"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nChanges:\n\n* enable cgroup v2 via kernel command line (https://github.com/flatcar-linux/scripts/commit/271ec2423bc99c9d23faf4ab6ae722726f955966)\n* make docker and containerd support cgroup v2 (https://github.com/flatcar-linux/coreos-overlay/commit/8184af2518634c115dd6ef623959da5948be4cca)\n"
+  },
+  "2051.99.2": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-26 14:00:54 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.20"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n* Add missing OEM changes for cloud providers to enable cgroup v2 (https://github.com/flatcar-linux/coreos-overlay/commit/f4dde83caf457fc5b480edbbb54d550632c92cf3)\n"
+  },
+  "2079.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-26 14:01:27 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "5.0.1"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nUpdates:\n\n* Linux [5.0.1](https://lwn.net/Articles/782717/)"
+  },
+  "2107.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-26 14:02:24 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "5.0.7"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nChanges:\n\n* add cgroupid and patch runc for OCI hooks (https://github.com/flatcar-linux/coreos-overlay/pull/23)\n* add bpftool (https://github.com/flatcar-linux/coreos-overlay/pull/24)\n\nUpdates:\n\n* Linux [5.0.7](https://lwn.net/Articles/786049/)"
+  },
+  "2121.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-29 19:25:05 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "5.0.9"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nChanges:\n\n* add a new package cri-o (https://github.com/flatcar-linux/coreos-overlay/pull/29)\n* add CFLAGS to prevent the Spectre v2 (https://github.com/flatcar-linux/coreos-overlay/pull/28)\n\nUpdates:\n\n* Linux [5.0.9](https://lwn.net/Articles/786360/)"
+  },
+  "2135.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-15 13:42:10 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "5.1.0"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Initial release\n\nThis is the first release meant to be used by the public so all the Edge changes are listed.\n\n## Flatcar updates\n\nChanges:\n\n* Add bpftool (https://github.com/flatcar-linux/coreos-overlay/pull/24)\n* Add [wireguard](https://www.wireguard.com/) (https://github.com/flatcar-linux/coreos-overlay/pull/32)\n* Add a new package cri-o (https://github.com/flatcar-linux/coreos-overlay/pull/29)\n* Add cgroupid and patch runc for OCI hooks (https://github.com/flatcar-linux/coreos-overlay/pull/23)\n* Enable cgroup v2 via kernel command line (https://github.com/flatcar-linux/scripts/commit/271ec2423bc99c9d23faf4ab6ae722726f955966)\n* Add missing OEM changes for cloud providers to enable cgroup v2 (https://github.com/flatcar-linux/coreos-overlay/commit/f4dde83caf457fc5b480edbbb54d550632c92cf3)\n* Make docker and containerd support cgroup v2 (https://github.com/flatcar-linux/coreos-overlay/commit/8184af2518634c115dd6ef623959da5948be4cca)\n* Add CFLAGS to prevent the Spectre v2 (https://github.com/flatcar-linux/coreos-overlay/pull/28)\n\nUpdates:\n\n* Linux [5.1.0](https://lwn.net/Articles/787556/)"
+  },
+  "2149.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-28 08:35:24 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "5.1.5"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n- Fix Intel CPU disclosure of memory to user process.  Complete mitigation requires [manually disabling SMT](https://docs.flatcar-linux.org/os/disabling-smt/) on affected processors. ([CVE-2019-11091](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11091), [CVE-2018-12126](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12126), [CVE-2018-12127](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12127), [CVE-2018-12130](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12130), [MDS](https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00233.html))\n\nBug fixes:\n- Fix kernel build path issues to build coreos-firmware (https://github.com/flatcar-linux/coreos-overlay/pull/36) (https://github.com/flatcar-linux/coreos-overlay/pull/31)\n\nUpdates:\n- intel-microcode [20190514](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190514/releasenote)\n- Linux [5.1.5](https://lwn.net/Articles/789418/)"
+  },
+  "2163.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-06-21 14:11:23 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "5.1.11"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n- Fix Linux TCP remotely-triggerable kernel panic and excessive resource consumption ([CVE-2019-11477](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11477), [CVE-2019-11478](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11478), [CVE-2019-11479](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11479))\n\nUpdates:\n\n- Linux [5.1.11](https://lwn.net/Articles/791290/)\n- cri-o [1.14.4](https://github.com/flatcar-linux/coreos-overlay/pull/40)"
+  },
+  "2191.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-04 08:25:18 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.1.15"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2191.0.0):\n\nSecurity fixes:\n\n * Fix libexpat denial of service ([CVE-2018-20843](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20843))\n\nBug fixes:\n\n * Fix Ignition panic when no `guestinfo.(coreos|ignition).config` parameters are specified on VMware (https://github.com/coreos/ignition/issues/821)\n\nUpdates:\n\n * expat [2.2.7](https://github.com/libexpat/libexpat/releases/tag/R_2_2_7)\n * Ignition [0.33.0](https://github.com/coreos/ignition/releases/tag/v0.33.0)\n\n## Flatcar updates\n\nBug fixes:\n\n- make containerd listen on localhost (https://github.com/flatcar-linux/coreos-overlay/pull/41)\n\nUpdates:\n\n- Linux [5.1.15](https://lwn.net/Articles/792008/)\n- cri-tools [1.14.0](https://github.com/flatcar-linux/coreos-overlay/pull/42)\n\nChanges:\n\n- Fix installation prefix of conmon in a cri-o example config (https://github.com/flatcar-linux/coreos-overlay/pull/43)\n"
+  },
+  "2191.99.1": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-09 13:00:37 +0000",
+    "major_software": {
+      "docker": [
+        "18.09.7"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.2.0"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n- Fix a bug in systemd not being able to activate netlink (https://github.com/flatcar-linux/coreos-overlay/pull/49)\n\nUpdates:\n\n- Linux [5.2](https://lwn.net/Articles/792995/)\n- docker [18.09.7](https://github.com/flatcar-linux/coreos-overlay/pull/46)\n- wireguard [0.0.20190702](https://github.com/flatcar-linux/coreos-overlay/pull/48/commits/0af0437c3dc14e4ac8763a9a335b799e739f4f3b)\n- coreos-firmware [20190620](https://github.com/flatcar-linux/coreos-overlay/pull/48/commits/e0e285c0bf7a6953fafbe10a5539bc8c84dbf48f)\n"
+  },
+  "2205.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-17 13:54:57 +0000",
+    "major_software": {
+      "docker": [
+        "18.09.7"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.2.1"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2205.0.0):\n\nBug fixes:\n\n - Fix Docker `device or resource busy` error when creating overlay mounts, introduced in 2191.99.0\n\n## Flatcar updates\n\nUpdates: \n\n - Linux [5.2.1](https://lwn.net/Articles/793683/)"
+  },
+  "2205.99.1": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-29 09:39:34 +0000",
+    "major_software": {
+      "docker": [
+        "18.09.7"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.2.1"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n - [Temporary workaround for runc on Flatcar: disable SELinux for runc v1.0.0-rc8](https://github.com/flatcar-linux/coreos-overlay/pull/53)\n - [Fix a bug in bind mount options in systemd](https://github.com/flatcar-linux/coreos-overlay/pull/52)\n\nUpdates: \n\n - [Upgrade runc to 1.0.0-rc8](https://github.com/flatcar-linux/coreos-overlay/pull/51)\n"
+  },
+  "2219.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-05 09:06:39 +0000",
+    "major_software": {
+      "docker": [
+        "18.09.7"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.2.5"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2219.0.0):\n\nBug fixes:\n- Fix Ignition fetching from S3 URLs when network is slow to start ([ignition#826](https://github.com/coreos/ignition/issues/826))\n\n## Flatcar updates\n\nBug fixes:\n\n - Fix cgroup v2 path for systemd hybrid mode in runc (https://github.com/flatcar-linux/coreos-overlay/pull/58)\n - Fix issue of rsyslog not running with root directory in systemd (https://github.com/flatcar-linux/systemd/pull/3)\n\nUpdates: \n\n - Linux [5.2.5](https://lwn.net/Articles/795009/)\n\nChanges:\n - Enable SELinux for tar and coreutils for SDK profile (https://github.com/flatcar-linux/coreos-overlay/pull/55)\n"
+  },
+  "2219.99.1": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-09 17:41:16 +0000",
+    "major_software": {
+      "docker": [
+        "18.09.7"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.2.7"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2219.1.0):\n\nSecurity fixes:\n- Fix Linux information leak attack vector via speculative side channel ([CVE-2019-1125](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1125))\n\n## Flatcar updates\n\nSecurity fixes:\n- Use secure_getenv to fix a vulnerability around XDG_SEAT in pam_systemd (https://github.com/flatcar-linux/coreos-overlay/pull/61) ([CVE-2019-3842](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3842)) \n\nBug fixes:\n- Get SELinux context included in torcx tarballs (https://github.com/flatcar-linux/scripts/pull/16)\n- Enable XattrPrivileged for untar to fix SELinux issue (https://github.com/flatcar-linux/torcx/pull/1)\n\nUpdates:\n- Linux [5.2.7](https://lwn.net/Articles/795524/)\n- cri-o [1.15.0](https://github.com/flatcar-linux/coreos-overlay/pull/59)\n\nChanges:\n- Add \"-s\" flag in flatcar-install to install to smallest disk (https://github.com/flatcar-linux/init/pull/7)\n"
+  },
+  "2234.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-28 15:11:00 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.1"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.2.9"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n - Fix denial of service in HTTP/2 implementations written in Go ([CVE-2019-9512](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9512) [CVE-2019-9514](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9514) [CVE-2019-14809](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14809) )\n - Fix arbitrary execution of code in libarchive ( [CVE-2017-14166](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14166) [CVE-2017-14501](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14501) [CVE-2017-14502](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14502) [CVE-2017-14503](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-14503) )\n - Fix privilege escalation issues in polkit ([CVE-2018-1116](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1116) [CVE-2018-19788](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-19788) ) \n - Fix arbitrary execution of SQL statements in sqlite ( [CVE-2019-5018](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5018) [CVE-2019-9936](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9936) [CVE-2019-9937](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9937) )\n - Fix arbitrary execution of code in wget ( [CVE-2019-5953](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5953) )\n - Fix issues of secret leakage and nsswitch based config in Docker ( [CVE-2019-13509](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-13509) [CVE-2019-14271](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14271) )\n\nBug fixes:\n\n - Remove unnecessary dependency on Go 1.6 from cgroupid (https://github.com/flatcar-linux/coreos-overlay/commit/20f24ed14daf747e9b6923ee6baf2aa3635589e8)\n\nUpdates: \n\n - Linux [5.2.9](https://lwn.net/Articles/796462/)\n - Binutils [2.32-r1](https://github.com/flatcar-linux/portage-stable/commit/6124ccfbdf9b42b43f3bcc54331b1a590a09c142)\n - Docker [19.03.1](https://github.com/flatcar-linux/coreos-overlay/pull/62)\n - Go [1.12.9](https://github.com/golang/go/releases/tag/go1.12.9)\n - Libarchive [3.3.3](https://github.com/libarchive/libarchive/releases/tag/v3.3.3)\n - Patch [2.7.6-r4](https://github.com/flatcar-linux/portage-stable/commit/54a7e341d741c4dab4ac8df3bda7665c49700a12)\n - Polkit [0.113-r5](https://github.com/flatcar-linux/coreos-overlay/commit/a42f51d3714ae96577392293d0a683c324a4f6ee)\n - Rust [1.37.0](https://github.com/rust-lang/rust/releases/tag/1.37.0)\n - Cargo [1.37.0](https://github.com/rust-lang/rust/releases/tag/1.37.0) (https://github.com/rust-lang/cargo/releases/tag/0.38.0)\n - Sqlite [3.29.0](https://repo.or.cz/sqlite.git/shortlog/refs/tags/version-3.29.0)\n - Wget [1.20.3](http://git.savannah.gnu.org/cgit/wget.git/tag/?h=v1.20.3)\n"
+  },
+  "2247.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-09-03 18:01:18 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.1"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.2.11"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n - Fix secret leakage in libgcrypt ([CVE-2018-6829](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-6829))\n - Fix denial of service in libtasn1 ([CVE-2018-1000654](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1000654))\n - Fix bypass of a protection mechanism in libxslt ([CVE-2019-11068](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11068))\n\nBug fixes:\n\n - Fix an issue of oem-gce crashlooping in GCE images (https://github.com/flatcar-linux/coreos-overlay/pull/69)\n\nUpdates: \n\n - Linux [5.2.11](https://lwn.net/Articles/797814/)\n - libgcrypt [1.8.3](https://github.com/gpg/libgcrypt/releases/tag/libgcrypt-1.8.3)\n - libtasn1 [4.13](https://github.com/gnutls/libtasn1/releases/tag/libtasn1_4_13)\n - libxslt [1.1.33](https://github.com/GNOME/libxslt/releases/tag/v1.1.33)\n"
+  },
+  "2261.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-09-19 13:43:42 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.2"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.2.13"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "242"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix systemd-resolved bug allowing unprivileged users to change DNS settings ([CVE-2019-15718](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15718))\n\nBug fixes:\n\n - Fix commit ID to match with Manifest in coreos-firmware (https://github.com/flatcar-linux/coreos-overlay/pull/76)\n - Use mantle/ignition versions which have the `opt/org.flatcar-linux` Ignition variable (https://github.com/flatcar-linux/coreos-overlay/pull/77)\n\nUpdates: \n\n - Linux [5.2.13](https://lwn.net/Articles/798626/)\n - systemd [v242](https://github.com/systemd/systemd/releases/tag/v242) (https://github.com/flatcar-linux/coreos-overlay/pull/71)\n - containerd [1.2.8](https://github.com/containerd/containerd/releases/tag/v1.2.8)\n - cri-o [1.15.1](https://github.com/cri-o/cri-o/releases/tag/v1.15.1)\n - docker [19.03.2](https://docs.docker.com/engine/release-notes/#19032)"
+  },
+  "2275.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-10-14 08:54:42 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.2"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.3.1"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "242"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix dbus authentication bypass in non-default configurations ([CVE-2019-12749](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-12749))\n- Fix kernel KVM guest escape ([CVE-2019-14835](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14835))\n- Fix race condition in Intel microprocessors ([CVE-2019-11184](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11184))\n- Fix invalid HTTP/1.1 handling in net/http of Go ([CVE-2019-16276](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16276))\n\nBug fixes:\n\n- Fix path prefix in crio-wipe.service in cri-o (https://github.com/flatcar-linux/coreos-overlay/pull/91)\n- Fix ListenPort= in WireGuard section in systemd (https://github.com/flatcar-linux/systemd/pull/5)\n\nUpdates: \n\n - Linux [5.3.1](https://lwn.net/Articles/800245/)\n - Go [1.12.10](https://go.googlesource.com/go/+/refs/tags/go1.12.10)\n - coreos-firmware [20190815](https://github.com/flatcar-linux/coreos-overlay/pull/93/commits/3c63b3d592960030b32ddabac7a1f6cba61b18ab) (https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/tag/?h=20190815)\n - cri-o [1.15.2](https://github.com/cri-o/cri-o/releases/tag/v1.15.2)\n - cri-tools [1.16.1](https://github.com/kubernetes-sigs/cri-tools/releases/tag/v1.16.1)\n - intel-microcode [20190918](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190918/releasenote)\n"
+  },
+  "2296.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-10-23 08:54:42 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.2"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.3.7"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "242"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix panic caused by invalid DSA public keys in Go 1.12 and 1.13 ([CVE-2019-17596](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-17596))\n- Fix AppArmor restriction bypass issue in runc 1.0.0-rc8 or older ([CVE-2019-16884](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16884))\n- Fix bypass of certain policy blacklists and session PAM modules in sudo 1.8.27 or older ([CVE-2019-14287](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14287))\n\nBug fixes:\n\n- Fix rkt fetch issue that does not work without docker:// prefix in URLs (https://github.com/flatcar-linux/coreos-overlay/pull/96)\n- Multiple bug fixes from the upstream systemd-stable repo (https://github.com/flatcar-linux/coreos-overlay/pull/97)\n\nUpdates: \n\n- Linux [5.3.7](https://lwn.net/Articles/802627/)\n- Go [1.12.12](https://go.googlesource.com/go/+/refs/tags/go1.12.12) and [1.13.3](https://go.googlesource.com/go/+/refs/tags/go1.13.3)\n- runc [1.0.0-rc9](https://github.com/opencontainers/runc/releases/tag/v1.0.0-rc9)\n- sudo [1.8.28](https://www.sudo.ws/stable.html#1.8.28)"
+  },
+  "2303.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-10-28 09:51:36 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.2"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.3.7"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "242"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n- Fix issue of missing patches in grub (https://github.com/flatcar-linux/grub/pull/1)\n- Fix issue of wrong commit IDs for repos like [init](https://github.com/flatcar-linux/init)"
+  },
+  "2303.99.1": {
+    "channel": "edge",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-11-01 16:45:14 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.4"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.3.7"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "242"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n- Fix wrong CROS_WORKON_COMMIT values (https://github.com/flatcar-linux/coreos-overlay/pull/101)\n- Fix bug of unpacking tarballs failing when xattr is not supported (https://github.com/flatcar-linux/torcx/pull/3)\n\nChanges:\n\n- Replace rkt with docker in scripts like kubelet-wrapper (https://github.com/flatcar-linux/coreos-overlay/pull/103)\n\nUpdates:\n\n- docker [19.03.4](https://docs.docker.com/engine/release-notes/#19034)\n- containerd [1.3.0](https://github.com/containerd/containerd/releases/tag/v1.3.0)"
+  },
+  "2345.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2019-12-10 09:21:56 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.4.2"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "242"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nThis release is done for both amd64 and arm64.\n\nSecurity fixes:\n\n- Fix Intel CPU disclosure of memory to user process. Complete mitigation requires [manually disabling TSX or SMT](https://docs.flatcar-linux.org/os/disabling-smt/) on affected processors. ([CVE-2019-11135](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11135), [TAA](https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00270.html))\n- Fix Intel CPU denial of service by a malicious guest VM ([CVE-2018-12207](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12207))\n- Fix curl Kerberos FTP double free ([CVE-2019-5481](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5481))\n- Fix curl TFTP buffer overflow with non-default block size ([CVE-2019-5482](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5482))\n- Fix openssl key extraction attacks under non-default conditions ([CVE-2019-1563](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1563), [CVE-2019-1547](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1547))\n- Fix heap-based buffer over-read in libexpat ([CVE-2019-15903](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15903))\n\nBug fixes:\n\n- Fix cross-build issues around WAF by creating wrappers (https://github.com/flatcar-linux/coreos-overlay/pull/138)\n- Fix rust-related issues around cross toolchains (https://github.com/flatcar-linux/scripts/pull/34)\n- Fix time zone for Brazil (https://github.com/flatcar-linux/coreos-overlay/pull/118)\n\nChanges:\n\n- Support cross-builds for ARM64 (https://github.com/flatcar-linux/coreos-overlay/pull/122)\n\nUpdates:\n\n- Linux [5.4.2](https://lwn.net/Articles/806394/)\n- curl [7.66.0](https://curl.haxx.se/mail/archive-2019-09/0002.html)\n- docker [19.03.5](https://docs.docker.com/engine/release-notes/#19035)\n- etcd [3.3.18](https://github.com/etcd-io/etcd/releases/tag/v3.3.18)\n- expat [2.2.8](https://github.com/libexpat/libexpat/releases/tag/R_2_2_8)\n- intel-microcode [20191115](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20191115/releasenote)\n- ldb [1.3.6](https://gitlab.com/samba-team/samba/-/tags/ldb-1.3.6)\n- openssl [1.0.2t](https://www.openssl.org/news/cl102.txt)\n- samba [4.8.6](https://gitlab.com/samba-team/samba/-/tags/samba-4.8.6)\n- talloc [2.1.11](https://gitlab.com/samba-team/samba/-/tags/talloc-2.1.11)\n- tdb [1.3.15](https://gitlab.com/samba-team/samba/-/tags/tdb-1.3.15)\n- tevent [0.9.37](https://gitlab.com/samba-team/samba/-/tags/tevent-0.9.37)\n- timezone-data [2019c](http://mm.icann.org/pipermail/tz-announce/2019-September/000057.html)"
+  },
+  "2345.99.1": {
+    "channel": "edge",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2019-12-20 09:28:45 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.4.4"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "242"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix a denial-of-service issue via malicious access to `/dev/kvm` ([CVE-2019-19332](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19332))\n\nBug fixes:\n\n- Fix a bug when creating RAID0 arrays by setting the default layout (https://github.com/flatcar-linux/baselayout/pull/2)\n- Use rkt instead of docker in kubelet-wrapper (https://github.com/flatcar-linux/coreos-overlay/pull/148)\n\nChanges:\n\n- Support the default layout feature in mdadm (https://github.com/flatcar-linux/coreos-overlay/pull/146)\n\nUpdates:\n\n- Linux [5.4.4](https://lwn.net/Articles/807611/)\n- containerd [1.3.2](https://github.com/containerd/containerd/releases/tag/v1.3.2)\n- mdadm [4.1](https://git.kernel.org/pub/scm/utils/mdadm/mdadm.git/tag/?h=mdadm-4.1)\n- wireguard [20191212](https://git.zx2c4.com/WireGuard/tag/?h=0.0.20191212)"
+  },
+  "2387.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2020-02-06 13:20:48 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "5.4.16"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "242"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix stack-based buffer overflow in sudo ([CVE-2019-18634](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-18634))\n\nBug fixes:\n\n- Fix DNS resolution for the GCE metadata server (https://github.com/flatcar-linux/coreos-overlay/pull/160)\n- Use correct URLs for flatcar-linux in emerge-gitclone and scripts (https://github.com/flatcar-linux/dev-util/pull/1) (https://github.com/flatcar-linux/scripts/pull/50)\n- Fix a wrong profile reference in torcx (https://github.com/flatcar-linux/coreos-overlay/pull/162)\n- Use rkt again instead of docker in wrappers (https://github.com/flatcar-linux/coreos-overlay/pull/163)\n- Create symlink for /run/metadata/coreos (https://github.com/flatcar-linux/coreos-overlay/pull/166)\n- Create symlink for flatcar-install (https://github.com/flatcar-linux/init/pull/14)\n- Build static libraries for elfutils (https://github.com/flatcar-linux/coreos-overlay/pull/169)\n\nUpdates:\n\n- Linux [5.4.16](https://lwn.net/Articles/811027/)\n- dwarves [1.16](https://git.kernel.org/pub/scm/devel/pahole/pahole.git/tag/?h=v1.16)\n- elfutils [0.178](https://sourceware.org/git/?p=elfutils.git;a=tag;h=refs/tags/elfutils-0.178)\n- sudo [1.8.31](https://www.sudo.ws/stable.html#1.8.31)\n- wireguard [20200128](https://git.zx2c4.com/wireguard-linux-compat/tag/?h=v0.0.20200128)"
+  },
+  "2411.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2020-02-17 16:41:29 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.34.0"
+      ],
+      "kernel": [
+        "5.5.2"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "242"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nSecurity fixes:\n\n- Fix incorrect access control leading to privileges escalation in runc ([CVE-2019-19921](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19921))\n- Fix systemd use-after-free upon receiving crafted D-Bus message from local unprivileged attacker ([CVE-2020-1712](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1712))\n\nBug fixes:\n\n- Fix backwards compatibility issues for users to migrate from CoreOS Container Linux (https://github.com/flatcar-linux/Flatcar/issues/16 https://github.com/flatcar-linux/afterburn/pull/7 https://github.com/flatcar-linux/bootengine/pull/7 https://github.com/flatcar-linux/bootengine/pull/8 https://github.com/flatcar-linux/init/pull/16 https://github.com/flatcar-linux/init/pull/17 https://github.com/flatcar-linux/ignition/pull/8)\n\nChanges:\n\n- Build Flatcar tarballs to be used by containers (https://github.com/flatcar-linux/scripts/pull/51)\n- Enable qede kernel module\n- Enable kernel config for BTF (BPF Type Format)\n\nUpdates:\n\n- Linux [5.5.2](https://lwn.net/Articles/811599/)\n- coreos-firmware [20200122](https://github.com/flatcar-linux/coreos-overlay/pull/175/commits/8751b200031ca9d9b52a6ff060640b77f21b9504) (https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/tag/?h=20200122)\n- runc [1.0.0-rc10](https://github.com/opencontainers/runc/releases/tag/v1.0.0-rc10)\n"
+  },
+  "2430.99.0": {
+    "channel": "edge",
+    "architectures": [
+      "amd64",
+      "arm64"
+    ],
+    "release_date": "2020-03-05 10:27:05 +0000",
+    "major_software": {
+      "docker": [
+        "19.03.5"
+      ],
+      "ignition": [
+        "0.34.0"
+      ],
+      "kernel": [
+        "5.5.6"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "243"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n- Enable persistent network interface names already in the initramfs to fix https://github.com/coreos/bugs/issues/1767\n- Make systemd-hostnamed work again by updating systemd to v243 (https://github.com/flatcar-linux/systemd/pull/7)\n- Use correct branch name format in developer container tools (https://github.com/flatcar-linux/dev-util/pull/2)\n\nUpdates:\n\n- Linux [5.5.6](https://lwn.net/Articles/813155/)\n- systemd [243](https://github.com/systemd/systemd/releases/tag/v243)"
+  },
+  "1688.5.3": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-04-25 14:36:41 +0000",
+    "major_software": {
+      "docker": [
+        "17.12.1"
+      ],
+      "ignition": [
+        "0.22.0"
+      ],
+      "kernel": [
+        "4.14.32"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "237"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nInitial Flatcar release.\n\nBug fixes:\n- Fix GRUB crash at boot ([#2284](https://github.com/coreos/bugs/issues/2284))\n- Fix [poweroff problems](https://groups.google.com/forum/#!topic/coreos-user/YcGkRHU9SvQ) ([#8080](https://github.com/systemd/systemd/pull/8080))\n\nNotes:\n- Previous test images have been removed from the release servers. This is due to a new update key being generated using our updated security policy which we [included](https://github.com/flatcar-linux/coreos-overlay/pull/6) in the first public image.\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1688.5.3):\n\nBug fixes:\n- ~~Avoid GRUB crash at boot ([#2284](https://github.com/coreos/bugs/issues/2284))~~ We've included the [real fix for this](https://github.com/flatcar-linux/grub/commit/8281b03be34552e744fd08aae78b38704e2562b5).\n- Fix kernel panic with vxlan ([#2382](https://github.com/coreos/bugs/issues/2382))"
+  },
+  "1745.3.1": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-05-26 15:29:48 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.1"
+      ],
+      "kernel": [
+        "4.14.42"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1745.3.1):\n\nUpdates:\n- Ignition [0.24.1](https://github.com/coreos/ignition/releases/tag/v0.24.1)\n- Linux [4.14.42](https://lwn.net/Articles/754972/)"
+  },
+  "1745.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-05-27 09:02:48 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.1"
+      ],
+      "kernel": [
+        "4.14.42"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1745.4.0):\n\nBug fixes:\n- Fix inadvertent change of network interface names ([#2437](https://github.com/coreos/bugs/issues/2437))"
+  },
+  "1745.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-01 13:23:44 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.1"
+      ],
+      "kernel": [
+        "4.14.44"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1745.5.0):\n\nSecurity fixes:\n- Fix Git arbitrary code execution when cloning untrusted repositories ([CVE-2018-11235](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11235))\n\nBug fixes:\n- Fix failure to set network interface MTU ([#2443](https://github.com/coreos/bugs/issues/2443))\n\nUpdates:\n- Git [2.16.4](https://raw.githubusercontent.com/git/git/v2.16.4/Documentation/RelNotes/2.16.4.txt)\n- Linux [4.14.44](https://lwn.net/Articles/755717/)"
+  },
+  "1745.6.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-13 13:21:16 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.1"
+      ],
+      "kernel": [
+        "4.14.48"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1745.6.0):\n\nBug fixes:\n- Fix Hyper-V network driver regression ([#2454](https://github.com/coreos/bugs/issues/2454))\n\nUpdates:\n- Linux [4.14.48](https://lwn.net/Articles/756652/)"
+  },
+  "1745.7.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-06-15 14:51:25 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.24.1"
+      ],
+      "kernel": [
+        "4.14.48"
+      ],
+      "rkt": [
+        "1.29.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1745.7.0):\n\nBug fixes:\n- Fix TCP connection stalls ([#2457](https://github.com/coreos/bugs/issues/2457))"
+  },
+  "1800.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-07-26 09:38:46 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.14.55"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1800.4.0):\n\nNo changes for stable promotion"
+  },
+  "1800.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-07-31 09:16:01 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.14.59"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1800.5.0):\n\nBug fixes:\n- Fix kernel CIFS client ([#2480](https://github.com/coreos/bugs/issues/2480))\n\nUpdates:\n- Linux [4.14.59](https://lwn.net/Articles/761180/)"
+  },
+  "1800.6.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-08-08 10:49:51 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.14.59"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1800.6.0):\n\nSecurity fixes:\n- Fix Linux local denial of service as Xen PV guest ([CVE-2018-14678](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-14678))\n\nBug fixes:\n- Fix failure to mount large ext4 filesystems ([#2485](https://github.com/coreos/bugs/issues/2485))"
+  },
+  "1800.7.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-08-17 12:07:54 +0000",
+    "major_software": {
+      "docker": [
+        "18.03.1"
+      ],
+      "ignition": [
+        "0.25.1"
+      ],
+      "kernel": [
+        "4.14.63"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1800.7.0):\n\nSecurity fixes:\n- Fix Linux remote denial of service ([FragmentSmack](https://access.redhat.com/security/cve/cve-2018-5391), [CVE-2018-5391](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-5391))\n- Fix Linux privileged memory access via speculative execution ([L1TF/Foreshadow](https://foreshadowattack.eu/), [CVE-2018-3620](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3620), [CVE-2018-3646](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3646))\n\nUpdates:\n- intel-microcode [20180703](https://downloadcenter.intel.com/download/27945/Linux-Processor-Microcode-Data-File)\n- Linux [4.14.63](https://lwn.net/Articles/762808/)"
+  },
+  "1855.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-09-14 09:59:47 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.14.67"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1855.4.0):\n\nBug fixes:\n- Fix Docker mounting named volumes ([#2497](https://github.com/coreos/bugs/issues/2497))\n"
+  },
+  "1855.4.2": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-10-11 20:17:03 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.14.67"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nChanges:\n\n* Add new image signing subkey to `flatcar-install` ([flatcar-linux/init#4](https://github.com/flatcar-linux/init/pull/4))\n"
+  },
+  "1855.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-10-26 10:13:33 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.26.0"
+      ],
+      "kernel": [
+        "4.14.74"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1855.5.0):\n\nSecurity fixes:\n- Fix Git remote code execution during recursive clone ([CVE-2018-17456](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17456))\n\nUpdates:\n- Git [2.16.5](https://raw.githubusercontent.com/git/git/v2.16.5/Documentation/RelNotes/2.16.5.txt)\n- Linux [4.14.74](https://lwn.net/Articles/767628/)"
+  },
+  "1911.3.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-11-08 16:14:37 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.78"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1911.3.0):\n\nSecurity fixes:\n- Fix systemd re-executing with arbitrary supplied state ([CVE-2018-15686](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15686))\n- Fix systemd race allowing changing file permissions ([CVE-2018-15687](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15687))\n- Fix systemd-networkd buffer overflow in the dhcp6 client ([CVE-2018-15688](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-15688))"
+  },
+  "1911.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-11-27 14:54:50 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.81"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1911.4.0):\n\nSecurity fixes:\n- Disable containerd CRI plugin to stop it from listening on a TCP port ([#2524](https://github.com/coreos/bugs/issues/2524))\n\nUpdates:\n- Linux [4.14.81](https://lwn.net/Articles/771885/)"
+  },
+  "1911.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2018-12-21 09:08:00 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.84"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1911.5.0):\n\nSecurity fixes:\n- Fix Go CPU denial of service in X.509 verification ([CVE-2018-16875](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16875))\n- Fix PolicyKit always authorizing UIDs greater than `INT_MAX` ([CVE-2018-19788](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-19788))\n\nUpdates:\n- Go [1.10.6](https://golang.org/doc/devel/release.html#go1.10.minor)\n- Go [1.11.3](https://golang.org/doc/devel/release.html#go1.11.minor)\n- Linux [4.14.84](https://lwn.net/Articles/773114/)"
+  },
+  "1967.3.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-01-28 11:05:20 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.88"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1967.3.0):\n\nNo changes for stable promotion"
+  },
+  "1967.3.1": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-01-28 10:32:57 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.88"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1967.3.0):\n\nNo changes for stable promotion\n\n## Flatcar updates\n\nChanges:\n- [Fix the previous update of Flatcar](https://github.com/flatcar-linux/coreos-overlay/blob/build-1967.3.1/coreos-base/coreos-init/coreos-init-9999.ebuild#L13) where instead of https://github.com/flatcar-linux/init the upstream coreos-init package was referenced and used accidentally."
+  },
+  "1967.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-01-30 13:45:29 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.96"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1967.4.0):\n\nUpdates:\n- Linux [4.14.96](https://lwn.net/Articles/777581/)"
+  },
+  "1967.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-02-14 10:29:38 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.96"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1967.5.0):\nSecurity fixes:\n - Fix runc container breakout ([CVE-2019-5736](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5736))"
+  },
+  "1967.6.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-02-21 08:40:53 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.28.0"
+      ],
+      "kernel": [
+        "4.14.96"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v1967.6.0):\n\nBug fixes:\n- Fix kernel POSIX timer rearming ([#2549](https://github.com/coreos/bugs/issues/2549))"
+  },
+  "2023.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-02-27 08:52:33 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.23"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2023.4.0):\n\nSecurity fixes:\n- Fix Linux use-after-free in `sockfs_setattr` ([CVE-2019-8912](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-8912))"
+  },
+  "2023.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-03-12 14:35:58 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.1"
+      ],
+      "ignition": [
+        "0.30.0"
+      ],
+      "kernel": [
+        "4.19.25"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "238"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2023.5.0):\n\nSecurity fixes:\n- Fix systemd crash from a specially-crafted D-Bus message ([CVE-2019-6454](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6454))\n\nBug fixes:\n- Fix systemd-journald memory leak ([#2564](https://github.com/coreos/bugs/issues/2564))\n\nUpdates:\n- Linux [4.19.25](https://lwn.net/Articles/780611/)"
+  },
+  "2079.3.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-24 10:00:10 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.34"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2079.3.0):\n\nNo changes for stable promotion"
+  },
+  "2079.3.1": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-25 10:05:40 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.34"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n* Fix a wrong vendor-specific string in [CMDLINE_OEM_FLAG](https://github.com/flatcar-linux/afterburn/blob/f4f0adc6a96a1ba77a0f87b612ecdf21782aa8c6/src/main.rs#L60) in [afterburn](https://github.com/flatcar-linux/afterburn) \n\n"
+  },
+  "2079.3.2": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-04-26 07:43:52 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.34"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n* Fix a regression from the latest hotfix builds, about [CROS_WORKON_COMMIT](https://github.com/flatcar-linux/coreos-overlay/blob/60e44f23a1a5527cfa6bcbc978b1ffdef74e2e3f/coreos-base/coreos-metadata/coreos-metadata-9999.ebuild#L13) in [coreos-overlay](https://github.com/flatcar-linux/coreos-overlay) \n"
+  },
+  "2079.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-05-16 10:57:17 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.43"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2079.4.0):\n\nSecurity fixes:\n- Fix Intel CPU disclosure of memory to user process.  Complete mitigation requires [manually disabling SMT](https://docs.flatcar-linux.org/os/disabling-smt/) on affected processors. ([CVE-2019-11091](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11091), [CVE-2018-12126](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12126), [CVE-2018-12127](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12127), [CVE-2018-12130](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12130), [MDS](https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00233.html))\n\nUpdates:\n- intel-microcode [20190514](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190514/releasenote)\n- Linux [4.19.43](https://lwn.net/Articles/788388/)"
+  },
+  "2079.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-06-06 08:49:52 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.43"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2079.5.0):\n\nBug fixes:\n- Fix systemd `MountFlags=shared` option ([#2579](https://github.com/coreos/bugs/issues/2579))\n\nChanges:\n- Pin network interface naming to systemd v238 scheme ([#2578](https://github.com/coreos/bugs/issues/2578))"
+  },
+  "2079.6.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-06-19 08:15:07 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.31.0"
+      ],
+      "kernel": [
+        "4.19.43"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2079.6.0):\n\nSecurity fixes:\n\n- Fix Linux TCP remotely-triggerable kernel panic and excessive resource consumption ([CVE-2019-11477](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11477), [CVE-2019-11478](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11478), [CVE-2019-11479](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11479))\n\nBug fixes:\n\n- Fix invalid bzip2 compression of Container Linux release images ([#2589](https://github.com/coreos/bugs/issues/2589))"
+  },
+  "2135.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-01 10:47:02 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.32.0"
+      ],
+      "kernel": [
+        "4.19.50"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2135.4.0):\n\nNo changes for stable promotion\n"
+  },
+  "2135.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-07-03 08:01:54 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.50"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2135.5.0):\n\nBug fixes:\n\n * Fix Ignition panic when no `guestinfo.(coreos|ignition).config` parameters are specified on VMware (coreos/ignition#821)\n\nUpdates:\n\n * Ignition [0.33.0](https://github.com/coreos/ignition/releases/tag/v0.33.0)\n"
+  },
+  "2135.6.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-01 09:14:26 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.56"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2135.6.0):\n\n- intel-microcode [20190618](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20190618/releasenote)\n- Linux [4.19.56](https://lwn.net/Articles/792009/)"
+  },
+  "2191.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-16 09:42:56 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.65"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2191.4.0):\n\nSecurity fixes:\n- Use secure_getenv to fix a vulnerability around XDG_SEAT in pam_systemd (https://github.com/coreos/systemd/pull/118) ([CVE-2019-3842](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3842))\n\nUpdates:\n- Linux [4.19.65](https://lwn.net/Articles/795525/)\n\n## Flatcar updates\n\nBug fixes:\n- Fix wrong key name for fw_cfg in ignition with QEMU (https://github.com/flatcar-linux/ignition/issues/2)\n- Get SELinux context included in torcx tarballs (https://github.com/flatcar-linux/scripts/pull/16)\n- Enable XattrPrivileged for untar to fix SELinux issue (https://github.com/flatcar-linux/torcx/pull/1)\n\nChanges:\n- Add \"-s\" flag in flatcar-install to install to smallest disk (https://github.com/flatcar-linux/init/pull/7)"
+  },
+  "2191.4.1": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-08-30 07:36:13 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.66"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2191.4.1):\n\nSecurity fixes:\n- Fix wget buffer overflow allowing arbitrary code execution ([CVE-2019-5953](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5953))\n\nUpdates:\n- Linux [4.19.66](https://lwn.net/Articles/795843/)\n- wget [1.20.3](http://git.savannah.gnu.org/cgit/wget.git/tree/NEWS?h=v1.20.3&id=a220ead43505bc3e0ea8efb1572919111dbbf6dc#n8)"
+  },
+  "2191.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-09-05 08:52:34 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.68"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2191.5.0):\n\nSecurity fixes:\n\n- Fix pam_systemd bug allowing authenticated remote users to perform polkit actions as if locally logged in ([CVE-2019-3842](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-3842))\n- Fix systemd-resolved bug allowing unprivileged users to change DNS settings ([CVE-2019-15718](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15718))\n\nBug fixes:\n\n- Fix GCE agent crash loop in new installs ([#2608](https://github.com/coreos/bugs/issues/2608))\n\nUpdates:\n\n- Linux [4.19.68](https://lwn.net/Articles/797250/)"
+  },
+  "2247.5.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-10-17 18:54:06 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.78"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2247.5.0):\n\nNo changes for stable promotion"
+  },
+  "2247.6.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-11-11 14:11:52 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.78"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2247.6.0):\n\nBug fixes:\n\n- Fix time zone for Brazil ([#2627](https://github.com/coreos/bugs/issues/2627))\n\nUpdates:\n\n- timezone-data [2019c](http://mm.icann.org/pipermail/tz-announce/2019-September/000057.html)"
+  },
+  "2247.7.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-11-21 09:27:14 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.84"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2247.7.0):\n\nSecurity fixes:\n\n- Fix Intel CPU disclosure of memory to user process. Complete mitigation requires [manually disabling TSX or SMT](https://docs.flatcar-linux.org/os/disabling-smt/) on affected processors. ([CVE-2019-11135](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-11135), [TAA](https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00270.html))\n- Fix Intel CPU denial of service by a malicious guest VM ([CVE-2018-12207](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12207))\n\nBug fixes:\n\n- Fix CFS scheduler throttling highly-threaded I/O-bound applications ([#2623](https://github.com/coreos/bugs/issues/2623))\n\nUpdates:\n\n- intel-microcode [20191115](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/blob/microcode-20191115/releasenote)\n- Linux [4.19.84](https://lwn.net/Articles/804465/)"
+  },
+  "2303.3.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-12-05 06:33:04 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.86"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2303.3.0):\n\nUpdates:\n  - Linux [4.19.86](https://lwn.net/Articles/805531/)"
+  },
+  "2303.3.1": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2019-12-18 09:49:23 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.86"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n\n- Fix a bug when creating RAID0 arrays by setting the default layout (https://github.com/flatcar-linux/baselayout/pull/2)\n- Fix bug of unpacking tarballs failing when xattr is not supported (https://github.com/flatcar-linux/torcx/pull/2)\n\nUpdates:\n\n- ldb [1.3.6](https://gitlab.com/samba-team/samba/-/tags/ldb-1.3.6)\n- samba [4.8.6](https://gitlab.com/samba-team/samba/-/tags/samba-4.8.6)\n- talloc [2.1.11](https://gitlab.com/samba-team/samba/-/tags/talloc-2.1.11)\n- tdb [1.3.15](https://gitlab.com/samba-team/samba/-/tags/tdb-1.3.15)\n- tevent [0.9.37](https://gitlab.com/samba-team/samba/-/tags/tevent-0.9.37)"
+  },
+  "2303.4.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2020-02-10 11:10:47 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.95"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\n\nBug fixes:\n- Fix DNS resolution for the GCE metadata server (https://github.com/flatcar-linux/coreos-overlay/pull/160)\n- Create symlink for /run/metadata/coreos (https://github.com/flatcar-linux/coreos-overlay/pull/166)\n- Create symlink for flatcar-install (https://github.com/flatcar-linux/init/pull/14)\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2303.4.0):\n\nUpdates:\n- Linux [4.19.95](https://lwn.net/Articles/809258/)"
+  },
+  "2345.3.0": {
+    "channel": "stable",
+    "architectures": [
+      "amd64"
+    ],
+    "release_date": "2020-03-02 14:03:06 +0000",
+    "major_software": {
+      "docker": [
+        "18.06.3"
+      ],
+      "ignition": [
+        "0.33.0"
+      ],
+      "kernel": [
+        "4.19.106"
+      ],
+      "rkt": [
+        "1.30.0"
+      ],
+      "systemd": [
+        "241"
+      ]
+    },
+    "release_notes": "## Flatcar updates\nBug fixes:\n- Enable persistent network interface names already in the initramfs to fix https://github.com/coreos/bugs/issues/1767\n- Fix backwards compatibility issues for users to migrate from CoreOS Container Linux. Support the kernel command line parameters `coreos.oem.*`, `coreos.autologin`, `coreos.first_boot`, and the QEMU firmware config path `opt/com.coreos/config` (https://github.com/flatcar-linux/Flatcar/issues/16 https://github.com/flatcar-linux/afterburn/pull/7 https://github.com/flatcar-linux/bootengine/pull/7 https://github.com/flatcar-linux/bootengine/pull/8 https://github.com/flatcar-linux/init/pull/16 https://github.com/flatcar-linux/init/pull/17 https://github.com/flatcar-linux/ignition/pull/8)\n\n## [Upstream Container Linux updates](https://github.com/coreos/manifest/releases/tag/v2345.3.0)\nSecurity fixes:\n- Fix systemd use-after-free upon receiving crafted D-Bus message from local unprivileged attacker [CVE-2020-1712](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1712)\n- Fix heap-based buffer over-read in libexpat ([CVE-2019-15903](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15903))\n- Fix multiple Git [vulnerabilities](https://marc.info/?l=git&m=157600115215285&w=2) ([CVE-2019-1348](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1348), [CVE-2019-1349](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1349), [CVE-2019-1350](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1350), [CVE-2019-1351](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1351), [CVE-2019-1352](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1352), [CVE-2019-1353](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1353), [CVE-2019-1354](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1354), [CVE-2019-1387](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1387), [CVE-2019-19604](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-19604))\n- Fix curl Kerberos FTP double free ([CVE-2019-5481](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5481))\n - Fix curl TFTP buffer overflow with non-default block size ([CVE-2019-5482](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5482))\n - Fix OpenSSL key extraction attacks under non-default conditions ([CVE-2019-1563](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1563), [CVE-2019-1547](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1547))\n\nUpdates:\n\n- Git [2.24.1](https://github.com/git/git/blob/master/Documentation/RelNotes/2.24.1.txt)\n- Linux [4.19.106](https://lwn.net/Articles/813157/)\n- OpenSSL [1.0.2t](https://www.openssl.org/news/cl102.txt)\n- curl [7.66.0](https://curl.haxx.se/mail/archive-2019-09/0002.html)\n- etcd [3.3.18](https://github.com/etcd-io/etcd/releases/tag/v3.3.18)\n- expat [2.2.8](https://github.com/libexpat/libexpat/releases/tag/R_2_2_8)\n"
+  }
+}


### PR DESCRIPTION
As the data/ files the
static/releases-json/ files are
coming from the scripts in the
flatcar-linux-release-info repository.
This PR just adds them but does not
introduce links on the website.