### PR TITLE
fixes broken run_sdk_container invocations in in developer-guides

### DIFF
--- a/content/docs/latest/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/content/docs/latest/reference/developer-guides/sdk-modifying-flatcar.md
@@ -334,7 +334,7 @@ Both board chroot and SDK use Gentoo's portage to manage its respective packages
 
 All of the following is done inside the SDK container, i.e. after running
 ```shell
-$ ./run_sdk_container.sh -t
+$ ./run_sdk_container -t
 ```
 
 <table><tr><td>
@@ -485,7 +485,7 @@ Then `emerge` the application once more to force re-packaging, and rebuild the i
 
 All of the following is done inside the SDK container, i.e. after running
 ```shell
-$ ./run_sdk_container.sh -t
+$ ./run_sdk_container -t
 ```
 
 <table><tr><td>


### PR DESCRIPTION
`run_sdk_container.sh` renamed to `run_sdk_container` at some point or possibly a typo.

# Renames `run_sdk_container.sh` to `run_sdk_container` in sdk-modifying-flatcar.md.

## How to use

## Testing done

- [ ] searched main branch of scripts repo for `run_sdk_container.sh` using `git log --follow run_sdk_container`, `git log -M --summary | grep rename | grep run_sdk_container`