### PR TITLE
Add link to channel name in overview box

### DIFF
--- a/layouts/releases/single.html
+++ b/layouts/releases/single.html
@@ -13,7 +13,12 @@
        {{ $chan := index $.Site.Data.releases $name }}
        <div class="card" {{ if eq $chan.current.channel "edge" }}style="background-color: rgba(239, 239, 239, 0.5)"{{ end }}>
            <div class="card-header align-middle">
-               <h5 class="d-inline"> {{ humanize $chan.current.channel }} </h5>
+               <h5 class="d-inline">
+                   <a href="#{{ $chan.current.channel }}-release" style="border-bottom: none; box-shadow: none;"
+                      onclick="javascript:$('#{{ $chan.current.channel }}-release-tab').click(); $(document).scrollTop($('#release-tabs').offset().top);">
+                          {{ humanize $chan.current.channel }}
+                   </a>
+               </h5>
                <div class="pull-right text-right">
                {{ $chan.current.version }}<br>
                {{ range $j, $arch := $chan.current.architectures }}


### PR DESCRIPTION
The channel tabs in below "Release Notes" already have links to themselves.
Add these links also to the channel name in the release channel overview,
so that people can jump to the channel's releases or share these links.