### PR TITLE
.github: Bump github actions

### DIFF
--- a/.github/workflows/azure-static-web-apps-lemon-wave-085522403.yml
+++ b/.github/workflows/azure-static-web-apps-lemon-wave-085522403.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: '1.15.4'
         id: go


### PR DESCRIPTION
This is to avoid using deprecated node16.
