### PR TITLE
adds necessary steps for kernel modification when using a new build environment

### DIFF
--- a/content/docs/latest/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/content/docs/latest/reference/developer-guides/sdk-modifying-flatcar.md
@@ -488,6 +488,12 @@ All of the following is done inside the SDK container, i.e. after running
 $ ./run_sdk_container -t
 ```
 
+You'll want to make sure that you've run the following commands at least once inside your SDK container. This will download the necessary packages and kernel source code in preparation for your changes.
+```shell
+$ ./build_packages
+$ ./build_image
+```
+
 <table><tr><td>
 
 **tl;dr** In the SDK container, build the kernel package with a custom config, run+test, and persist


### PR DESCRIPTION
# adds necessary steps for kernel modification when using a new build environment

- ensure `./build_packages && ./build_image` have been run at least once before attempting to configure ebuilds which would otherwise throw a file not found error.
- automated removal of misc endline whitespace 


## How to use

## Testing done

- [ ] In a freshly instantiated sdk container, attempt to follow instructions for kernel modification per guide without first running: `./build_packages && ./build_image` from a separate task with a different heading.
- [ ] Results in file not found error. Guide assumes familiarity or at least a pre-existing container used for other development work.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
