### PR TITLE
hugo: enable emoji

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -83,3 +83,4 @@ menu:
       identifier: docs
       weight: -200
 
+enableEmoji: true


### PR DESCRIPTION
Emoji in documentation can be useful to provide visual information (like disclaimer, check mark, etc.)

Currently, they are not rendered: https://www.flatcar.org/docs/latest/container-runtimes/getting-started-with-kubernetes/

See also: https://gohugo.io/getting-started/configuration/#enableemoji
