### PR TITLE
Direct Flatcar Docs link to Kinvolk docs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -34,7 +34,7 @@ menu:
       weight: -50
   left:
     - name: Docs
-      url: https://docs.flatcar-linux.org
+      url: https://kinvolk.io/docs/flatcar-container-linux/latest
       identifier: docs
       weight: -200
     - name: Releases


### PR DESCRIPTION
Once the Docs are live under kinvolk.io/docs we need to direct the Flatcar docs link to there which is what this PR does.

For the time being we are not going to remove the docs but we will no longer point to it directly. Once we have redirects in place we can remove the docs.flatcar-linux.org content.