### PR TITLE
update dead link to flatcar documentation

### DIFF
--- a/content/faq.md
+++ b/content/faq.md
@@ -32,7 +32,7 @@ If for any reason something goes wrong during the boot process, the system autom
 
 ### How do I get started with Flatcar Container Linux?
 
-You can deploy Flatcar Container Linux on a wide array of platforms. Consult [the documentation](https://kinvolk.io/docs/flatcar-container-linux) on how to use Flatcar Container Linux.
+You can deploy Flatcar Container Linux on a wide array of platforms. Consult [the documentation](https://flatcar-linux.org/docs/latest/) on how to use Flatcar Container Linux.
 
 Check out our [release page](https://flatcar-linux.org/releases/) to see the latest changes on each channel.
 


### PR DESCRIPTION
closes #243

# Update dead link in [https://www.flatcar.org/faq](https://www.flatcar.org/faq)

updated dead link in [https://www.flatcar.org/faq](https://www.flatcar.org/faq) pointing to [https://kinvolk.io/docs/flatcar-container-linux](https://kinvolk.io/docs/flatcar-container-linux) to point to [https://flatcar-linux.org/docs/latest/](https://flatcar-linux.org/docs/latest/)

## How to use

Click on the link and it leads you to Flatcar's docs :)

## Testing done

Manually tested and  the new link works.
