### PR TITLE
tutorial: update git repository URL

### DIFF
--- a/content/docs/latest/tutorial/hands-on-2/_index.md
+++ b/content/docs/latest/tutorial/hands-on-2/_index.md
@@ -14,7 +14,7 @@ This is what we've done in the previous hands-on but now it's done _as code_, we
 
 # Step-by-step
 
-* Clone the tutorial repository and cd into it: `git clone https://github.com/tormath1/flatcar-tutorial ; cd flatcar-tutorial/hands-on-2`
+* Clone the tutorial repository and cd into it: `git clone https://github.com/flatcar/flatcar-tutorial ; cd flatcar-tutorial/hands-on-2`
 * Open `./config.yaml` and find the TODO section.
 * Add the following section (from https://coreos.github.io/butane/examples/#files):
 ```

--- a/content/docs/latest/tutorial/hands-on-3/_index.md
+++ b/content/docs/latest/tutorial/hands-on-3/_index.md
@@ -15,7 +15,7 @@ This is a bundle of hands-on-1 and hands-on-2 but it's not a local deployment an
 # Step-by-step
 
 ```bash
-git clone https://github.com/tormath1/flatcar-tutorial; cd flatcar-tutorial/hands-on-3
+git clone https://github.com/flatcar/flatcar-tutorial; cd flatcar-tutorial/hands-on-3
 # go into the terraform directory
 cd terraform
 # update the config for creating index.html from previous hands-on


### PR DESCRIPTION
`flatcar-tutorial` is now available in the Flatcar org: https://github.com/flatcar/flatcar-tutorial/. Let's update this in the documentation. 

NOTE: Does anyone with correct permission can update the settings of the repository to remove the `issues` tab? I don't have the permission :shrug: 