### PR TITLE
Add LTS-<YEAR> ATOM and JSON feeds

### DIFF
--- a/themes/flatcar/layouts/section/releases.html
+++ b/themes/flatcar/layouts/section/releases.html
@@ -96,6 +96,14 @@
                       <a href="/releases-feed/releases-{{ $chan.current.channel }}.xml" class="small" style="box-shadow: 0 0 0 white; border: none;"><span class="fa fa-rss"></span> ATOM feed ({{ $channel.title }})</a>
                       <a href="/releases-json/releases-{{ $chan.current.channel }}.json" class="small" style="box-shadow: 0 0 0 white; border: none;"><span class="fa"></span> JSON feed ({{ $channel.title }})</a>
                       </div>
+                      {{ if eq $chan.current.channel "lts" }}
+                      {{ range slice "2022" "2021" }}
+                      <div style="text-align: right;">
+                      <a href="/releases-feed/releases-{{ $chan.current.channel }}-{{ . }}.xml" class="small" style="box-shadow: 0 0 0 white; border: none;"><span class="fa fa-rss"></span> ATOM feed (LTS {{ . }})</a>
+                      <a href="/releases-json/releases-{{ $chan.current.channel }}-{{ . }}.json" class="small" style="box-shadow: 0 0 0 white; border: none;"><span class="fa"></span> JSON feed (LTS {{ . }})</a>
+                      </div>
+                      {{ end }}
+                      {{ end }}
                       {{ range $pkg, $ver := $chan.current.image_packages }}
                       {{ $.Scratch.SetInMap "pkgPkgMap" $pkg $pkg }}
                       {{ end }}


### PR DESCRIPTION
With two LTS streams being available at the same time, the single
column or ATOM/JSON feeds are not perfect for looking up the releases
of a stream.
Provide the LTS-<YEAR> ATOM and JSON feeds for the both LTS streams to
help users track a stream or get the list of all releases of a stream.

## How to use

Check the deployed temporary website in the link of the GitHub check, go to the LTS channel under "Releases" and see the additional feeds.

## Testing done

Local build to check that it works. Resized the window to a phone width and checked that the layout is correct.