### PR TITLE
socials: add mastodon

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,6 +28,8 @@ params:
     - title: github
       url: 'https://github.com/flatcar'
       image: 'github-icon'
+    - title: mastodon
+      url: 'https://hachyderm.io/@flatcar'
   favicon: "/media/brand-logo.svg"
   docs:
     github_edit_url: https://github.com/flatcar/flatcar-docs/edit/main/docs/

--- a/themes/flatcar/layouts/partials/socials.html
+++ b/themes/flatcar/layouts/partials/socials.html
@@ -2,7 +2,7 @@
   {{ range .Site.Params.social }}
   <li class="list-inline-item socials__item">
     <a href="{{ .url }}" class="socials__link" target="_blank" rel="noopener" aria-label="Flatcar Container Linux's {{ .title }}">
-      <i class="fab fa-{{ .title }}-square"></i>
+      <i class="fab fa-{{ .title }}{{if ne .title "mastodon"}}-square{{ end }}"></i>
     </a>
   </li>
   {{ end }}


### PR DESCRIPTION
In this PR, we add a link to the Mastodon account of Flatcar on Hachyderm instance. 

Note: `fa-mastodon-square` does not exist on Font Awesome so we need to add a condition on the used icon

![tmp lxG47siZnX](https://github.com/flatcar/flatcar-website/assets/28657343/4d529d62-c000-4ee1-8448-32f2dcb261cf)
