### PR TITLE
themes/flatcar/layouts: Fix HTML link on docs redirection page

### DIFF
--- a/themes/flatcar/layouts/docs/redirect.html
+++ b/themes/flatcar/layouts/docs/redirect.html
@@ -6,6 +6,6 @@
     <meta http-equiv="refresh" content="0; url='/docs/{{ $redirectURL }}'" />
   </head>
   <body>
-    <p>Please follow <a href="{{ $redirectURL }}">this link</a>.</p>
+    <p>Please follow <a href="/docs/{{ $redirectURL }}">this link</a>.</p>
   </body>
 </html>


### PR DESCRIPTION
The meta tag prepends /docs/ to the link, but this prefix is missing on the HTML link.

I dedicate any and all copyright interest in this software to the
public domain. I make this dedication for the benefit of the public at
large and to the detriment of my heirs and successors. I intend this
dedication to be an overt act of relinquishment in perpetuity of all
present and future rights to this software under copyright law.

# Fix HTML link on docs redirection page

When clicking on the *Docs* link on Flatcar main web page and that your browser is configured not to follow redirections by default, it shows a page with the text `Please follow [this link](latest).` on `https://www.flatcar.org/docs`.

If you click on the link, you arrive to `https://www.flatcar.org/latest` which is a 404 error page, instead of `https://www.flatcar.org/docs/latest` (where the meta refresh tag points to).

## How to use

Check in the generated HTML code that the link matches the meta tag, e.g. with a curl command:
```
curl -v http://localhost:1313/docs
```

## Testing done

:warning: Code has not been tested.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
