### PR TITLE
k8s: Use new permanent URL for sysext-bakery release assets

### DIFF
--- a/content/docs/latest/container-runtimes/getting-started-with-kubernetes.md
+++ b/content/docs/latest/container-runtimes/getting-started-with-kubernetes.md
@@ -68,13 +68,13 @@ storage:
   files:
     - path: /etc/sysupdate.kubernetes.d/kubernetes.conf
       contents:
-        source: https://github.com/flatcar/sysext-bakery/releases/download/20230901/kubernetes.conf
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes.conf
     - path: /etc/sysupdate.d/noop.conf
       contents:
-        source: https://github.com/flatcar/sysext-bakery/releases/download/20230901/noop.conf
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
     - path: /opt/extensions/kubernetes/kubernetes-v1.27.4-x86-64.raw
       contents:
-        source: https://github.com/flatcar/sysext-bakery/releases/download/20230901/kubernetes-v1.27.4-x86-64.raw
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-v1.27.4-x86-64.raw
 systemd:
   units:
     - name: systemd-sysupdate.timer
@@ -233,13 +233,13 @@ storage:
   files:
     - path: /etc/sysupdate.kubernetes.d/kubernetes.conf
       contents:
-        source: https://github.com/flatcar/sysext-bakery/releases/download/20230901/kubernetes.conf
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes.conf
     - path: /etc/sysupdate.d/noop.conf
       contents:
-        source: https://github.com/flatcar/sysext-bakery/releases/download/20230901/noop.conf
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/noop.conf
     - path: /opt/extensions/kubernetes/kubernetes-v1.27.4-x86-64.raw
       contents:
-        source: https://github.com/flatcar/sysext-bakery/releases/download/20230901/kubernetes-v1.27.4-x86-64.raw
+        source: https://github.com/flatcar/sysext-bakery/releases/download/latest/kubernetes-v1.27.4-x86-64.raw
 systemd:
   units:
     - name: systemd-sysupdate.timer


### PR DESCRIPTION
We use GitHub release assets to host the config files and images. To have a stable reference we now only accumulate everything in the "latest" release.
