### PR TITLE
github: enable build on scheduled event

### DIFF
--- a/.github/workflows/azure-static-web-apps-lemon-wave-085522403.yml
+++ b/.github/workflows/azure-static-web-apps-lemon-wave-085522403.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed') || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:


### PR DESCRIPTION
schedule event is used to run a build of the website each day but the
`if` condition is being skipped because it does not include `schedule`
events.

Example: https://github.com/flatcar-linux/flatcar-website/actions/runs/2586833682

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>