### PR TITLE
data/releases/stable, beta: fix torcx removal warning

### DIFF
--- a/data/releases/beta/3760.1.0.yml
+++ b/data/releases/beta/3760.1.0.yml
@@ -24,7 +24,7 @@ github_release:
     subscriptions_url: https://api.github.com/users/tormath1/subscriptions
     type: User
     url: https://api.github.com/users/tormath1
-  body: ":warning: From Alpha 3794.0.0 Torcx has been removed - please assert that\
+  body: "⚠️ From Alpha 3794.0.0 Torcx has been removed - please assert that\
     \ you don't rely on specific Torcx mechanism but now use systemd-sysext. See [here](https://www.flatcar.org/docs/latest/provisioning/sysext/)\
     \ for more information.\r\n\r\n _Changes since **Beta 3745.1.0**_\r\n \r\n ####\
     \ Security fixes:\r\n \r\n - Linux ([CVE-2023-35827](https://nvd.nist.gov/vuln/detail/CVE-2023-35827),\

--- a/data/releases/beta/current.yml
+++ b/data/releases/beta/current.yml
@@ -24,7 +24,7 @@ github_release:
     subscriptions_url: https://api.github.com/users/tormath1/subscriptions
     type: User
     url: https://api.github.com/users/tormath1
-  body: ":warning: From Alpha 3794.0.0 Torcx has been removed - please assert that\
+  body: "⚠️ From Alpha 3794.0.0 Torcx has been removed - please assert that\
     \ you don't rely on specific Torcx mechanism but now use systemd-sysext. See [here](https://www.flatcar.org/docs/latest/provisioning/sysext/)\
     \ for more information.\r\n\r\n _Changes since **Beta 3745.1.0**_\r\n \r\n ####\
     \ Security fixes:\r\n \r\n - Linux ([CVE-2023-35827](https://nvd.nist.gov/vuln/detail/CVE-2023-35827),\

--- a/data/releases/stable/3602.2.2.yml
+++ b/data/releases/stable/3602.2.2.yml
@@ -24,7 +24,7 @@ github_release:
     subscriptions_url: https://api.github.com/users/tormath1/subscriptions
     type: User
     url: https://api.github.com/users/tormath1
-  body: ":warning: From Alpha 3794.0.0 Torcx has been removed - please assert that\
+  body: "⚠️ From Alpha 3794.0.0 Torcx has been removed - please assert that\
     \ you don't rely on specific Torcx mechanism but now use systemd-sysext. See [here](https://www.flatcar.org/docs/latest/provisioning/sysext/)\
     \ for more information.\r\n\r\n\r\n _Changes since **Stable 3602.2.1**_\r\n \r\
     \n #### Security fixes:\r\n \r\n - Linux ([CVE-2023-46813](https://nvd.nist.gov/vuln/detail/CVE-2023-46813),\

--- a/data/releases/stable/current.yml
+++ b/data/releases/stable/current.yml
@@ -24,7 +24,7 @@ github_release:
     subscriptions_url: https://api.github.com/users/tormath1/subscriptions
     type: User
     url: https://api.github.com/users/tormath1
-  body: ":warning: From Alpha 3794.0.0 Torcx has been removed - please assert that\
+  body: "⚠️ From Alpha 3794.0.0 Torcx has been removed - please assert that\
     \ you don't rely on specific Torcx mechanism but now use systemd-sysext. See [here](https://www.flatcar.org/docs/latest/provisioning/sysext/)\
     \ for more information.\r\n\r\n\r\n _Changes since **Stable 3602.2.1**_\r\n \r\
     \n #### Security fixes:\r\n \r\n - Linux ([CVE-2023-46813](https://nvd.nist.gov/vuln/detail/CVE-2023-46813),\


### PR DESCRIPTION
This small change replaces the `:warning:` semantic emoji - which does not render in Hugo and hence appears as a literal `:warning:` string - with the UTF8 emoji ⚠️.