### PR TITLE
data: add lost releases

### DIFF
--- a/data/releases/alpha/2783.0.0.yml
+++ b/data/releases/alpha/2783.0.0.yml
@@ -1,0 +1,91 @@
+architectures:
+- amd64
+- arm64
+channel: alpha
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/38226456/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/500628?v=4
+    events_url: https://api.github.com/users/sayanchowdhury/events{/privacy}
+    followers_url: https://api.github.com/users/sayanchowdhury/followers
+    following_url: https://api.github.com/users/sayanchowdhury/following{/other_user}
+    gists_url: https://api.github.com/users/sayanchowdhury/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/sayanchowdhury
+    id: 500628
+    login: sayanchowdhury
+    node_id: MDQ6VXNlcjUwMDYyOA==
+    organizations_url: https://api.github.com/users/sayanchowdhury/orgs
+    received_events_url: https://api.github.com/users/sayanchowdhury/received_events
+    repos_url: https://api.github.com/users/sayanchowdhury/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/sayanchowdhury/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/sayanchowdhury/subscriptions
+    type: User
+    url: https://api.github.com/users/sayanchowdhury
+  body: "**Security fixes**\r\n\r\n\r\n\r\n*   Linux ([CVE-2021-3347](https://nvd.nist.gov/vuln/detail/CVE-2021-3347),\
+    \ [CVE-2021-3348](https://nvd.nist.gov/vuln/detail/CVE-2021-3348), [CVE-2021-26708](https://nvd.nist.gov/vuln/detail/CVE-2021-26708),\
+    \ [CVE-2021-20194](https://nvd.nist.gov/vuln/detail/CVE-2021-20194))\r\n*   Docker\
+    \ ([CVE-2021-21285](https://nvd.nist.gov/vuln/detail/CVE-2021-21285), [CVE-2021-21284](https://nvd.nist.gov/vuln/detail/CVE-2021-21284))\r\
+    \n*   samba ([CVE-2020-14318](https://nvd.nist.gov/vuln/detail/CVE-2020-14318),\
+    \ [CVE-2020-14323](https://nvd.nist.gov/vuln/detail/CVE-2020-14323), [CVE-2020-14383](https://nvd.nist.gov/vuln/detail/CVE-2020-14383))\r\
+    \n*   openldap ([CVE-2020-36221](https://nvd.nist.gov/vuln/detail/CVE-2020-36221),[\
+    \ CVE-2020-36222](https://nvd.nist.gov/vuln/detail/CVE-2020-36222),[ CVE-2020-36223](https://nvd.nist.gov/vuln/detail/CVE-2020-36223),[\
+    \ CVE-2020-36224](https://nvd.nist.gov/vuln/detail/-2020-36224),[ CVE-2020-36225](https://nvd.nist.gov/vuln/detail/CVE-2020-36225),[\
+    \ CVE-2020-36226](https://nvd.nist.gov/vuln/detail/CVE-2020-36226),[ CVE-2020-36227](https://nvd.nist.gov/vuln/detail/CVE-2020-36227),[\
+    \ CVE-2020-36228](https://nvd.nist.gov/vuln/detail/CVE-2020-36228),[ CVE-2020-36229](https://nvd.nist.gov/vuln/detail/CVE-2020-36229),[\
+    \ CVE-2020-36230](https://nvd.nist.gov/vuln/detail/CVE-2020-36230))\r\n*   c-ares\
+    \ ([CVE-2020-8277](https://nvd.nist.gov/vuln/detail/CVE-2020-8277))\r\n*   coreutils\
+    \ ([CVE-2017-7476](https://nvd.nist.gov/vuln/detail/CVE-2017-7476))\r\n*   intel-microcode\
+    \ ([CVE-2020-8698](https://nvd.nist.gov/vuln/detail/CVE-2020-8698), [CVE-2020-8694](https://nvd.nist.gov/vuln/detail/CVE-2020-8694),\
+    \ [CVE-2020-8695](https://nvd.nist.gov/vuln/detail/CVE-2020-8695), [CVE-2020-8696](https://nvd.nist.gov/vuln/detail/CVE-2020-8696))\r\
+    \n\r\n**Bug fixes**\r\n\r\n\r\n\r\n*   profile: filter out bullet point when parsing\
+    \ failed units ([baselayout#16](https://github.com/kinvolk/baselayout/pull/16))\r\
+    \n*   app-crypt/trousers: use correct file permissions ([coreos-overlay#809](https://github.com/kinvolk/coreos-overlay/pull/809))\r\
+    \n*   sys-apps/systemd: Fix unit installation ([coreos-overlay#810](https://github.com/kinvolk/coreos-overlay/pull/810))\r\
+    \n*   passwd: use correct GID for tss([baselayout#15](https://github.com/kinvolk/baselayout/pull/15))\r\
+    \n*   flatcar-eks: add missing mkdir and update to latest versions([coreos-overlay#817](https://github.com/kinvolk/coreos-overlay/pull/817))\r\
+    \n*   coreos-base/gmerge: Stop installing gmerge script ([coreos-overlay#828](https://github.com/kinvolk/coreos-overlay/pull/828))\r\
+    \n*   Update sys-apps/coreutils and make sure they have split-usr disabled for\
+    \ generic images ([coreos-overlay#829](https://github.com/kinvolk/coreos-overlay/pull/829))\r\
+    \n\r\n**Changes**\r\n\r\n\r\n\r\n*   dev-lang/go: delete go 1.6 ([coreos-overlay#827](https://github.com/kinvolk/coreos-overlay/pull/827))\r\
+    \n*   sys-block/open-iscsi: Command substitution in iscsi-init system service\
+    \ ([coreos-overlay#801](https://github.com/kinvolk/coreos-overlay/pull/801))\r\
+    \n*   scripts/motdgen: Add OEM information to motd output ([init#34](https://github.com/kinvolk/init/pull/34))\r\
+    \n*   torcx: delete Docker 1.12 ([coreos-overlay#826](https://github.com/kinvolk/coreos-overlay/pull/826))\r\
+    \n*   portage update: update portage and related packages to newer versions ([coreos-overlay#840](https://github.com/kinvolk/coreos-overlay/pull/840))\r\
+    \n*   bin/flatcar-install: add parameters to make wget more resilient ([init#35](https://github.com/kinvolk/init/pull/35))\r\
+    \n\r\n**Updates**\r\n\r\n\r\n\r\n*   Linux ([5.10.16](https://lwn.net/Articles/846116/))\r\
+    \n*   Docker ([19.03.15](https://docs.docker.com/engine/release-notes/19.03/#190315))\r\
+    \n*   go ([1.15.8](https://go.googlesource.com/go/+/refs/tags/go1.15.8))\r\n*\
+    \   c-ares ([1.17.1](https://c-ares.haxx.se/changelog.html#1_17_1))\r\n*   cri-tools\
+    \ ([1.19.0](https://github.com/kubernetes-sigs/cri-tools/releases/tag/v1.19.0))\r\
+    \n*   samba ([4.12.9](https://www.samba.org/samba/history/samba-4.12.9.html))\r\
+    \n*   openldap ([2.4.57](https://www.openldap.org/software/release/announce.html))\r\
+    \n*   coreutils ([8.32](https://git.savannah.gnu.org/cgit/coreutils.git/tree/NEWS?h=v8.32))\r\
+    \n*   intel-microcode ([20201112](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases/tag/microcode-20201112))\r\
+    \n\r\n**Deprecation**\r\n\r\n\r\n\r\n*   Docker 1.12 will be deprecated from Alpha,\
+    \ also from other channels in the future.\r\n\r\nNote: Please note that ARM images\
+    \ remain experimental for now.\r\n"
+  created_at: '2021-02-12T19:09:00Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2783.0.0
+  id: 38226456
+  name: v2783.0.0
+  node_id: MDc6UmVsZWFzZTM4MjI2NDU2
+  prerelease: false
+  published_at: '2021-02-18T12:43:43Z'
+  tag_name: v2783.0.0
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2783.0.0
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/38226456/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/38226456
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2783.0.0
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.16
+  systemd: '247'
+release: 2783.0.0
+version: 2783.0.0

--- a/data/releases/alpha/2801.0.1.yml
+++ b/data/releases/alpha/2801.0.1.yml
@@ -1,0 +1,59 @@
+architectures:
+- amd64
+- arm64
+channel: alpha
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/39641301/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/10096906?v=4
+    events_url: https://api.github.com/users/dongsupark/events{/privacy}
+    followers_url: https://api.github.com/users/dongsupark/followers
+    following_url: https://api.github.com/users/dongsupark/following{/other_user}
+    gists_url: https://api.github.com/users/dongsupark/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/dongsupark
+    id: 10096906
+    login: dongsupark
+    node_id: MDQ6VXNlcjEwMDk2OTA2
+    organizations_url: https://api.github.com/users/dongsupark/orgs
+    received_events_url: https://api.github.com/users/dongsupark/received_events
+    repos_url: https://api.github.com/users/dongsupark/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/dongsupark/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/dongsupark/subscriptions
+    type: User
+    url: https://api.github.com/users/dongsupark
+  body: "**Security fixes**\r\n\r\n*   Linux - ([CVE-2020-25639](https://nvd.nist.gov/vuln/detail/CVE-2020-25639),\
+    \ [CVE-2021-27365](https://nvd.nist.gov/vuln/detail/CVE-2021-27365), [CVE-2021-27364](https://nvd.nist.gov/vuln/detail/CVE-2021-27364),\
+    \ [CVE-2021-27363](https://nvd.nist.gov/vuln/detail/CVE-2021-27363), [CVE-2021-28038](https://nvd.nist.gov/vuln/detail/CVE-2021-28038),\
+    \ [CVE-2021-28039](https://nvd.nist.gov/vuln/detail/CVE-2021-28039))\r\n*   containerd\
+    \ ([GHSA-6g2q-w5j3-fwh4](https://github.com/containerd/containerd/security/advisories/GHSA-6g2q-w5j3-fwh4))\r\
+    \n\r\n**Bug fixes**\r\n\r\n*   Include firmware files for all modules shipped\
+    \ in our image ([Issue #359](https://github.com/kinvolk/Flatcar/issues/359), [PR\
+    \ #887](https://github.com/kinvolk/coreos-overlay/pull/887))\r\n*   Add explicit\
+    \ path to the binary call in the coreos-metadata unit file ([Issue #360](https://github.com/kinvolk/Flatcar/issues/360))\r\
+    \n\r\n**Updates**\r\n\r\n*   Linux ([5.10.21](https://lwn.net/Articles/848617/))\r\
+    \n*   Containerd ([1.4.4](https://github.com/containerd/containerd/releases/tag/v1.4.4))\r\
+    \n"
+  created_at: '2021-03-09T16:07:54Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2801.0.1
+  id: 39641301
+  name: v2801.0.1
+  node_id: MDc6UmVsZWFzZTM5NjQxMzAx
+  prerelease: false
+  published_at: '2021-03-11T09:20:29Z'
+  tag_name: v2801.0.1
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2801.0.1
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/39641301/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/39641301
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2801.0.1
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.21
+  systemd: '247'
+release: 2801.0.1
+version: 2801.0.1

--- a/data/releases/alpha/2823.0.0.yml
+++ b/data/releases/alpha/2823.0.0.yml
@@ -1,0 +1,92 @@
+architectures:
+- amd64
+- arm64
+channel: alpha
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/40423987/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/500628?v=4
+    events_url: https://api.github.com/users/sayanchowdhury/events{/privacy}
+    followers_url: https://api.github.com/users/sayanchowdhury/followers
+    following_url: https://api.github.com/users/sayanchowdhury/following{/other_user}
+    gists_url: https://api.github.com/users/sayanchowdhury/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/sayanchowdhury
+    id: 500628
+    login: sayanchowdhury
+    node_id: MDQ6VXNlcjUwMDYyOA==
+    organizations_url: https://api.github.com/users/sayanchowdhury/orgs
+    received_events_url: https://api.github.com/users/sayanchowdhury/received_events
+    repos_url: https://api.github.com/users/sayanchowdhury/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/sayanchowdhury/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/sayanchowdhury/subscriptions
+    type: User
+    url: https://api.github.com/users/sayanchowdhury
+  body: "**Security fixes**\r\n\r\n\r\n\r\n*   Linux ([CVE-2021-27365](https://nvd.nist.gov/vuln/detail/CVE-2021-27365),\
+    \ [CVE-2021-27364](https://nvd.nist.gov/vuln/detail/CVE-2021-27364), [CVE-2021-27363](https://nvd.nist.gov/vuln/detail/CVE-2021-27363),\
+    \ [CVE-2021-28038](https://nvd.nist.gov/vuln/detail/CVE-2021-28038), [CVE-2021-28039](https://nvd.nist.gov/vuln/detail/CVE-2021-28039),\
+    \ [CVE-2021-28375](https://nvd.nist.gov/vuln/detail/CVE-2021-28375), [CVE-2021-28660](https://nvd.nist.gov/vuln/detail/CVE-2021-28660),\
+    \ [CVE-2021-27218](https://nvd.nist.gov/vuln/detail/CVE-2021-27218), [CVE-2021-27219](https://nvd.nist.gov/vuln/detail/CVE-2021-27219))\r\
+    \n*   Go ([CVE-2021-27918](https://nvd.nist.gov/vuln/detail/CVE-2021-27918),[\
+    \ CVE-2021-27919](https://nvd.nist.gov/vuln/detail/CVE-2021-27919)) \r\n*   boost\
+    \ ([CVE-2012-2677](https://nvd.nist.gov/vuln/detail/CVE-2012-2677))\r\n*   glib\
+    \ ([CVE-2021-28153](https://nvd.nist.gov/vuln/detail/CVE-2021-28153),[ CVE-2021-27218](https://nvd.nist.gov/vuln/detail/CVE-2021-27218),[\
+    \ CVE-2021-27219](https://nvd.nist.gov/vuln/detail/CVE-2021-27219)) \r\n*   ncurses\
+    \ ([CVE-2019-17594](https://nvd.nist.gov/vuln/detail/CVE-2019-17594),[ CVE-2019-17595](https://nvd.nist.gov/vuln/detail/CVE-2019-17595))\r\
+    \n*   openssl ([CVE-2021-3449](https://nvd.nist.gov/vuln/detail/CVE-2021-3449),[\
+    \ CVE-2021-3450](https://nvd.nist.gov/vuln/detail/CVE-2021-3450))\r\n*   zstd\
+    \ ([CVE-2021-24032](https://nvd.nist.gov/vuln/detail/CVE-2021-24032))\r\n\r\n\
+    **Bug Fixes**\r\n\r\n\r\n\r\n*   GCE: The old interface name ens4v1 which was\
+    \ replaced by eth0 due to a broken udev rule was restored, but now as alternative\
+    \ interface name, and eth0 will stay the primary name for consistency across cloud\
+    \ environments. ([init#38](https://github.com/kinvolk/init/pull/38))\r\n\r\n**Changes**\r\
+    \n\r\n\r\n\r\n*   The virtio network interfaces got predictable interface names\
+    \ as alternative interface names, and thus these names can also be used to match\
+    \ for a specific interface in case there is more than one and the eth0 and eth1\
+    \ name assignment is not stable. ([init#38](https://github.com/kinvolk/init/pull/38))\r\
+    \n*   The pam_faillock PAM module was enabled as replacement for the removed pam_tally2\
+    \ module and will temporarily lock an account if there were login attempts with\
+    \ a wrong password. The faillock command can be used to show the current state.\
+    \ With pam_tally2 there was no limit for wrong password login attempts but with\
+    \ faillock the default is already restricting the attempts. The default behavior\
+    \ was relaxed to allow 5 wrong passwords per two minutes, and a one minute account\
+    \ lock time. This does not apply to logins with an SSH key. ([baselayout#17](https://github.com/kinvolk/baselayout/pull/17))\r\
+    \n*   The etcd and flannel services are now run with Docker and any rkt-based\
+    \ customizations of the etcd-member and flanneld services not supported anymore.\
+    \ Also, because the flanneld service relies on Docker and will restart Docker\
+    \ after applying the new configuration, it is not possible anymore to set Requires=flanneld.service\
+    \ for docker.service and instead it\u2019s enough to have flanneld.service enabled.\
+    \ ([coreos-overlay#857](https://github.com/kinvolk/coreos-overlay/pull/857))\r\
+    \n\r\n**Updates**\r\n\r\n\r\n\r\n*   Linux ([5.10.25](https://lwn.net/Articles/849951/))\r\
+    \n*   Linux firmware ([20210315](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/tag/?h=20210315))\r\
+    \n*   Go ([1.15.10](https://go.googlesource.com/go/+/refs/tags/go1.15.10))\r\n\
+    *   boost ([1.75.0](https://www.boost.org/users/history/version_1_75_0.html))\r\
+    \n*   glib ([2.66.8](https://gitlab.gnome.org/GNOME/glib/-/releases/2.66.8))\r\
+    \n*   ncurses ([6.2](https://invisible-island.net/ncurses/announce-6.2.html))\r\
+    \n*   openssl ([1.1.1k](https://mta.openssl.org/pipermail/openssl-announce/2021-March/000197.html))\r\
+    \n*   open-iscsi ([2.1.4](https://github.com/open-iscsi/open-iscsi/releases/tag/2.1.4))\r\
+    \n*   zstd ([1.4.9](https://github.com/facebook/zstd/releases/tag/v1.4.9))\r\n\
+    \r\nNote: Please note that ARM images remain experimental for now."
+  created_at: '2021-03-24T11:42:19Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2823.0.0
+  id: 40423987
+  name: v2823.0.0
+  node_id: MDc6UmVsZWFzZTQwNDIzOTg3
+  prerelease: false
+  published_at: '2021-03-25T15:36:49Z'
+  tag_name: v2823.0.0
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2823.0.0
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/40423987/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/40423987
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2823.0.0
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.25
+  systemd: '247'
+release: 2823.0.0
+version: 2823.0.0

--- a/data/releases/alpha/2879.0.0.yml
+++ b/data/releases/alpha/2879.0.0.yml
@@ -1,0 +1,73 @@
+architectures:
+- amd64
+- arm64
+channel: alpha
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/43208967/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/10096906?v=4
+    events_url: https://api.github.com/users/dongsupark/events{/privacy}
+    followers_url: https://api.github.com/users/dongsupark/followers
+    following_url: https://api.github.com/users/dongsupark/following{/other_user}
+    gists_url: https://api.github.com/users/dongsupark/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/dongsupark
+    id: 10096906
+    login: dongsupark
+    node_id: MDQ6VXNlcjEwMDk2OTA2
+    organizations_url: https://api.github.com/users/dongsupark/orgs
+    received_events_url: https://api.github.com/users/dongsupark/received_events
+    repos_url: https://api.github.com/users/dongsupark/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/dongsupark/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/dongsupark/subscriptions
+    type: User
+    url: https://api.github.com/users/dongsupark
+  body: "**Security fixes**\r\n\r\n*   Linux ([CVE-2021-3491](https://nvd.nist.gov/vuln/detail/CVE-2021-3491),\
+    \ [CVE-2021-31440](https://nvd.nist.gov/vuln/detail/CVE-2021-31440), [CVE-2021-31829](https://nvd.nist.gov/vuln/detail/CVE-2021-31829))\r\
+    \n*   dbus ([CVE-2020-35512](https://nvd.nist.gov/vuln/detail/CVE-2020-35512))\r\
+    \n*   Go ([CVE-2021-31525](https://nvd.nist.gov/vuln/detail/CVE-2021-31525))\r\
+    \n*   nvidia-drivers ([CVE-2021-1052](https://nvd.nist.gov/vuln/detail/CVE-2021-1052),\
+    \ [CVE-2021-1053](https://nvd.nist.gov/vuln/detail/CVE-2021-1053), [CVE-2021-1056](https://nvd.nist.gov/vuln/detail/CVE-2021-1056),\
+    \ [CVE-2021-1076](https://nvd.nist.gov/vuln/detail/CVE-2021-1076), [CVE-2021-1077](https://nvd.nist.gov/vuln/detail/CVE-2021-1077))\r\
+    \n*   runc ([CVE-2021-30465](https://nvd.nist.gov/vuln/detail/CVE-2021-30465))\r\
+    \n*   Rust ([CVE-2020-36323](https://nvd.nist.gov/vuln/detail/CVE-2020-36323),\
+    \ [CVE-2021-28876](https://nvd.nist.gov/vuln/detail/CVE-2021-28876), [CVE-2021-28877](https://nvd.nist.gov/vuln/detail/CVE-2021-28877),\
+    \ [CVE-2021-28878](https://nvd.nist.gov/vuln/detail/CVE-2021-28878), [CVE-2021-28879](https://nvd.nist.gov/vuln/detail/CVE-2021-28879),\
+    \ [CVE-2021-31162](https://nvd.nist.gov/vuln/detail/CVE-2021-31162))\r\n\r\n**Bug\
+    \ fixes**\r\n\r\n*   systemd-networkd: Do not manage loopback network interface\
+    \ ([bootengine#24](https://github.com/kinvolk/bootengine/pull/24) [init#40](https://github.com/kinvolk/init/pull/40))\r\
+    \n*   flatcar-install: Detect device mapper (e.g., LVM/LUKS) usage when searching\
+    \ for free drives with the -s flag ([Flatcar#332](https://github.com/kinvolk/Flatcar/issues/332))\r\
+    \n\r\n**Changes**\r\n\r\n*   flatcar-install: Add -D flag to only download the\
+    \ image file ([Flatcar#248](https://github.com/kinvolk/Flatcar/issues/248))\r\n\
+    *   SDK: Drop jobs parameter in flatcar-scripts ([flatcar-scripts#121](https://github.com/kinvolk/flatcar-scripts/pull/121))\r\
+    \n\r\n**Updates**\r\n\r\n*   Linux ([5.10.37](https://lwn.net/Articles/856269/))\r\
+    \n*   dbus ([1.10.32](https://lists.freedesktop.org/archives/ftp-release/2020-July/000759.html))\r\
+    \n*   nvidia-drivers ([460.73.01](https://www.nvidia.com/Download/driverResults.aspx/172376/en-us))\r\
+    \n*   SDK: cmake ([3.18.5](https://github.com/Kitware/CMake/releases/tag/v3.18.5))\r\
+    \n*   SDK: Go ([1.16.4](https://go.googlesource.com/go/+/refs/tags/go1.16.4))\r\
+    \n*   SDK: Rust ([1.52.1](https://blog.rust-lang.org/2021/05/10/Rust-1.52.1.html))\r\
+    \n\r\nNote: Please note that ARM images remain experimental for now.\r\n"
+  created_at: '2021-05-17T18:48:45Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2879.0.0
+  id: 43208967
+  name: v2879.0.0
+  node_id: MDc6UmVsZWFzZTQzMjA4OTY3
+  prerelease: false
+  published_at: '2021-05-19T11:40:56Z'
+  tag_name: v2879.0.0
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2879.0.0
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/43208967/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/43208967
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2879.0.0
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.37
+  systemd: '247'
+release: 2879.0.0
+version: 2879.0.0

--- a/data/releases/alpha/2879.0.1.yml
+++ b/data/releases/alpha/2879.0.1.yml
@@ -1,0 +1,51 @@
+architectures:
+- amd64
+- arm64
+channel: alpha
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/43348306/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/1189130?v=4
+    events_url: https://api.github.com/users/pothos/events{/privacy}
+    followers_url: https://api.github.com/users/pothos/followers
+    following_url: https://api.github.com/users/pothos/following{/other_user}
+    gists_url: https://api.github.com/users/pothos/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/pothos
+    id: 1189130
+    login: pothos
+    node_id: MDQ6VXNlcjExODkxMzA=
+    organizations_url: https://api.github.com/users/pothos/orgs
+    received_events_url: https://api.github.com/users/pothos/received_events
+    repos_url: https://api.github.com/users/pothos/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/pothos/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/pothos/subscriptions
+    type: User
+    url: https://api.github.com/users/pothos
+  body: "**Bug fixes**\r\n\r\n*   The Linux kernel IOMMU-related crash introduced\
+    \ in the 5.10.37 update got fixed through the 5.10.38 update ([Flatcar#400](https://github.com/kinvolk/Flatcar/issues/400))\r\
+    \n\r\n**Updates**\r\n\r\n*   Linux ([5.10.38](https://lwn.net/Articles/856654/))\r\
+    \n\r\nNote: Please note that ARM images remain experimental for now."
+  created_at: '2021-05-20T15:14:46Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2879.0.1
+  id: 43348306
+  name: v2879.0.1
+  node_id: MDc6UmVsZWFzZTQzMzQ4MzA2
+  prerelease: false
+  published_at: '2021-05-21T12:08:01Z'
+  tag_name: v2879.0.1
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2879.0.1
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/43348306/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/43348306
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2879.0.1
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.38
+  systemd: '247'
+release: 2879.0.1
+version: 2879.0.1

--- a/data/releases/alpha/2905.0.0.yml
+++ b/data/releases/alpha/2905.0.0.yml
@@ -1,0 +1,68 @@
+architectures:
+- amd64
+- arm64
+channel: alpha
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/44785635/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/500628?v=4
+    events_url: https://api.github.com/users/sayanchowdhury/events{/privacy}
+    followers_url: https://api.github.com/users/sayanchowdhury/followers
+    following_url: https://api.github.com/users/sayanchowdhury/following{/other_user}
+    gists_url: https://api.github.com/users/sayanchowdhury/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/sayanchowdhury
+    id: 500628
+    login: sayanchowdhury
+    node_id: MDQ6VXNlcjUwMDYyOA==
+    organizations_url: https://api.github.com/users/sayanchowdhury/orgs
+    received_events_url: https://api.github.com/users/sayanchowdhury/received_events
+    repos_url: https://api.github.com/users/sayanchowdhury/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/sayanchowdhury/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/sayanchowdhury/subscriptions
+    type: User
+    url: https://api.github.com/users/sayanchowdhury
+  body: "**Security fixes**\r\n\r\n\r\n\r\n*   Linux ([CVE-2020-26558](https://nvd.nist.gov/vuln/detail/CVE-2020-26558),\
+    \ [CVE-2021-0129](https://nvd.nist.gov/vuln/detail/CVE-2021-0129), [CVE-2020-24587](https://nvd.nist.gov/vuln/detail/CVE-2020-24587),\
+    \ [CVE-2020-24586](https://nvd.nist.gov/vuln/detail/CVE-2020-24586), [CVE-2020-24588](https://nvd.nist.gov/vuln/detail/CVE-2020-24588),\
+    \ [CVE-2020-26139](https://nvd.nist.gov/vuln/detail/CVE-2020-26139), [CVE-2020-26145](https://nvd.nist.gov/vuln/detail/CVE-2020-26145),\
+    \ [CVE-2020-26147](https://nvd.nist.gov/vuln/detail/CVE-2020-26147), [CVE-2020-26141](https://nvd.nist.gov/vuln/detail/CVE-2020-26141),\
+    \ [CVE-2021-3564](https://nvd.nist.gov/vuln/detail/CVE-2021-3564), [CVE-2021-28691](https://nvd.nist.gov/vuln/detail/CVE-2021-28691),\
+    \ [CVE-2021-3587](https://nvd.nist.gov/vuln/detail/CVE-2021-3587), [CVE-2021-3573](https://nvd.nist.gov/vuln/detail/CVE-2021-3573))\r\
+    \n*   binutils ([CVE-2021-20197](https://nvd.nist.gov/vuln/detail/CVE-2021-20197),[CVE-2021-3487](https://nvd.nist.gov/vuln/detail/CVE-2021-3487))\r\
+    \n*   Go (CVE-2021-33195,CVE-2021-33196,CVE-2021-33197,CVE-2021-33198)\r\n*  \
+    \ libxml2 ([CVE-2021-3516](https://nvd.nist.gov/vuln/detail/CVE-2021-3516),[CVE-2021-3517](https://nvd.nist.gov/vuln/detail/CVE-2021-3517),[CVE-2021-3518](https://nvd.nist.gov/vuln/detail/CVE-2021-3518),CVE-2021-3541)\r\
+    \n\r\n**Bug fixes**\r\n\r\n\r\n\r\n*   Update-engine sent empty requests when\
+    \ restarted before a pending reboot ([Flatcar#388](https://github.com/kinvolk/Flatcar/issues/388))\r\
+    \n\r\n**Changes**\r\n\r\n\r\n\r\n*   Disabled SELinux for Docker ([coreos-overlay#1055](https://github.com/kinvolk/coreos-overlay/pull/1055))\r\
+    \n\r\n**Updates**\r\n\r\n\r\n\r\n*   Linux ([5.10.43](https://lwn.net/Articles/859022/))\r\
+    \n*   Linux Firmware ([20210511](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/tag/?h=20210511))\r\
+    \n*   containerd ([1.5.2](https://github.com/containerd/containerd/releases/tag/v1.5.2))\r\
+    \n*   libxml2 ([2.9.12](https://gitlab.gnome.org/GNOME/libxml2/-/tags/v2.9.12))\r\
+    \n*   runc ([1.0.0_rc95](https://github.com/opencontainers/runc/releases/tag/v1.0.0-rc95))\r\
+    \n*   openssh ([8.6_p1](https://www.openssh.com/txt/release-8.6))\r\n*   SDK:\
+    \ binutils ([2.36.1](https://sourceware.org/pipermail/binutils/2021-February/115240.html))\r\
+    \n\r\nNote: Please note that ARM images remain experimental for now.\r\n"
+  created_at: '2021-06-15T16:12:43Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2905.0.0
+  id: 44785635
+  name: v2905.0.0
+  node_id: MDc6UmVsZWFzZTQ0Nzg1NjM1
+  prerelease: false
+  published_at: '2021-06-17T10:29:49Z'
+  tag_name: v2905.0.0
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2905.0.0
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/44785635/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/44785635
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2905.0.0
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.43
+  systemd: '247'
+release: 2905.0.0
+version: 2905.0.0

--- a/data/releases/alpha/2920.0.0.yml
+++ b/data/releases/alpha/2920.0.0.yml
@@ -1,0 +1,62 @@
+architectures:
+- amd64
+- arm64
+channel: alpha
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/45605559/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/500628?v=4
+    events_url: https://api.github.com/users/sayanchowdhury/events{/privacy}
+    followers_url: https://api.github.com/users/sayanchowdhury/followers
+    following_url: https://api.github.com/users/sayanchowdhury/following{/other_user}
+    gists_url: https://api.github.com/users/sayanchowdhury/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/sayanchowdhury
+    id: 500628
+    login: sayanchowdhury
+    node_id: MDQ6VXNlcjUwMDYyOA==
+    organizations_url: https://api.github.com/users/sayanchowdhury/orgs
+    received_events_url: https://api.github.com/users/sayanchowdhury/received_events
+    repos_url: https://api.github.com/users/sayanchowdhury/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/sayanchowdhury/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/sayanchowdhury/subscriptions
+    type: User
+    url: https://api.github.com/users/sayanchowdhury
+  body: "**Security fixes**\r\n\r\n\r\n\r\n* Linux ([CVE-2021-34693](https://nvd.nist.gov/vuln/detail/CVE-2021-34693),\
+    \ [CVE-2021-33624](https://nvd.nist.gov/vuln/detail/CVE-2021-33624))\r\n* lz4\
+    \ ([CVE-2021-3520](https://nvd.nist.gov/vuln/detail/CVE-2021-3520))\r\n* curl\
+    \ ([CVE-2021-22898](https://nvd.nist.gov/vuln/detail/CVE-2021-22898),[ CVE-2021-22901](https://nvd.nist.gov/vuln/detail/CVE-2021-22901))\r\
+    \n* gptfdisk ([CVE-2021-0308](https://nvd.nist.gov/vuln/detail/CVE-2021-0308))\r\
+    \n* gettext ([CVE-2020-12825](https://nvd.nist.gov/vuln/detail/CVE-2020-12825))\r\
+    \n* intel-microcode ([CVE-2020-24489](https://nvd.nist.gov/vuln/detail/CVE-2020-24489),[\
+    \ CVE-2020-24511](https://nvd.nist.gov/vuln/detail/CVE-2020-24511),[ CVE-2020-24513](https://nvd.nist.gov/vuln/detail/CVE-2020-24513))\r\
+    \n\r\n**Updates**\r\n\r\n\r\n\r\n* Linux ([5.10.46](https://lwn.net/Articles/860655/))\r\
+    \n* lz4 ([1.9.3-r1](https://github.com/lz4/lz4/releases/tag/v1.9.3)) \r\n* curl\
+    \ ([7.77.0-r1](https://curl.se/changes.html#7_77_0)) \r\n* gptfdisk (1.0.7)\r\n\
+    * gettext ([0.21-r1](https://lists.gnu.org/archive/html/info-gnu/2020-07/msg00009.html))\r\
+    \n* intel-microcode ([20210608_p20210608](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases/tag/microcode-20210608))\r\
+    \n* runc ([1.0.0](https://github.com/opencontainers/runc/releases/tag/v1.0.0))\r\
+    \n\r\nNote: Please note that ARM images remain experimental for now.\r\n"
+  created_at: '2021-06-29T17:11:45Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2920.0.0
+  id: 45605559
+  name: v2920.0.0
+  node_id: MDc6UmVsZWFzZTQ1NjA1NTU5
+  prerelease: false
+  published_at: '2021-07-02T07:38:53Z'
+  tag_name: v2920.0.0
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2920.0.0
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/45605559/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/45605559
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2920.0.0
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.46
+  systemd: '247'
+release: 2920.0.0
+version: 2920.0.0

--- a/data/releases/alpha/2942.0.0.yml
+++ b/data/releases/alpha/2942.0.0.yml
@@ -1,0 +1,79 @@
+architectures:
+- amd64
+- arm64
+channel: alpha
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/46887118/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/500628?v=4
+    events_url: https://api.github.com/users/sayanchowdhury/events{/privacy}
+    followers_url: https://api.github.com/users/sayanchowdhury/followers
+    following_url: https://api.github.com/users/sayanchowdhury/following{/other_user}
+    gists_url: https://api.github.com/users/sayanchowdhury/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/sayanchowdhury
+    id: 500628
+    login: sayanchowdhury
+    node_id: MDQ6VXNlcjUwMDYyOA==
+    organizations_url: https://api.github.com/users/sayanchowdhury/orgs
+    received_events_url: https://api.github.com/users/sayanchowdhury/received_events
+    repos_url: https://api.github.com/users/sayanchowdhury/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/sayanchowdhury/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/sayanchowdhury/subscriptions
+    type: User
+    url: https://api.github.com/users/sayanchowdhury
+  body: "**Security Fixes**\r\n\r\n\r\n\r\n* containerd ([CVE-2021-32760](https://nvd.nist.gov/vuln/detail/CVE-2021-32760))\r\
+    \n* curl (CVE-2021-22922, CVE-2021-22923, CVE-2021-22924, CVE-2021-22925, CVE-2021-22926)\r\
+    \n* glibc ([CVE-2020-29562](https://nvd.nist.gov/vuln/detail/CVE-2020-29562),\
+    \ [CVE-2019-25013](https://nvd.nist.gov/vuln/detail/CVE-2019-25013), [CVE-2020-27618](https://nvd.nist.gov/vuln/detail/https://cve.circl.lu/cve/CVE-2020-27618),\
+    \ [CVE-2021-27645](https://nvd.nist.gov/vuln/detail/CVE-2021-27645), [CVE-2021-33574](https://nvd.nist.gov/vuln/detail/CVE-2021-33574))\r\
+    \n* Go ([CVE-2021-34558](https://nvd.nist.gov/vuln/detail/CVE-2021-34558))\r\n\
+    * libgcrypt ([CVE-2021-33560](https://nvd.nist.gov/vuln/detail/CVE-2021-33560))\r\
+    \n* libpcre ([CVE-2019-20838](https://nvd.nist.gov/vuln/detail/CVE-2019-20838),\
+    \ [CVE-2020-14155](https://nvd.nist.gov/vuln/detail/CVE-2020-14155))\r\n* Linux\
+    \ ([CVE-2020-26541](https://nvd.nist.gov/vuln/detail/CVE-2020-26541), [CVE-2021-35039](https://nvd.nist.gov/vuln/detail/CVE-2021-35039),\
+    \ [CVE-2021-22543](https://nvd.nist.gov/vuln/detail/CVE-2021-22543), CVE-2021-3609,\
+    \ CVE-2021-3655, [CVE-2021-33909](https://nvd.nist.gov/vuln/detail/CVE-2021-33909))\r\
+    \n\r\n**Bug Fixes**\r\n\r\n\r\n\r\n* Add the systemd tag in udev for Azure storage\
+    \ devices, to fix /boot automount ([init#41](https://github.com/kinvolk/init/pull/41))\r\
+    \n\r\n**Changes**\r\n\r\n\r\n\r\n* Enable telnet support for curl ([coreos-overlay#1099](https://github.com/kinvolk/coreos-overlay/pull/1099))\r\
+    \n* Enable ssl USE flag for wget ([coreos-overlay#932](https://github.com/kinvolk/coreos-overlay/pull/932))\r\
+    \n* Enable MDIO_BCM_UNIMAC for arm64 ([coreos-overlay#929](https://github.com/kinvolk/coreos-overlay/pull/929))\r\
+    \n\r\n**Updates**\r\n\r\n\r\n\r\n* Linux ([5.10.52](https://lwn.net/Articles/863648/))\r\
+    \n* containerd ([1.5.4](https://github.com/containerd/containerd/releases/tag/v1.5.4))\r\
+    \n* curl ([7.78](https://curl.se/changes.html#7_78_0))\r\n* dbus ([1.12.20](https://github.com/freedesktop/dbus/blob/ab88811768f750777d1a8b9d9ab12f13390bfd3a/NEWS#L1))\r\
+    \n* dracut ([053](https://github.com/dracutdevs/dracut/releases/tag/053))\r\n\
+    * glibc ([2.33](https://sourceware.org/pipermail/libc-alpha/2021-February/122207.html))\r\
+    \n* go ([1.16.6](https://golang.org/doc/devel/release#go1.16.minor)) \r\n* libev\
+    \ (4.33)\r\n* libgcrypt ([1.9.3](https://github.com/gpg/libgcrypt/blob/cb78627203705365d24b48ec4fc4cf2fc804b277/NEWS#L1))\r\
+    \n* libpcre (8.44)\r\n* libverto ([0.3.1](https://github.com/latchset/libverto/releases/tag/0.3.1))\r\
+    \n* pax-utils (1.3.1)\r\n* readline ([8.1_p1](https://tiswww.case.edu/php/chet/readline/CHANGES))\r\
+    \n* rust ([1.53.0](https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html))\r\n\
+    * selinux ([3.1](https://github.com/SELinuxProject/selinux/releases/tag/20200710))\r\
+    \n* selinux-refpolicy ([2.20200818](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20200818))\r\
+    \n* systemd ([247.7](https://github.com/systemd/systemd-stable/releases/tag/v247.7))\r\
+    \n* VMWare: open-vm-tools ([11.3.0](https://github.com/vmware/open-vm-tools/releases/tag/stable-11.3.0))\r\
+    \n\r\nNote: Please note that ARM images remain experimental for now."
+  created_at: '2021-07-21T13:28:18Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2942.0.0
+  id: 46887118
+  name: v2942.0.0
+  node_id: MDc6UmVsZWFzZTQ2ODg3MTE4
+  prerelease: false
+  published_at: '2021-07-28T08:20:14Z'
+  tag_name: v2942.0.0
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2942.0.0
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/46887118/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/46887118
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2942.0.0
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.52
+  systemd: '247'
+release: 2942.0.0
+version: 2942.0.0

--- a/data/releases/beta/2801.1.0.yml
+++ b/data/releases/beta/2801.1.0.yml
@@ -1,0 +1,72 @@
+architectures:
+- amd64
+channel: beta
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/40424098/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/500628?v=4
+    events_url: https://api.github.com/users/sayanchowdhury/events{/privacy}
+    followers_url: https://api.github.com/users/sayanchowdhury/followers
+    following_url: https://api.github.com/users/sayanchowdhury/following{/other_user}
+    gists_url: https://api.github.com/users/sayanchowdhury/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/sayanchowdhury
+    id: 500628
+    login: sayanchowdhury
+    node_id: MDQ6VXNlcjUwMDYyOA==
+    organizations_url: https://api.github.com/users/sayanchowdhury/orgs
+    received_events_url: https://api.github.com/users/sayanchowdhury/received_events
+    repos_url: https://api.github.com/users/sayanchowdhury/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/sayanchowdhury/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/sayanchowdhury/subscriptions
+    type: User
+    url: https://api.github.com/users/sayanchowdhury
+  body: "**Security fixes**\r\n\r\n\r\n\r\n*   Linux ([CVE-2021-27365](https://nvd.nist.gov/vuln/detail/CVE-2021-27365),\
+    \ [CVE-2021-27364](https://nvd.nist.gov/vuln/detail/CVE-2021-27364), [CVE-2021-27363](https://nvd.nist.gov/vuln/detail/CVE-2021-27363),\
+    \ [CVE-2021-28038](https://nvd.nist.gov/vuln/detail/CVE-2021-28038), [CVE-2021-28039](https://nvd.nist.gov/vuln/detail/CVE-2021-28039),\
+    \ [CVE-2021-28375](https://nvd.nist.gov/vuln/detail/CVE-2021-28375), [CVE-2021-28660](https://nvd.nist.gov/vuln/detail/CVE-2021-28660),\
+    \ [CVE-2021-27218](https://nvd.nist.gov/vuln/detail/CVE-2021-27218), [CVE-2021-27219](https://nvd.nist.gov/vuln/detail/CVE-2021-27219),\
+    \ [CVE-2021-3444](https://nvd.nist.gov/vuln/detail/CVE-2021-3444))\r\n*   openssl\
+    \ ([CVE-2021-23840](https://nvd.nist.gov/vuln/detail/CVE-2021-23840),[ CVE-2021-23841](https://nvd.nist.gov/vuln/detail/CVE-2021-23841),\
+    \ [CVE-2020-1971](https://nvd.nist.gov/vuln/detail/CVE-2020-1971),[ CVE-2021-23840](https://nvd.nist.gov/vuln/detail/CVE-2021-23840),[\
+    \ CVE-2021-23841](https://nvd.nist.gov/vuln/detail/CVE-2021-23841), [CVE-2021-3449](https://nvd.nist.gov/vuln/detail/CVE-2021-3449),[\
+    \ CVE-2021-3450](https://nvd.nist.gov/vuln/detail/CVE-2021-3450))\r\n\r\n**Bug\
+    \ Fixes**\r\n\r\n\r\n\r\n*   GCE: The old interface name ens4v1 which was replaced\
+    \ by eth0 due to a broken udev rule was restored, but now as alternative interface\
+    \ name, and eth0 will stay the primary name for consistency across cloud environments.\
+    \ ([init#38](https://github.com/kinvolk/init/pull/38))\r\n\r\n**Changes**\r\n\r\
+    \n\r\n\r\n*   The virtio network interfaces got predictable interface names as\
+    \ alternative interface names, and thus these names can also be used to match\
+    \ for a specific interface in case there is more than one and the eth0 and eth1\
+    \ name assignment is not stable. ([init#38](https://github.com/kinvolk/init/pull/38))\r\
+    \n\r\n**Updates**\r\n\r\n\r\n\r\n*   Linux ([5.10.25](https://lwn.net/Articles/849951/))\r\
+    \n*   openssl ([1.1.1k](https://mta.openssl.org/pipermail/openssl-announce/2021-March/000197.html))\r\
+    \n*   open-iscsi ([2.1.4](https://github.com/open-iscsi/open-iscsi/releases/tag/2.1.4))\r\
+    \n\r\n**Deprecation**\r\n\r\n\r\n\r\n*   dhcpcd and containerd-stress are deprecated\
+    \ and removed from Beta, also from subsequent channels in the future. Users that\
+    \ relied on dhcpd should either migrate to systemd-networkd as a DHCP server or\
+    \ run dhcpd from a container.\r\n*   Docker 1.12 is deprecated and removed from\
+    \ Beta, also from subsequent channels in the future."
+  created_at: '2021-03-24T11:44:12Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2801.1.0
+  id: 40424098
+  name: v2801.1.0
+  node_id: MDc6UmVsZWFzZTQwNDI0MDk4
+  prerelease: false
+  published_at: '2021-03-25T15:38:18Z'
+  tag_name: v2801.1.0
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2801.1.0
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/40424098/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/40424098
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2801.1.0
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.25
+  systemd: '247'
+release: 2801.1.0
+version: 2801.1.0

--- a/data/releases/beta/2823.1.1.yml
+++ b/data/releases/beta/2823.1.1.yml
@@ -1,0 +1,54 @@
+architectures:
+- amd64
+channel: beta
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/43208885/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/10096906?v=4
+    events_url: https://api.github.com/users/dongsupark/events{/privacy}
+    followers_url: https://api.github.com/users/dongsupark/followers
+    following_url: https://api.github.com/users/dongsupark/following{/other_user}
+    gists_url: https://api.github.com/users/dongsupark/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/dongsupark
+    id: 10096906
+    login: dongsupark
+    node_id: MDQ6VXNlcjEwMDk2OTA2
+    organizations_url: https://api.github.com/users/dongsupark/orgs
+    received_events_url: https://api.github.com/users/dongsupark/received_events
+    repos_url: https://api.github.com/users/dongsupark/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/dongsupark/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/dongsupark/subscriptions
+    type: User
+    url: https://api.github.com/users/dongsupark
+  body: "**Security fixes**\r\n\r\n*   Linux ([CVE-2021-3491](https://nvd.nist.gov/vuln/detail/CVE-2021-3491),\
+    \ [CVE-2021-31440](https://nvd.nist.gov/vuln/detail/CVE-2021-31440), [CVE-2021-31829](https://nvd.nist.gov/vuln/detail/CVE-2021-31829))\r\
+    \n*   nvidia-drivers ([CVE-2021-1052](https://nvd.nist.gov/vuln/detail/CVE-2021-1052),\
+    \ [CVE-2021-1053](https://nvd.nist.gov/vuln/detail/CVE-2021-1053), [CVE-2021-1056](https://nvd.nist.gov/vuln/detail/CVE-2021-1056),\
+    \ [CVE-2021-1076](https://nvd.nist.gov/vuln/detail/CVE-2021-1076), [CVE-2021-1077](https://nvd.nist.gov/vuln/detail/CVE-2021-1077))\r\
+    \n*   runc ([CVE-2021-30465](https://nvd.nist.gov/vuln/detail/CVE-2021-30465))\r\
+    \n\r\n**Updates**\r\n\r\n*   Linux ([5.10.37](https://lwn.net/Articles/856269/))\r\
+    \n*   nvidia-drivers ([460.73.01](https://www.nvidia.com/Download/driverResults.aspx/172376/en-us))"
+  created_at: '2021-05-17T18:48:12Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2823.1.1
+  id: 43208885
+  name: v2823.1.1
+  node_id: MDc6UmVsZWFzZTQzMjA4ODg1
+  prerelease: false
+  published_at: '2021-05-19T11:39:05Z'
+  tag_name: v2823.1.1
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2823.1.1
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/43208885/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/43208885
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2823.1.1
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.37
+  systemd: '247'
+release: 2823.1.1
+version: 2823.1.1

--- a/data/releases/beta/2823.1.2.yml
+++ b/data/releases/beta/2823.1.2.yml
@@ -1,0 +1,50 @@
+architectures:
+- amd64
+channel: beta
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/43348326/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/1189130?v=4
+    events_url: https://api.github.com/users/pothos/events{/privacy}
+    followers_url: https://api.github.com/users/pothos/followers
+    following_url: https://api.github.com/users/pothos/following{/other_user}
+    gists_url: https://api.github.com/users/pothos/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/pothos
+    id: 1189130
+    login: pothos
+    node_id: MDQ6VXNlcjExODkxMzA=
+    organizations_url: https://api.github.com/users/pothos/orgs
+    received_events_url: https://api.github.com/users/pothos/received_events
+    repos_url: https://api.github.com/users/pothos/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/pothos/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/pothos/subscriptions
+    type: User
+    url: https://api.github.com/users/pothos
+  body: "**Bug fixes**\r\n\r\n*   The Linux kernel IOMMU-related crash introduced\
+    \ in the 5.10.37 update got fixed through the 5.10.38 update ([Flatcar#400](https://github.com/kinvolk/Flatcar/issues/400))\r\
+    \n\r\n**Updates**\r\n\r\n*   Linux ([5.10.38](https://lwn.net/Articles/856654/))\r\
+    \n"
+  created_at: '2021-05-20T15:14:03Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2823.1.2
+  id: 43348326
+  name: v2823.1.2
+  node_id: MDc6UmVsZWFzZTQzMzQ4MzI2
+  prerelease: false
+  published_at: '2021-05-21T12:08:31Z'
+  tag_name: v2823.1.2
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2823.1.2
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/43348326/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/43348326
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2823.1.2
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.38
+  systemd: '247'
+release: 2823.1.2
+version: 2823.1.2

--- a/data/releases/beta/2823.1.3.yml
+++ b/data/releases/beta/2823.1.3.yml
@@ -1,0 +1,57 @@
+architectures:
+- amd64
+channel: beta
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/44785705/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/500628?v=4
+    events_url: https://api.github.com/users/sayanchowdhury/events{/privacy}
+    followers_url: https://api.github.com/users/sayanchowdhury/followers
+    following_url: https://api.github.com/users/sayanchowdhury/following{/other_user}
+    gists_url: https://api.github.com/users/sayanchowdhury/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/sayanchowdhury
+    id: 500628
+    login: sayanchowdhury
+    node_id: MDQ6VXNlcjUwMDYyOA==
+    organizations_url: https://api.github.com/users/sayanchowdhury/orgs
+    received_events_url: https://api.github.com/users/sayanchowdhury/received_events
+    repos_url: https://api.github.com/users/sayanchowdhury/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/sayanchowdhury/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/sayanchowdhury/subscriptions
+    type: User
+    url: https://api.github.com/users/sayanchowdhury
+  body: "**Security fixes**\r\n\r\n\r\n\r\n*   Linux ([CVE-2020-26558](https://nvd.nist.gov/vuln/detail/CVE-2020-26558),\
+    \ [CVE-2021-0129](https://nvd.nist.gov/vuln/detail/CVE-2021-0129), [CVE-2020-24587](https://nvd.nist.gov/vuln/detail/CVE-2020-24587),\
+    \ [CVE-2020-24586](https://nvd.nist.gov/vuln/detail/CVE-2020-24586), [CVE-2020-24588](https://nvd.nist.gov/vuln/detail/CVE-2020-24588),\
+    \ [CVE-2020-26139](https://nvd.nist.gov/vuln/detail/CVE-2020-26139), [CVE-2020-26145](https://nvd.nist.gov/vuln/detail/CVE-2020-26145),\
+    \ [CVE-2020-26147](https://nvd.nist.gov/vuln/detail/CVE-2020-26147), [CVE-2020-26141](https://nvd.nist.gov/vuln/detail/CVE-2020-26141),\
+    \ [CVE-2021-3564](https://nvd.nist.gov/vuln/detail/CVE-2021-3564), [CVE-2021-28691](https://nvd.nist.gov/vuln/detail/CVE-2021-28691),\
+    \ [CVE-2021-3587](https://nvd.nist.gov/vuln/detail/CVE-2021-3587), [CVE-2021-3573](https://nvd.nist.gov/vuln/detail/CVE-2021-3573))\r\
+    \n\r\n**Bug fixes**\r\n\r\n\r\n\r\n*   Update-engine sent empty requests when\
+    \ restarted before a pending reboot ([Flatcar#388](https://github.com/kinvolk/Flatcar/issues/388))\r\
+    \n\r\n**Changes**\r\n\r\n\r\n\r\n*   Disabled SELinux for Docker ([coreos-overlay#1055](https://github.com/kinvolk/coreos-overlay/pull/1055))\r\
+    \n\r\n**Updates**\r\n\r\n\r\n\r\n*   Linux ([5.10.43](https://lwn.net/Articles/859022/))"
+  created_at: '2021-06-15T16:11:24Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2823.1.3
+  id: 44785705
+  name: v2823.1.3
+  node_id: MDc6UmVsZWFzZTQ0Nzg1NzA1
+  prerelease: false
+  published_at: '2021-06-17T10:30:54Z'
+  tag_name: v2823.1.3
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2823.1.3
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/44785705/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/44785705
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2823.1.3
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.43
+  systemd: '247'
+release: 2823.1.3
+version: 2823.1.3

--- a/data/releases/beta/2905.1.0.yml
+++ b/data/releases/beta/2905.1.0.yml
@@ -1,0 +1,82 @@
+architectures:
+- amd64
+channel: beta
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/45605519/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/500628?v=4
+    events_url: https://api.github.com/users/sayanchowdhury/events{/privacy}
+    followers_url: https://api.github.com/users/sayanchowdhury/followers
+    following_url: https://api.github.com/users/sayanchowdhury/following{/other_user}
+    gists_url: https://api.github.com/users/sayanchowdhury/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/sayanchowdhury
+    id: 500628
+    login: sayanchowdhury
+    node_id: MDQ6VXNlcjUwMDYyOA==
+    organizations_url: https://api.github.com/users/sayanchowdhury/orgs
+    received_events_url: https://api.github.com/users/sayanchowdhury/received_events
+    repos_url: https://api.github.com/users/sayanchowdhury/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/sayanchowdhury/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/sayanchowdhury/subscriptions
+    type: User
+    url: https://api.github.com/users/sayanchowdhury
+  body: "_Changes since **Alpha** **2905.0.0**:_\r\n**Security fixes**\r\n\r\n* Linux\
+    \ ([CVE-2021-34693](https://nvd.nist.gov/vuln/detail/CVE-2021-34693), [CVE-2021-33624](https://nvd.nist.gov/vuln/detail/CVE-2021-33624))\r\
+    \n\r\n**Changes**\r\n\r\n* NVIDIA GPU Support added in the AWS Pro images ([coreos-overlay#1078](https://github.com/kinvolk/coreos-overlay/pull/1078))\
+    \ \r\n\r\n**Updates**\r\n\r\n* Linux ([5.10.46](https://lwn.net/Articles/860655/))\r\
+    \n\r\n\r\n\r\n_Changes since **Beta** **2823.1.3**:_\r\n**Security fixes**\r\n\
+    \r\n\r\n\r\n* Linux ([CVE-2021-34693](https://nvd.nist.gov/vuln/detail/CVE-2021-34693),\
+    \ [CVE-2021-33624](https://nvd.nist.gov/vuln/detail/CVE-2021-33624))\r\n* binutils\
+    \ ([CVE-2021-20197](https://nvd.nist.gov/vuln/detail/CVE-2021-20197),[CVE-2021-3487](https://nvd.nist.gov/vuln/detail/CVE-2021-3487))\r\
+    \n* openldap ([CVE-2021-27212](https://nvd.nist.gov/vuln/detail/CVE-2021-27212))\r\
+    \n* sqlite ([CVE-2021-20227](https://nvd.nist.gov/vuln/detail/CVE-2021-20227))\r\
+    \n* Go (CVE-2021-33195,CVE-2021-33196,CVE-2021-33197,CVE-2021-33198)\r\n* libxml2\
+    \ ([CVE-2021-3516](https://nvd.nist.gov/vuln/detail/CVE-2021-3516),[CVE-2021-3517](https://nvd.nist.gov/vuln/detail/CVE-2021-3517),[CVE-2021-3518](https://nvd.nist.gov/vuln/detail/CVE-2021-3518),CVE-2021-3541)\r\
+    \n* qemu ([CVE-2020-10717](https://nvd.nist.gov/vuln/detail/CVE-2020-10717),[\
+    \ CVE-2020-13754](https://nvd.nist.gov/vuln/detail/CVE-2020-13754),[ CVE-2020-15859](https://nvd.nist.gov/vuln/detail/CVE-2020-15859),[\
+    \ CVE-2020-15863](https://nvd.nist.gov/vuln/detail/CVE-2020-15863),[ CVE-2020-16092](https://nvd.nist.gov/vuln/detail/CVE-2020-16092),[\
+    \ CVE-2020-25741](https://nvd.nist.gov/vuln/detail/CVE-2020-25741),[ CVE-2020-25742](https://nvd.nist.gov/vuln/detail/CVE-2020-25742),[\
+    \ CVE-2020-25743](https://nvd.nist.gov/vuln/detail/CVE-2020-25743))\r\n* git ([CVE-2021-21300](https://nvd.nist.gov/vuln/detail/CVE-2021-21300))\r\
+    \n* gnutls ([CVE-2021-20231](https://nvd.nist.gov/vuln/detail/CVE-2021-20231),[\
+    \ CVE-2021-20232](https://nvd.nist.gov/vuln/detail/CVE-2021-20232))\r\n* curl\
+    \ ([CVE-2021-22876](https://nvd.nist.gov/vuln/detail/CVE-2021-22876),[ CVE-2021-22890](https://nvd.nist.gov/vuln/detail/CVE-2021-22890))\r\
+    \n\r\n**Bug Fixes**\r\n\r\n\r\n\r\n* NVIDIA GPU Support added in the AWS Pro images\
+    \ ([coreos-overlay#1078](https://github.com/kinvolk/coreos-overlay/pull/1078))\
+    \ \r\n\r\n**Updates**\r\n\r\n\r\n\r\n* Linux ([5.10.46](https://lwn.net/Articles/860655/))\r\
+    \n* dbus ([1.10.32](https://github.com/freedesktop/dbus/releases/tag/dbus-1.10.32))\r\
+    \n* openssh ([8.6_p1](https://www.openssh.com/txt/release-8.6))\r\n* openldap\
+    \ ([2.4.58](https://www.openldap.org/software/release/announce.html))\r\n* curl\
+    \ ([7.76.1](https://curl.se/changes.html#7_76_1))\r\n* gnutls ([3.7.1](https://gitlab.com/gnutls/gnutls/-/tags/3.7.1))\r\
+    \n* git ([2.26.3](https://raw.githubusercontent.com/git/git/v2.26.3/Documentation/RelNotes/2.26.3.txt))\r\
+    \n* go ([1.16.4](https://go.googlesource.com/go/+/refs/tags/go1.16.4))\r\n* dnsmasq\
+    \ ([2.83](https://thekelleys.org.uk/dnsmasq/CHANGELOG))\r\n* libxml2 ([2.9.12](https://github.com/GNOME/libxml2/releases/tag/v2.9.12))\r\
+    \n* sqlite ([3.34.1](https://www.sqlite.org/releaselog/3_34_1.html))\r\n* SDK:\
+    \ binutils ([2.36.1](https://sourceware.org/pipermail/binutils/2021-February/115240.html))\r\
+    \n* SDK: QEMU ([5.2.0](https://wiki.qemu.org/ChangeLog/5.2))\r\n\r\n**Deprecation**\r\
+    \n\r\n\r\n\r\n* rkt and kubelet-wrapper are deprecated and removed from Beta,\
+    \ also from subsequent channels in the future. Please read the[ removal announcement](https://groups.google.com/g/flatcar-linux-user/c/MeinndLqJO4)\
+    \ to know more."
+  created_at: '2021-06-29T17:42:58Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2905.1.0
+  id: 45605519
+  name: v2905.1.0
+  node_id: MDc6UmVsZWFzZTQ1NjA1NTE5
+  prerelease: false
+  published_at: '2021-07-02T07:37:53Z'
+  tag_name: v2905.1.0
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2905.1.0
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/45605519/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/45605519
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2905.1.0
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.46
+  systemd: '247'
+release: 2905.1.0
+version: 2905.1.0

--- a/data/releases/beta/2920.1.0.yml
+++ b/data/releases/beta/2920.1.0.yml
@@ -1,0 +1,60 @@
+architectures:
+- amd64
+channel: beta
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/46887154/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/500628?v=4
+    events_url: https://api.github.com/users/sayanchowdhury/events{/privacy}
+    followers_url: https://api.github.com/users/sayanchowdhury/followers
+    following_url: https://api.github.com/users/sayanchowdhury/following{/other_user}
+    gists_url: https://api.github.com/users/sayanchowdhury/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/sayanchowdhury
+    id: 500628
+    login: sayanchowdhury
+    node_id: MDQ6VXNlcjUwMDYyOA==
+    organizations_url: https://api.github.com/users/sayanchowdhury/orgs
+    received_events_url: https://api.github.com/users/sayanchowdhury/received_events
+    repos_url: https://api.github.com/users/sayanchowdhury/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/sayanchowdhury/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/sayanchowdhury/subscriptions
+    type: User
+    url: https://api.github.com/users/sayanchowdhury
+  body: "_Changes since **Alpha 2920.0.0**_\r\n\r\n**Security Fixes**\r\n\r\n\r\n\r\
+    \n* containerd ([CVE-2021-32760](https://nvd.nist.gov/vuln/detail/CVE-2021-32760))\r\
+    \n* curl (CVE-2021-22922, CVE-2021-22923, CVE-2021-22924, CVE-2021-22925, CVE-2021-22926)\r\
+    \n* linux ([CVE-2020-26541](https://nvd.nist.gov/vuln/detail/CVE-2020-26541),\
+    \ [CVE-2021-35039](https://nvd.nist.gov/vuln/detail/CVE-2021-35039), [CVE-2021-22543](https://nvd.nist.gov/vuln/detail/CVE-2021-22543),\
+    \ CVE-2021-3609, CVE-2021-3655, [CVE-2021-33909](https://nvd.nist.gov/vuln/detail/CVE-2021-33909))\r\
+    \n\r\n**Updates**\r\n\r\n\r\n\r\n* Linux ([5.10.52](https://lwn.net/Articles/863648/))\r\
+    \n* curl ([7.78](https://curl.se/changes.html#7_78_0))\r\n* containerd ([1.5.4](https://github.com/containerd/containerd/releases/tag/v1.5.4))\r\
+    \n\r\n_Changes since **Beta 2905.1.0**_\r\n\r\n**Updates**\r\n\r\n\r\n\r\n* Linux\
+    \ ([5.10.52](https://lwn.net/Articles/863648/))\r\n* lz4 ([1.9.3-r1](https://github.com/lz4/lz4/releases/tag/v1.9.3))\r\
+    \n* curl ([7.78](https://curl.se/changes.html#7_78_0))\r\n* gptfdisk (1.0.7)\r\
+    \n* gettext ([0.21-r1](https://lists.gnu.org/archive/html/info-gnu/2020-07/msg00009.html))\r\
+    \n* intel-microcode ([20210608_p20210608](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases/tag/microcode-20210608))\r\
+    \n* runc ([1.0.0](https://github.com/opencontainers/runc/releases/tag/v1.0.0))"
+  created_at: '2021-07-21T13:34:34Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2920.1.0
+  id: 46887154
+  name: v2920.1.0
+  node_id: MDc6UmVsZWFzZTQ2ODg3MTU0
+  prerelease: false
+  published_at: '2021-07-28T08:21:00Z'
+  tag_name: v2920.1.0
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2920.1.0
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/46887154/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/46887154
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2920.1.0
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.52
+  systemd: '247'
+release: 2920.1.0
+version: 2920.1.0

--- a/data/releases/lts-2021/2605.16.1.yml
+++ b/data/releases/lts-2021/2605.16.1.yml
@@ -1,0 +1,50 @@
+architectures:
+- amd64
+channel: lts
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/43208781/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/10096906?v=4
+    events_url: https://api.github.com/users/dongsupark/events{/privacy}
+    followers_url: https://api.github.com/users/dongsupark/followers
+    following_url: https://api.github.com/users/dongsupark/following{/other_user}
+    gists_url: https://api.github.com/users/dongsupark/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/dongsupark
+    id: 10096906
+    login: dongsupark
+    node_id: MDQ6VXNlcjEwMDk2OTA2
+    organizations_url: https://api.github.com/users/dongsupark/orgs
+    received_events_url: https://api.github.com/users/dongsupark/received_events
+    repos_url: https://api.github.com/users/dongsupark/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/dongsupark/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/dongsupark/subscriptions
+    type: User
+    url: https://api.github.com/users/dongsupark
+  body: "**Security fixes**\r\n\r\n*   Linux ([CVE-2021-31829](https://nvd.nist.gov/vuln/detail/CVE-2021-31829))\r\
+    \n*   runc ([CVE-2021-30465](https://nvd.nist.gov/vuln/detail/CVE-2021-30465))\r\
+    \n\r\n**Updates**\r\n\r\n*   Linux ([5.4.119](https://lwn.net/Articles/856270/))\r\
+    \n*   systemd ([246.13](https://github.com/systemd/systemd-stable/releases/tag/v246.13))"
+  created_at: '2021-05-17T18:46:43Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2605.16.1
+  id: 43208781
+  name: v2605.16.1
+  node_id: MDc6UmVsZWFzZTQzMjA4Nzgx
+  prerelease: false
+  published_at: '2021-05-19T11:36:59Z'
+  tag_name: v2605.16.1
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2605.16.1
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/43208781/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/43208781
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2605.16.1
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.4.119
+  systemd: '246'
+release: 2605.16.1
+version: 2605.16.1

--- a/data/releases/lts-2021/2605.17.1.yml
+++ b/data/releases/lts-2021/2605.17.1.yml
@@ -1,0 +1,53 @@
+architectures:
+- amd64
+channel: lts
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/44785824/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/500628?v=4
+    events_url: https://api.github.com/users/sayanchowdhury/events{/privacy}
+    followers_url: https://api.github.com/users/sayanchowdhury/followers
+    following_url: https://api.github.com/users/sayanchowdhury/following{/other_user}
+    gists_url: https://api.github.com/users/sayanchowdhury/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/sayanchowdhury
+    id: 500628
+    login: sayanchowdhury
+    node_id: MDQ6VXNlcjUwMDYyOA==
+    organizations_url: https://api.github.com/users/sayanchowdhury/orgs
+    received_events_url: https://api.github.com/users/sayanchowdhury/received_events
+    repos_url: https://api.github.com/users/sayanchowdhury/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/sayanchowdhury/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/sayanchowdhury/subscriptions
+    type: User
+    url: https://api.github.com/users/sayanchowdhury
+  body: "\r\n**Security fixes**\r\n\r\n\r\n\r\n*   Linux ([CVE-2020-26558](https://nvd.nist.gov/vuln/detail/CVE-2020-26558),\
+    \ [CVE-2021-0129](https://nvd.nist.gov/vuln/detail/CVE-2021-0129), [CVE-2020-24587](https://nvd.nist.gov/vuln/detail/CVE-2020-24587),\
+    \ [CVE-2020-24586](https://nvd.nist.gov/vuln/detail/CVE-2020-24586), [CVE-2020-24588](https://nvd.nist.gov/vuln/detail/CVE-2020-24588),\
+    \ [CVE-2020-26139](https://nvd.nist.gov/vuln/detail/CVE-2020-26139), [CVE-2020-26145](https://nvd.nist.gov/vuln/detail/CVE-2020-26145),\
+    \ [CVE-2020-26141](https://nvd.nist.gov/vuln/detail/CVE-2020-26141), [CVE-2021-3564](https://nvd.nist.gov/vuln/detail/CVE-2021-3564),\
+    \ [CVE-2021-3587](https://nvd.nist.gov/vuln/detail/CVE-2021-3587), [CVE-2021-3573](https://nvd.nist.gov/vuln/detail/CVE-2021-3573))\r\
+    \n\r\n**Updates**\r\n\r\n\r\n\r\n*   Linux ([5.4.125](https://lwn.net/Articles/859023/))"
+  created_at: '2021-06-15T16:07:00Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2605.17.1
+  id: 44785824
+  name: v2605.17.1
+  node_id: MDc6UmVsZWFzZTQ0Nzg1ODI0
+  prerelease: false
+  published_at: '2021-06-17T10:32:57Z'
+  tag_name: v2605.17.1
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2605.17.1
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/44785824/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/44785824
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2605.17.1
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.4.125
+  systemd: '246'
+release: 2605.17.1
+version: 2605.17.1

--- a/data/releases/lts/2605.14.1.yml
+++ b/data/releases/lts/2605.14.1.yml
@@ -1,0 +1,58 @@
+architectures:
+- amd64
+channel: lts
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/40424260/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/500628?v=4
+    events_url: https://api.github.com/users/sayanchowdhury/events{/privacy}
+    followers_url: https://api.github.com/users/sayanchowdhury/followers
+    following_url: https://api.github.com/users/sayanchowdhury/following{/other_user}
+    gists_url: https://api.github.com/users/sayanchowdhury/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/sayanchowdhury
+    id: 500628
+    login: sayanchowdhury
+    node_id: MDQ6VXNlcjUwMDYyOA==
+    organizations_url: https://api.github.com/users/sayanchowdhury/orgs
+    received_events_url: https://api.github.com/users/sayanchowdhury/received_events
+    repos_url: https://api.github.com/users/sayanchowdhury/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/sayanchowdhury/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/sayanchowdhury/subscriptions
+    type: User
+    url: https://api.github.com/users/sayanchowdhury
+  body: "**Security fixes**\r\n\r\n\r\n\r\n*   Linux ([CVE-2021-28375](https://nvd.nist.gov/vuln/detail/CVE-2021-28375),\
+    \ [CVE-2021-28660](https://nvd.nist.gov/vuln/detail/CVE-2021-28660), [CVE-2021-27363](https://nvd.nist.gov/vuln/detail/CVE-2021-27363),\
+    \ [CVE-2021-27365](https://nvd.nist.gov/vuln/detail/CVE-2021-27365), [CVE-2021-28038](https://nvd.nist.gov/vuln/detail/CVE-2021-28038),\
+    \ [CVE-2021-27364](https://nvd.nist.gov/vuln/detail/CVE-2021-27364), [CVE-2020-25639](https://nvd.nist.gov/vuln/detail/CVE-2020-25639))\r\
+    \n*   openssl ([CVE-2021-23840](https://nvd.nist.gov/vuln/detail/CVE-2021-23840),[\
+    \ CVE-2021-23841](https://nvd.nist.gov/vuln/detail/CVE-2021-23841), [CVE-2020-1971](https://nvd.nist.gov/vuln/detail/CVE-2020-1971),[\
+    \ CVE-2021-23840](https://nvd.nist.gov/vuln/detail/CVE-2021-23840),[ CVE-2021-23841](https://nvd.nist.gov/vuln/detail/CVE-2021-23841),\
+    \ [CVE-2021-3449](https://nvd.nist.gov/vuln/detail/CVE-2021-3449),[ CVE-2021-3450](https://nvd.nist.gov/vuln/detail/CVE-2021-3450))\r\
+    \n\r\n**Updates**\r\n\r\n\r\n\r\n*   Linux ([5.4.107](https://lwn.net/Articles/849952/))\r\
+    \n*   openssl ([1.1.1k](https://mta.openssl.org/pipermail/openssl-announce/2021-March/000197.html))\r\
+    \n*   open-iscsi ([2.1.4](https://github.com/open-iscsi/open-iscsi/releases/tag/2.1.4))\r\
+    \n*   containerd ([1.4.4](https://github.com/containerd/containerd/releases/tag/v1.4.4))"
+  created_at: '2021-03-24T11:43:35Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2605.14.1
+  id: 40424260
+  name: v2605.14.1
+  node_id: MDc6UmVsZWFzZTQwNDI0MjYw
+  prerelease: false
+  published_at: '2021-03-25T15:40:57Z'
+  tag_name: v2605.14.1
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2605.14.1
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/40424260/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/40424260
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2605.14.1
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.4.107
+  systemd: '246'
+release: 2605.14.1
+version: 2605.14.1

--- a/data/releases/lts/2605.16.1.yml
+++ b/data/releases/lts/2605.16.1.yml
@@ -1,0 +1,50 @@
+architectures:
+- amd64
+channel: lts
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/43208781/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/10096906?v=4
+    events_url: https://api.github.com/users/dongsupark/events{/privacy}
+    followers_url: https://api.github.com/users/dongsupark/followers
+    following_url: https://api.github.com/users/dongsupark/following{/other_user}
+    gists_url: https://api.github.com/users/dongsupark/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/dongsupark
+    id: 10096906
+    login: dongsupark
+    node_id: MDQ6VXNlcjEwMDk2OTA2
+    organizations_url: https://api.github.com/users/dongsupark/orgs
+    received_events_url: https://api.github.com/users/dongsupark/received_events
+    repos_url: https://api.github.com/users/dongsupark/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/dongsupark/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/dongsupark/subscriptions
+    type: User
+    url: https://api.github.com/users/dongsupark
+  body: "**Security fixes**\r\n\r\n*   Linux ([CVE-2021-31829](https://nvd.nist.gov/vuln/detail/CVE-2021-31829))\r\
+    \n*   runc ([CVE-2021-30465](https://nvd.nist.gov/vuln/detail/CVE-2021-30465))\r\
+    \n\r\n**Updates**\r\n\r\n*   Linux ([5.4.119](https://lwn.net/Articles/856270/))\r\
+    \n*   systemd ([246.13](https://github.com/systemd/systemd-stable/releases/tag/v246.13))"
+  created_at: '2021-05-17T18:46:43Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2605.16.1
+  id: 43208781
+  name: v2605.16.1
+  node_id: MDc6UmVsZWFzZTQzMjA4Nzgx
+  prerelease: false
+  published_at: '2021-05-19T11:36:59Z'
+  tag_name: v2605.16.1
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2605.16.1
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/43208781/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/43208781
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2605.16.1
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.4.119
+  systemd: '246'
+release: 2605.16.1
+version: 2605.16.1

--- a/data/releases/lts/2605.17.1.yml
+++ b/data/releases/lts/2605.17.1.yml
@@ -1,0 +1,53 @@
+architectures:
+- amd64
+channel: lts
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/44785824/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/500628?v=4
+    events_url: https://api.github.com/users/sayanchowdhury/events{/privacy}
+    followers_url: https://api.github.com/users/sayanchowdhury/followers
+    following_url: https://api.github.com/users/sayanchowdhury/following{/other_user}
+    gists_url: https://api.github.com/users/sayanchowdhury/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/sayanchowdhury
+    id: 500628
+    login: sayanchowdhury
+    node_id: MDQ6VXNlcjUwMDYyOA==
+    organizations_url: https://api.github.com/users/sayanchowdhury/orgs
+    received_events_url: https://api.github.com/users/sayanchowdhury/received_events
+    repos_url: https://api.github.com/users/sayanchowdhury/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/sayanchowdhury/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/sayanchowdhury/subscriptions
+    type: User
+    url: https://api.github.com/users/sayanchowdhury
+  body: "\r\n**Security fixes**\r\n\r\n\r\n\r\n*   Linux ([CVE-2020-26558](https://nvd.nist.gov/vuln/detail/CVE-2020-26558),\
+    \ [CVE-2021-0129](https://nvd.nist.gov/vuln/detail/CVE-2021-0129), [CVE-2020-24587](https://nvd.nist.gov/vuln/detail/CVE-2020-24587),\
+    \ [CVE-2020-24586](https://nvd.nist.gov/vuln/detail/CVE-2020-24586), [CVE-2020-24588](https://nvd.nist.gov/vuln/detail/CVE-2020-24588),\
+    \ [CVE-2020-26139](https://nvd.nist.gov/vuln/detail/CVE-2020-26139), [CVE-2020-26145](https://nvd.nist.gov/vuln/detail/CVE-2020-26145),\
+    \ [CVE-2020-26141](https://nvd.nist.gov/vuln/detail/CVE-2020-26141), [CVE-2021-3564](https://nvd.nist.gov/vuln/detail/CVE-2021-3564),\
+    \ [CVE-2021-3587](https://nvd.nist.gov/vuln/detail/CVE-2021-3587), [CVE-2021-3573](https://nvd.nist.gov/vuln/detail/CVE-2021-3573))\r\
+    \n\r\n**Updates**\r\n\r\n\r\n\r\n*   Linux ([5.4.125](https://lwn.net/Articles/859023/))"
+  created_at: '2021-06-15T16:07:00Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2605.17.1
+  id: 44785824
+  name: v2605.17.1
+  node_id: MDc6UmVsZWFzZTQ0Nzg1ODI0
+  prerelease: false
+  published_at: '2021-06-17T10:32:57Z'
+  tag_name: v2605.17.1
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2605.17.1
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/44785824/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/44785824
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2605.17.1
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.4.125
+  systemd: '246'
+release: 2605.17.1
+version: 2605.17.1

--- a/data/releases/stable/2765.2.1.yml
+++ b/data/releases/stable/2765.2.1.yml
@@ -1,0 +1,58 @@
+architectures:
+- amd64
+channel: stable
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/39641249/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/10096906?v=4
+    events_url: https://api.github.com/users/dongsupark/events{/privacy}
+    followers_url: https://api.github.com/users/dongsupark/followers
+    following_url: https://api.github.com/users/dongsupark/following{/other_user}
+    gists_url: https://api.github.com/users/dongsupark/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/dongsupark
+    id: 10096906
+    login: dongsupark
+    node_id: MDQ6VXNlcjEwMDk2OTA2
+    organizations_url: https://api.github.com/users/dongsupark/orgs
+    received_events_url: https://api.github.com/users/dongsupark/received_events
+    repos_url: https://api.github.com/users/dongsupark/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/dongsupark/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/dongsupark/subscriptions
+    type: User
+    url: https://api.github.com/users/dongsupark
+  body: "**Security fixes**\r\n\r\n*   Linux - ([CVE-2020-25639](https://nvd.nist.gov/vuln/detail/CVE-2020-25639),\
+    \ [CVE-2021-27365](https://nvd.nist.gov/vuln/detail/CVE-2021-27365), [CVE-2021-27364](https://nvd.nist.gov/vuln/detail/CVE-2021-27364),\
+    \ [CVE-2021-27363](https://nvd.nist.gov/vuln/detail/CVE-2021-27363), [CVE-2021-28038](https://nvd.nist.gov/vuln/detail/CVE-2021-28038),\
+    \ [CVE-2021-28039](https://nvd.nist.gov/vuln/detail/CVE-2021-28039))\r\n*   containerd\
+    \ ([GHSA-6g2q-w5j3-fwh4](https://github.com/containerd/containerd/security/advisories/GHSA-6g2q-w5j3-fwh4))\r\
+    \n\r\n**Bug fixes**\r\n\r\n*   Include firmware files for all modules shipped\
+    \ in our image ([Issue #359](https://github.com/kinvolk/Flatcar/issues/359), [PR\
+    \ #887](https://github.com/kinvolk/coreos-overlay/pull/887))\r\n*   Add explicit\
+    \ path to the binary call in the coreos-metadata unit file ([Issue #360](https://github.com/kinvolk/Flatcar/issues/360))\r\
+    \n\r\n**Updates**\r\n\r\n*   Linux ([5.10.21](https://lwn.net/Articles/848617/))\r\
+    \n*   Containerd ([1.4.4](https://github.com/containerd/containerd/releases/tag/v1.4.4))\r\
+    \n\r\n"
+  created_at: '2021-03-09T16:07:19Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2765.2.1
+  id: 39641249
+  name: v2765.2.1
+  node_id: MDc6UmVsZWFzZTM5NjQxMjQ5
+  prerelease: false
+  published_at: '2021-03-11T09:19:31Z'
+  tag_name: v2765.2.1
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2765.2.1
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/39641249/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/39641249
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2765.2.1
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.21
+  systemd: '247'
+release: 2765.2.1
+version: 2765.2.1

--- a/data/releases/stable/2765.2.2.yml
+++ b/data/releases/stable/2765.2.2.yml
@@ -1,0 +1,66 @@
+architectures:
+- amd64
+channel: stable
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/40424165/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/500628?v=4
+    events_url: https://api.github.com/users/sayanchowdhury/events{/privacy}
+    followers_url: https://api.github.com/users/sayanchowdhury/followers
+    following_url: https://api.github.com/users/sayanchowdhury/following{/other_user}
+    gists_url: https://api.github.com/users/sayanchowdhury/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/sayanchowdhury
+    id: 500628
+    login: sayanchowdhury
+    node_id: MDQ6VXNlcjUwMDYyOA==
+    organizations_url: https://api.github.com/users/sayanchowdhury/orgs
+    received_events_url: https://api.github.com/users/sayanchowdhury/received_events
+    repos_url: https://api.github.com/users/sayanchowdhury/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/sayanchowdhury/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/sayanchowdhury/subscriptions
+    type: User
+    url: https://api.github.com/users/sayanchowdhury
+  body: "**Security fixes**\r\n\r\n\r\n\r\n*   Linux ([CVE-2021-27365](https://nvd.nist.gov/vuln/detail/CVE-2021-27365),\
+    \ [CVE-2021-27364](https://nvd.nist.gov/vuln/detail/CVE-2021-27364), [CVE-2021-27363](https://nvd.nist.gov/vuln/detail/CVE-2021-27363),\
+    \ [CVE-2021-28038](https://nvd.nist.gov/vuln/detail/CVE-2021-28038),[CVE-2021-28039](https://nvd.nist.gov/vuln/detail/CVE-2021-28039),\
+    \ [CVE-2021-28375](https://nvd.nist.gov/vuln/detail/CVE-2021-28375), [CVE-2021-28660](https://nvd.nist.gov/vuln/detail/CVE-2021-28660),\
+    \ [CVE-2021-27218](https://nvd.nist.gov/vuln/detail/CVE-2021-27218), [CVE-2021-27219](https://nvd.nist.gov/vuln/detail/CVE-2021-27219))\r\
+    \n*   openssl ([CVE-2021-23840](https://nvd.nist.gov/vuln/detail/CVE-2021-23840),[\
+    \ CVE-2021-23841](https://nvd.nist.gov/vuln/detail/CVE-2021-23841), [CVE-2020-1971](https://nvd.nist.gov/vuln/detail/CVE-2020-1971),[\
+    \ CVE-2021-23840](https://nvd.nist.gov/vuln/detail/CVE-2021-23840),[ CVE-2021-23841](https://nvd.nist.gov/vuln/detail/CVE-2021-23841),\
+    \ [CVE-2021-3449](https://nvd.nist.gov/vuln/detail/CVE-2021-3449),[ CVE-2021-3450](https://nvd.nist.gov/vuln/detail/CVE-2021-3450))\r\
+    \n\r\n**Bug Fixes**\r\n\r\n\r\n\r\n*   GCE: The old interface name ens4v1 which\
+    \ was replaced by eth0 due to a broken udev rule was restored, but now as alternative\
+    \ interface name, and eth0 will stay the primary name for consistency across cloud\
+    \ environments. ([init#38](https://github.com/kinvolk/init/pull/38))\r\n\r\n**Changes**\r\
+    \n\r\n\r\n\r\n*   The virtio network interfaces got predictable interface names\
+    \ as alternative interface names, and thus these names can also be used to match\
+    \ for a specific interface in case there is more than one and the eth0 and eth1\
+    \ name assignment is not stable. ([init#38](https://github.com/kinvolk/init/pull/38))\r\
+    \n\r\n**Updates**\r\n\r\n\r\n\r\n*   Linux ([5.10.25](https://lwn.net/Articles/849951/))\r\
+    \n*   openssl ([1.1.1k](https://mta.openssl.org/pipermail/openssl-announce/2021-March/000197.html))\r\
+    \n*   open-iscsi ([2.1.4](https://github.com/open-iscsi/open-iscsi/releases/tag/2.1.4))"
+  created_at: '2021-03-24T11:44:39Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2765.2.2
+  id: 40424165
+  name: v2765.2.2
+  node_id: MDc6UmVsZWFzZTQwNDI0MTY1
+  prerelease: false
+  published_at: '2021-03-25T15:39:33Z'
+  tag_name: v2765.2.2
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2765.2.2
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/40424165/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/40424165
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2765.2.2
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.25
+  systemd: '247'
+release: 2765.2.2
+version: 2765.2.2

--- a/data/releases/stable/2765.2.4.yml
+++ b/data/releases/stable/2765.2.4.yml
@@ -1,0 +1,54 @@
+architectures:
+- amd64
+channel: stable
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/43208845/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/10096906?v=4
+    events_url: https://api.github.com/users/dongsupark/events{/privacy}
+    followers_url: https://api.github.com/users/dongsupark/followers
+    following_url: https://api.github.com/users/dongsupark/following{/other_user}
+    gists_url: https://api.github.com/users/dongsupark/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/dongsupark
+    id: 10096906
+    login: dongsupark
+    node_id: MDQ6VXNlcjEwMDk2OTA2
+    organizations_url: https://api.github.com/users/dongsupark/orgs
+    received_events_url: https://api.github.com/users/dongsupark/received_events
+    repos_url: https://api.github.com/users/dongsupark/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/dongsupark/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/dongsupark/subscriptions
+    type: User
+    url: https://api.github.com/users/dongsupark
+  body: "**Security fixes**\r\n\r\n*   Linux ([CVE-2021-3491](https://nvd.nist.gov/vuln/detail/CVE-2021-3491),\
+    \ [CVE-2021-31440](https://nvd.nist.gov/vuln/detail/CVE-2021-31440), [CVE-2021-31829](https://nvd.nist.gov/vuln/detail/CVE-2021-31829))\r\
+    \n*   nvidia-drivers ([CVE-2021-1052](https://nvd.nist.gov/vuln/detail/CVE-2021-1052),\
+    \ [CVE-2021-1053](https://nvd.nist.gov/vuln/detail/CVE-2021-1053), [CVE-2021-1056](https://nvd.nist.gov/vuln/detail/CVE-2021-1056),\
+    \ [CVE-2021-1076](https://nvd.nist.gov/vuln/detail/CVE-2021-1076), [CVE-2021-1077](https://nvd.nist.gov/vuln/detail/CVE-2021-1077))\r\
+    \n*   runc ([CVE-2021-30465](https://nvd.nist.gov/vuln/detail/CVE-2021-30465))\r\
+    \n\r\n**Updates**\r\n\r\n*   Linux ([5.10.37](https://lwn.net/Articles/856269/))\r\
+    \n*   nvidia-drivers ([460.73.01](https://www.nvidia.com/Download/driverResults.aspx/172376/en-us))"
+  created_at: '2021-05-17T18:47:33Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2765.2.4
+  id: 43208845
+  name: v2765.2.4
+  node_id: MDc6UmVsZWFzZTQzMjA4ODQ1
+  prerelease: false
+  published_at: '2021-05-19T11:38:16Z'
+  tag_name: v2765.2.4
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2765.2.4
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/43208845/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/43208845
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2765.2.4
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.37
+  systemd: '247'
+release: 2765.2.4
+version: 2765.2.4

--- a/data/releases/stable/2765.2.5.yml
+++ b/data/releases/stable/2765.2.5.yml
@@ -1,0 +1,50 @@
+architectures:
+- amd64
+channel: stable
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/43348332/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/1189130?v=4
+    events_url: https://api.github.com/users/pothos/events{/privacy}
+    followers_url: https://api.github.com/users/pothos/followers
+    following_url: https://api.github.com/users/pothos/following{/other_user}
+    gists_url: https://api.github.com/users/pothos/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/pothos
+    id: 1189130
+    login: pothos
+    node_id: MDQ6VXNlcjExODkxMzA=
+    organizations_url: https://api.github.com/users/pothos/orgs
+    received_events_url: https://api.github.com/users/pothos/received_events
+    repos_url: https://api.github.com/users/pothos/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/pothos/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/pothos/subscriptions
+    type: User
+    url: https://api.github.com/users/pothos
+  body: "**Bug fixes**\r\n\r\n*   The Linux kernel IOMMU-related crash introduced\
+    \ in the 5.10.37 update got fixed through the 5.10.38 update ([Flatcar#400](https://github.com/kinvolk/Flatcar/issues/400))\r\
+    \n\r\n**Updates**\r\n\r\n*   Linux ([5.10.38](https://lwn.net/Articles/856654/))\r\
+    \n"
+  created_at: '2021-05-20T18:12:17Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2765.2.5
+  id: 43348332
+  name: v2765.2.5
+  node_id: MDc6UmVsZWFzZTQzMzQ4MzMy
+  prerelease: false
+  published_at: '2021-05-21T12:08:45Z'
+  tag_name: v2765.2.5
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2765.2.5
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/43348332/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/43348332
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2765.2.5
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.38
+  systemd: '247'
+release: 2765.2.5
+version: 2765.2.5

--- a/data/releases/stable/2765.2.6.yml
+++ b/data/releases/stable/2765.2.6.yml
@@ -1,0 +1,61 @@
+architectures:
+- amd64
+channel: stable
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/44785772/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/500628?v=4
+    events_url: https://api.github.com/users/sayanchowdhury/events{/privacy}
+    followers_url: https://api.github.com/users/sayanchowdhury/followers
+    following_url: https://api.github.com/users/sayanchowdhury/following{/other_user}
+    gists_url: https://api.github.com/users/sayanchowdhury/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/sayanchowdhury
+    id: 500628
+    login: sayanchowdhury
+    node_id: MDQ6VXNlcjUwMDYyOA==
+    organizations_url: https://api.github.com/users/sayanchowdhury/orgs
+    received_events_url: https://api.github.com/users/sayanchowdhury/received_events
+    repos_url: https://api.github.com/users/sayanchowdhury/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/sayanchowdhury/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/sayanchowdhury/subscriptions
+    type: User
+    url: https://api.github.com/users/sayanchowdhury
+  body: "\r\n**Security fixes**\r\n\r\n\r\n\r\n*   Linux ([CVE-2020-26558](https://nvd.nist.gov/vuln/detail/CVE-2020-26558),\
+    \ [CVE-2021-0129](https://nvd.nist.gov/vuln/detail/CVE-2021-0129), [CVE-2020-24587](https://nvd.nist.gov/vuln/detail/CVE-2020-24587),\
+    \ [CVE-2020-24586](https://nvd.nist.gov/vuln/detail/CVE-2020-24586), [CVE-2020-24588](https://nvd.nist.gov/vuln/detail/CVE-2020-24588),\
+    \ [CVE-2020-26139](https://nvd.nist.gov/vuln/detail/CVE-2020-26139), [CVE-2020-26145](https://nvd.nist.gov/vuln/detail/CVE-2020-26145),\
+    \ [CVE-2020-26147](https://nvd.nist.gov/vuln/detail/CVE-2020-26147), [CVE-2020-26141](https://nvd.nist.gov/vuln/detail/CVE-2020-26141),\
+    \ [CVE-2021-3564](https://nvd.nist.gov/vuln/detail/CVE-2021-3564), [CVE-2021-28691](https://nvd.nist.gov/vuln/detail/CVE-2021-28691),\
+    \ [CVE-2021-3587](https://nvd.nist.gov/vuln/detail/CVE-2021-3587), [CVE-2021-3573](https://nvd.nist.gov/vuln/detail/CVE-2021-3573))\r\
+    \n\r\n**Bug fixes**\r\n\r\n\r\n\r\n*   Update-engine sent empty requests when\
+    \ restarted before a pending reboot ([Flatcar#388](https://github.com/kinvolk/Flatcar/issues/388))\r\
+    \n*   motd login prompt list of failed services: The output of \"systemctl list-units\
+    \ --state=failed --no-legend\" contains a bullet point which is not expected and\
+    \ ended up being taken as the unit name of failed units which was previously on\
+    \ the start of the line. Filtered the bullet point out to stay compatible with\
+    \ the old behavior in case upstream would remove the bullet point again. ([coreos-overlay#1042](https://github.com/kinvolk/coreos-overlay/pull/1042))\r\
+    \n\r\n**Updates**\r\n\r\n\r\n\r\n*   Linux ([5.10.43](https://lwn.net/Articles/859022/))"
+  created_at: '2021-06-15T16:10:15Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2765.2.6
+  id: 44785772
+  name: v2765.2.6
+  node_id: MDc6UmVsZWFzZTQ0Nzg1Nzcy
+  prerelease: false
+  published_at: '2021-06-17T10:32:06Z'
+  tag_name: v2765.2.6
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2765.2.6
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/44785772/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/44785772
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2765.2.6
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.43
+  systemd: '247'
+release: 2765.2.6
+version: 2765.2.6

--- a/data/releases/stable/2905.2.0.yml
+++ b/data/releases/stable/2905.2.0.yml
@@ -1,0 +1,170 @@
+architectures:
+- amd64
+channel: stable
+github_release:
+  assets: []
+  assets_url: https://api.github.com/repos/kinvolk/manifest/releases/46887392/assets
+  author:
+    avatar_url: https://avatars.githubusercontent.com/u/500628?v=4
+    events_url: https://api.github.com/users/sayanchowdhury/events{/privacy}
+    followers_url: https://api.github.com/users/sayanchowdhury/followers
+    following_url: https://api.github.com/users/sayanchowdhury/following{/other_user}
+    gists_url: https://api.github.com/users/sayanchowdhury/gists{/gist_id}
+    gravatar_id: ''
+    html_url: https://github.com/sayanchowdhury
+    id: 500628
+    login: sayanchowdhury
+    node_id: MDQ6VXNlcjUwMDYyOA==
+    organizations_url: https://api.github.com/users/sayanchowdhury/orgs
+    received_events_url: https://api.github.com/users/sayanchowdhury/received_events
+    repos_url: https://api.github.com/users/sayanchowdhury/repos
+    site_admin: false
+    starred_url: https://api.github.com/users/sayanchowdhury/starred{/owner}{/repo}
+    subscriptions_url: https://api.github.com/users/sayanchowdhury/subscriptions
+    type: User
+    url: https://api.github.com/users/sayanchowdhury
+  body: "_Changes since **Beta 2905.1.0**_\r\n\r\n**Security Fixes**\r\n\r\n\r\n\r\
+    \n* containerd ([CVE-2021-32760](https://nvd.nist.gov/vuln/detail/CVE-2021-32760))\r\
+    \n* curl (CVE-2021-22922, CVE-2021-22923, CVE-2021-22924, CVE-2021-22925, CVE-2021-22926)\r\
+    \n* linux ([CVE-2020-26541](https://nvd.nist.gov/vuln/detail/CVE-2020-26541),\
+    \ [CVE-2021-35039](https://nvd.nist.gov/vuln/detail/CVE-2021-35039), [CVE-2021-22543](https://nvd.nist.gov/vuln/detail/CVE-2021-22543),\
+    \ CVE-2021-3609, CVE-2021-3655, [CVE-2021-33909](https://nvd.nist.gov/vuln/detail/CVE-2021-33909))\r\
+    \n\r\n**Updates**\r\n\r\n\r\n\r\n* Linux ([5.10.52](https://lwn.net/Articles/863648/))\r\
+    \n* curl ([7.78](https://curl.se/changes.html#7_78_0))\r\n* containerd ([1.5.4](https://github.com/containerd/containerd/releases/tag/v1.5.4))\r\
+    \n\r\n_Changes since **Stable 2765.2.6**_\r\n\r\n**Security Fixes:**\r\n\r\n\r\
+    \n\r\n* Linux ([CVE-2020-26541](https://nvd.nist.gov/vuln/detail/CVE-2020-26541),\
+    \ [CVE-2021-35039](https://nvd.nist.gov/vuln/detail/CVE-2021-35039), [CVE-2021-22543](https://nvd.nist.gov/vuln/detail/CVE-2021-22543),\
+    \ CVE-2021-3609, CVE-2021-3655, [CVE-2021-33909](https://nvd.nist.gov/vuln/detail/CVE-2021-33909),\
+    \ [CVE-2021-34693](https://nvd.nist.gov/vuln/detail/CVE-2021-34693), [CVE-2021-33624](https://nvd.nist.gov/vuln/detail/CVE-2021-33624))\r\
+    \n* containerd ([CVE-2021-32760](https://nvd.nist.gov/vuln/detail/CVE-2021-32760))\r\
+    \n* curl (CVE-2021-22922, CVE-2021-22923, CVE-2021-22924, CVE-2021-22925, CVE-2021-22926)\r\
+    \n* boost ([CVE-2012-2677](https://nvd.nist.gov/vuln/detail/CVE-2012-2677))\r\n\
+    * Docker ([CVE-2021-21285](https://nvd.nist.gov/vuln/detail/CVE-2021-21285),[\
+    \ CVE-2021-21284](https://nvd.nist.gov/vuln/detail/CVE-2021-21284))\r\n* c-ares\
+    \ ([CVE-2020-8277](https://nvd.nist.gov/vuln/detail/CVE-2020-8277))\r\n* coreutils\
+    \ ([CVE-2017-7476](https://nvd.nist.gov/vuln/detail/CVE-2017-7476))\r\n* dbus\
+    \ ([CVE-2020-35512](https://nvd.nist.gov/vuln/detail/CVE-2020-35512))\r\n* dnsmasq\
+    \ ([CVE-2020-25681](https://nvd.nist.gov/vuln/detail/CVE-2020-25681),[ CVE-2020-25682](https://nvd.nist.gov/vuln/detail/CVE-2020-25682),[\
+    \ CVE-2020-25683](https://nvd.nist.gov/vuln/detail/CVE-2020-25683),[ CVE-2020-25684](https://nvd.nist.gov/vuln/detail/CVE-2020-25683),[\
+    \ CVE-2020-25685](https://nvd.nist.gov/vuln/detail/CVE-2020-25685),[ CVE-2020-25686](https://nvd.nist.gov/vuln/detail/CVE-2020-25686),[\
+    \ CVE-2020-25687](https://nvd.nist.gov/vuln/detail/CVE-2020-25687))\r\n* git ([CVE-2021-21300](https://nvd.nist.gov/vuln/detail/CVE-2021-21300))\r\
+    \n* glib ([CVE-2021-28153](https://nvd.nist.gov/vuln/detail/CVE-2021-28153),[\
+    \ CVE-2021-27218](https://nvd.nist.gov/vuln/detail/CVE-2021-27218),[ CVE-2021-27219](https://nvd.nist.gov/vuln/detail/CVE-2021-27219))\r\
+    \n* gnutls ([CVE-2021-20231](https://nvd.nist.gov/vuln/detail/CVE-2021-20231),[\
+    \ CVE-2021-20232](https://nvd.nist.gov/vuln/detail/CVE-2021-20232))\r\n* intel-microcode\
+    \ ([CVE-2020-8696](https://nvd.nist.gov/vuln/detail/CVE-2020-8696),[ CVE-2020-8698](https://nvd.nist.gov/vuln/detail/CVE-2020-8698))\r\
+    \n* libxml2 ([CVE-2021-3516](https://nvd.nist.gov/vuln/detail/CVE-2021-3516),[CVE-2021-3517](https://nvd.nist.gov/vuln/detail/CVE-2021-3517),[CVE-2021-3518](https://nvd.nist.gov/vuln/detail/CVE-2021-3518),CVE-2021-3541)\r\
+    \n* ncurses ([CVE-2019-17594](https://nvd.nist.gov/vuln/detail/CVE-2019-17594),[\
+    \ CVE-2019-17595](https://nvd.nist.gov/vuln/detail/CVE-2019-17595))\r\n* openldap\
+    \ ([CVE-2020-36221](https://nvd.nist.gov/vuln/detail/CVE-2020-36221),[ CVE-2020-36222](https://nvd.nist.gov/vuln/detail/CVE-2020-36222),[\
+    \ CVE-2020-36223](https://nvd.nist.gov/vuln/detail/CVE-2020-36223),[ CVE-2020-36224](https://nvd.nist.gov/vuln/detail/-2020-36224),[\
+    \ CVE-2020-36225](https://nvd.nist.gov/vuln/detail/CVE-2020-36225),[ CVE-2020-36226](https://nvd.nist.gov/vuln/detail/CVE-2020-36226),[\
+    \ CVE-2020-36227](https://nvd.nist.gov/vuln/detail/CVE-2020-36227),[ CVE-2020-36228](https://nvd.nist.gov/vuln/detail/CVE-2020-36228),[\
+    \ CVE-2020-36229](https://nvd.nist.gov/vuln/detail/CVE-2020-36229),[ CVE-2020-36230](https://nvd.nist.gov/vuln/detail/CVE-2020-36230))\r\
+    \n* samba ([CVE-2020-14318](https://nvd.nist.gov/vuln/detail/CVE-2020-14318),[\
+    \ CVE-2020-14323](https://nvd.nist.gov/vuln/detail/CVE-2020-14323),[ CVE-2020-14383](https://nvd.nist.gov/vuln/detail/CVE-2020-14383))\r\
+    \n* sqlite ([CVE-2021-20227](https://nvd.nist.gov/vuln/detail/CVE-2021-20227))\r\
+    \n* binutils ([CVE-2021-20197](https://nvd.nist.gov/vuln/detail/CVE-2021-20197),[CVE-2021-3487](https://nvd.nist.gov/vuln/detail/CVE-2021-3487))\r\
+    \n\r\n**Bug Fixes:**\r\n\r\n\r\n\r\n* passwd: use correct GID for tss ([baselayout#15](https://github.com/kinvolk/baselayout/pull/15))\r\
+    \n* flatcar-eks: add missing mkdir and update to latest versions ([coreos-overlay#817](https://github.com/kinvolk/coreos-overlay/pull/817))\r\
+    \n* gmerge: Stop installing gmerge script ([coreos-overlay#828](https://github.com/kinvolk/coreos-overlay/pull/828))\r\
+    \n* Add explicit path to the binary call in the coreos-metadata unit file ([Issue\
+    \ #360](https://github.com/kinvolk/Flatcar/issues/360))\r\n* Fix the patch to\
+    \ update DefaultTasksMax in systemd ([coreos-overlay#971](https://github.com/kinvolk/coreos-overlay/pull/971))\r\
+    \n\r\n**Changes**\r\n\r\n\r\n\r\n* Docker: disabled SELinux support in the Docker\
+    \ daemon\r\n* The pam_faillock PAM module was enabled as replacement for the removed\
+    \ pam_tally2 module and will temporarily lock an account if there were login attempts\
+    \ with a wrong password. The faillock command can be used to show the current\
+    \ state. With pam_tally2 there was no limit for wrong password login attempts\
+    \ but with faillock the default is already restricting the attempts. The default\
+    \ behavior was relaxed to allow 5 wrong passwords per two minutes, and a one minute\
+    \ account lock time. This does not apply to logins with an SSH key. ([baselayout#17](https://github.com/kinvolk/baselayout/pull/17))\r\
+    \n* The etcd and flannel services are now run with Docker and any rkt-based customizations\
+    \ of the etcd-member and flanneld services not supported anymore. Also, because\
+    \ the flanneld service relies on Docker and will restart Docker after applying\
+    \ the new configuration, it is not possible anymore to set Requires=flanneld.service\
+    \ for docker.service and instead it\u2019s enough to have flanneld.service enabled.\
+    \ ([coreos-overlay#857](https://github.com/kinvolk/coreos-overlay/pull/857))\r\
+    \n* toolbox: replace rkt with docker ([coreos-overlay#881](https://github.com/kinvolk/coreos-overlay/pull/881))\r\
+    \n* flatcar-install: add parameters to make wget more resilient ([init#35](https://github.com/kinvolk/init/pull/35))\r\
+    \n* flatcar-install: Add -D flag to only download the image file ([Flatcar#248](https://github.com/kinvolk/Flatcar/issues/248))\r\
+    \n* flatcar-install: Detect device mapper (e.g., LVM/LUKS) usage when searching\
+    \ for free drives with the -s flag ([Flatcar#332](https://github.com/kinvolk/Flatcar/issues/332))\r\
+    \n* motd: Add OEM information to motd output ([init#34](https://github.com/kinvolk/init/pull/34))\r\
+    \n* open-iscsi: Command substitution in iscsi-init system service ([coreos-overlay#801](https://github.com/kinvolk/coreos-overlay/pull/801))\r\
+    \n* sshd: use secure crypto algos only ([kinvolk/coreos-overlay#852](https://github.com/kinvolk/coreos-overlay/pull/852))\r\
+    \n* kernel: enable kernel config CONFIG_BPF_LSM ([kinvolk/coreos-overlay#846](https://github.com/kinvolk/coreos-overlay/pull/846))\r\
+    \n* bootengine: set hostname for EC2 and OpenStack from metadata ([kinvolk/coreos-overlay#848](https://github.com/kinvolk/coreos-overlay/pull/848))\r\
+    \n* Make the hostname setting units optional. Having the hostname units as required\
+    \ by the initrd.target meant that if the unit failed the machine wouldn\u2019\
+    t start, disrupting the whole boot. ([bootengine#23](https://github.com/kinvolk/bootengine/pull/23))\r\
+    \n* Enable using iSCSI netroot devices on Flatcar ([bootengine#22](https://github.com/kinvolk/bootengine/pull/22))\r\
+    \n* systemd-networkd: Do not manage loopback network interface ([bootengine#24\
+    \ init#40](https://github.com/kinvolk/bootengine/pull/24))\r\n* containerd: Removed\
+    \ the containerd-stress binary ([coreos-overlay#858](https://github.com/kinvolk/coreos-overlay/pull/858))\r\
+    \n* dhcpcd: Removed the dhcpcd binary from the image, systemd-networkd is the\
+    \ only DHCP client ([coreos-overlay#858](https://github.com/kinvolk/coreos-overlay/pull/858))\r\
+    \n* samba: Update to EAPI=7, add new USE flags and remove deps on icu ([kinvolk/coreos-overlay#864](https://github.com/kinvolk/coreos-overlay/pull/864))\r\
+    \n* GCE: The oem-gce.service was ported to use systemd-nspawn instead of rkt.\
+    \ A one-time action is required to fetch the new service file because the OEM\
+    \ partition is not updated: sudo curl -s -S -f -L -o /etc/systemd/system/oem-gce.service\
+    \ https://raw.githubusercontent.com/kinvolk/coreos-overlay/fe7b0047ef5b634ebe04c9627bbf1ce3008ee5fa/coreos-base/oem-gce/files/units/oem-gce.service\
+    \ && sudo systemctl daemon-reload && sudo systemctl restart oem-gce.service\r\n\
+    * SDK: update portage and related packages to newer versions ([coreos-overlay#840](https://github.com/kinvolk/coreos-overlay/pull/840))\r\
+    \n* SDK: Drop jobs parameter in flatcar-scripts ([flatcar-scripts#121](https://github.com/kinvolk/flatcar-scripts/pull/121))\r\
+    \n* SDK: delete Go 1.6 ([coreos-overlay#827](https://github.com/kinvolk/coreos-overlay/pull/827))\r\
+    \n* Update sys-apps/coreutils and make sure they have split-usr disabled for generic\
+    \ images ([coreos-overlay#829](https://github.com/kinvolk/coreos-overlay/pull/829))\r\
+    \n* systemd: Fix unit installation ([coreos-overlay#810](https://github.com/kinvolk/coreos-overlay/pull/810))\r\
+    \n\r\n**Updates**\r\n\r\n\r\n\r\n* Linux ([5.10.52](https://lwn.net/Articles/863648/))\r\
+    \n* Linux firmware ([20210511](https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git/tag/?h=20210511))\r\
+    \n* boost ([1.75.0](https://www.boost.org/users/history/version_1_75_0.html))\r\
+    \n* docker ([19.03.15](https://docs.docker.com/engine/release-notes/19.03/#190315))\r\
+    \n* c-ares ([1.17.1](https://c-ares.haxx.se/changelog.html#1_17_1))\r\n* curl\
+    \ ([7.78](https://curl.se/changes.html#7_78_0))\r\n* containerd ([1.5.4](https://github.com/containerd/containerd/releases/tag/v1.5.4))\r\
+    \n* coreutils ([8.32](https://git.savannah.gnu.org/cgit/coreutils.git/tree/NEWS?h=v8.32))\r\
+    \n* cri-tools ([1.19.0](https://github.com/kubernetes-sigs/cri-tools/releases/tag/v1.19.0))\r\
+    \n* dbus ([1.10.32](https://lists.freedesktop.org/archives/ftp-release/2020-July/000759.html))\r\
+    \n* dnsmasq ([2.83](https://thekelleys.org.uk/dnsmasq/CHANGELOG))\r\n* go ([1.16.5](https://go.googlesource.com/go/+/refs/tags/go1.16.5))\r\
+    \n* git ([2.26.3](https://raw.githubusercontent.com/git/git/v2.26.3/Documentation/RelNotes/2.26.3.txt))\r\
+    \n* glib ([2.66.8](https://gitlab.gnome.org/GNOME/glib/-/releases/2.66.8))\r\n\
+    * gnutls ([3.7.1](https://gitlab.com/gnutls/gnutls/-/tags/3.7.1))\r\n* intel-microcode\
+    \ ([20210216](https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases/tag/microcode-20210216))\r\
+    \n* libxml2 ([2.9.12](https://gitlab.gnome.org/GNOME/libxml2/-/tags/v2.9.12))\r\
+    \n* multipath-tools ([0.8.5](https://github.com/opensvc/multipath-tools/releases/tag/0.8.5))\r\
+    \n* ncurses ([6.2](https://invisible-island.net/ncurses/announce-6.2.html))\r\n\
+    * open-iscsi ([2.1.4](https://github.com/open-iscsi/open-iscsi/releases/tag/2.1.4))\r\
+    \n* openldap ([2.4.58](https://www.openldap.org/software/release/announce.html))\r\
+    \n* openssh ([8.6_p1](https://www.openssh.com/txt/release-8.6))\r\n* runc ([1.0.0_rc95](https://github.com/opencontainers/runc/releases/tag/v1.0.0-rc95))\r\
+    \n* samba ([4.12.9](https://www.samba.org/samba/history/samba-4.12.9.html))\r\n\
+    * sqlite ([3.34.1](https://www.sqlite.org/releaselog/3_34_1.html))\r\n* systemd\
+    \ ([247.6](https://github.com/systemd/systemd-stable/releases/tag/v247.6))\r\n\
+    * zstd ([1.4.9](https://github.com/facebook/zstd/releases/tag/v1.4.9))\r\n* SDK:\
+    \ Rust ([1.52.1](https://blog.rust-lang.org/2021/05/10/Rust-1.52.1.html))\r\n\
+    * SDK: QEMU ([5.2.0](https://wiki.qemu.org/ChangeLog/5.2))\r\n* SDK: cmake ([3.18.5](https://cmake.org/cmake/help/latest/release/3.18.html#id1))\r\
+    \n* SDK: binutils ([2.36.1](https://sourceware.org/pipermail/binutils/2021-February/115240.html))\r\
+    \n\r\n**Deprecation**\r\n\r\n\r\n\r\n* docker-1.12, rkt and kubelet-wrapper are\
+    \ deprecated and removed from Stable, also from subsequent channels in the future.\
+    \ Please read the[ removal announcement](https://groups.google.com/g/flatcar-linux-user/c/MeinndLqJO4)\
+    \ to know more"
+  created_at: '2021-07-21T13:36:38Z'
+  draft: false
+  html_url: https://github.com/kinvolk/manifest/releases/tag/v2905.2.0
+  id: 46887392
+  name: v2905.2.0
+  node_id: MDc6UmVsZWFzZTQ2ODg3Mzky
+  prerelease: false
+  published_at: '2021-07-28T08:25:15Z'
+  tag_name: v2905.2.0
+  tarball_url: https://api.github.com/repos/kinvolk/manifest/tarball/v2905.2.0
+  target_commitish: flatcar-master
+  upload_url: https://uploads.github.com/repos/kinvolk/manifest/releases/46887392/assets{?name,label}
+  url: https://api.github.com/repos/kinvolk/manifest/releases/46887392
+  zipball_url: https://api.github.com/repos/kinvolk/manifest/zipball/v2905.2.0
+image_packages:
+  docker: 19.03.15
+  ignition: 0.34.0
+  kernel: 5.10.52
+  systemd: '247'
+release: 2905.2.0
+version: 2905.2.0


### PR DESCRIPTION
Probably during the website migration not all releases got added.

Didn't update the feeds, this happens on the next regular release run.

## How to use

## Testing done

Running
```
comm -23 <(ls ../website/data/products/flatcar/releases/*/ | sort) <(ls data/releases/*/ | sort)
```
before and after