### PR TITLE
Avoid linking to the LTS release infrastructure

### DIFF
--- a/layouts/partials/release-notes.html
+++ b/layouts/partials/release-notes.html
@@ -6,7 +6,10 @@
   <div class="col-md-2">
     <h5 style="margin-bottom: 0" id="release-{{ $release.version }}"><a style="box-shadow: 0 0 0 white; border: none;" href="#release-{{ $release.version }}">{{ $release.version }}</a></h5>
     {{ range $j, $arch := $release.architectures }}
-    <a class="arch small font-weight-light" href="https://{{ $release.channel }}.release.flatcar-linux.net/{{ $arch }}-usr/{{ $release.version }}/">{{ $arch }}</a><br>
+    <a class="arch small font-weight-light"
+        {{ if ne $release.channel "lts" }}
+        href="https://{{ $release.channel }}.release.flatcar-linux.net/{{ $arch }}-usr/{{ $release.version }}/"
+        {{ end }}>{{ $arch }}</a><br>
     {{ end }}
   </div>
   <div class="col-md-10">

--- a/layouts/releases/single.html
+++ b/layouts/releases/single.html
@@ -26,8 +26,10 @@
                <div class="pull-right text-right">
                {{ $chan.current.version }}<br>
                {{ range $j, $arch := $chan.current.architectures }}
-               <a class="arch small font-weight-light" href="https://{{ $chan.current.channel }}.release.flatcar-linux.net/{{ $arch }}-usr/current/">
-                   {{ $arch }}</a>
+               <a class="arch small font-weight-light"
+                    {{ if ne $chan.current.channel "lts" }}
+                    href="https://{{ $chan.current.channel }}.release.flatcar-linux.net/{{ $arch }}-usr/current/"
+                    {{ end }}>{{ $arch }}</a>
                {{ end }}
                </div>
            </div>


### PR DESCRIPTION
The LTS release infrastructure is not publicly accessible, we shouldn't link to it from our release page.