### PR TITLE
Fix edit page link after docs repo rename

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,13 +32,13 @@ params:
       url: 'https://hachyderm.io/@flatcar'
   favicon: "/media/brand-logo.svg"
   docs:
-    github_edit_url: https://github.com/flatcar/flatcar-docs/edit/main/docs/
-    issues_url: https://github.com/kinvolk/flatcar/issues/new?labels=kind/docs
+    github_edit_url: https://github.com/flatcar/flatcar-website/edit/master/content/docs/latest
+    issues_url: https://github.com/flatcar/flatcar/issues/new?labels=kind/docs
     external_docs:
-    - repo: https://github.com/flatcar/flatcar-docs.git
+    - repo: https://github.com/flatcar/flatcar-website.git
       name: "latest"
-      branch: "main"
-      dir: "docs"
+      branch: "master"
+      dir: "content/docs"
 
 
 pygmentsCodefences: true


### PR DESCRIPTION
# [Title: describe the change in one sentence]

The "edit this page" link is current broken. Fix it.