### PR TITLE
change community meetings to office hours

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@ permalinks:
 
 params:
   news_stripe:
-    text: 'Join our <a href="https://github.com/flatcar-linux/Flatcar/#monthly-community-meeting-and-release-planning">community calls</a>, every second Tuesday of each month at 15:30 GMT.'
+    text: 'Join our <a href="https://github.com/flatcar-linux/Flatcar/#monthly-community-meeting-and-release-planning">Office Hours</a>, every second Tuesday of each month at 15:30 GMT.'
     expiration: "2023-12-29T17:00:00+02:00"
     style:
       bgcolor: ""


### PR DESCRIPTION
change news stripe to say office hours instead of community meetings