### PR TITLE
fix time of community calls

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@ permalinks:
 
 params:
   news_stripe:
-    text: 'Join our <a href="https://github.com/flatcar-linux/Flatcar/#monthly-community-meeting-and-release-planning">community calls</a>, every second Tuesday of each month at 4:30 GMT.'
+    text: 'Join our <a href="https://github.com/flatcar-linux/Flatcar/#monthly-community-meeting-and-release-planning">community calls</a>, every second Tuesday of each month at 16:30 GMT.'
     expiration: "2023-12-29T17:00:00+02:00"
     style:
       bgcolor: ""


### PR DESCRIPTION
4:30 GMT is incorrect. Should either be 16:30 (24 hour clock) or 4.30pm (12 hour). Fixed as 24 hour clock.

