### PR TITLE
update-flatcar-versions.sh: Add LTS 2022 to new update script

### DIFF
--- a/update-flatcar-versions.sh
+++ b/update-flatcar-versions.sh
@@ -19,7 +19,6 @@ FLATCAR_DATA="$WEBSITE_DIR"/data
 CHANNELS=(
     alpha
     beta
-    edge
     lts
     lts-2021
     lts-2022


### PR DESCRIPTION
The old update script in the flatcar-linux-release-info was up-to-date
but now we should use this here which wasn't yet up-to-date.
