### PR TITLE
kubernetes: kubernetes 1.25.10 is not tested anymore

### DIFF
--- a/content/docs/latest/container-runtimes/getting-started-with-kubernetes.md
+++ b/content/docs/latest/container-runtimes/getting-started-with-kubernetes.md
@@ -23,7 +23,8 @@ This is a compatibility matrix between Flatcar and Kubernetes deployed using van
 | Alpha                                | :large_orange_diamond: | :large_orange_diamond: | :large_orange_diamond: | :white_check_mark: |:white_check_mark: | :white_check_mark: |
 | Beta                                 | :large_orange_diamond: | :large_orange_diamond: | :large_orange_diamond: | :white_check_mark: |:white_check_mark: | :white_check_mark: |
 | Stable                               | :large_orange_diamond: | :large_orange_diamond: | :large_orange_diamond: | :white_check_mark: |:white_check_mark: | :white_check_mark: |
-| LTS                                  | :large_orange_diamond: | :large_orange_diamond: | :large_orange_diamond: | :x:                |:x:                | :x: |
+| LTS (2023)                           | :large_orange_diamond: | :large_orange_diamond: | :large_orange_diamond: | :white_check_mark: |:white_check_mark: | :white_check_mark: |
+| LTS (2022)                           | :large_orange_diamond: | :large_orange_diamond: | :large_orange_diamond: | :x:                |:x:                | :x: |
 
 :large_orange_diamond:: The version is not tested anymore before a release but was known for working.
 


### PR DESCRIPTION
It's EOL / unmaintained since 27th Oct. 2023 also added the LTS 2023 (which supports out of the box the tested Kubernetes version)

---

Related-PR: https://github.com/flatcar/mantle/pull/478