### PR TITLE
Add quote for `LOCKSMITHD_REBOOT_WINDOW_START` value

### DIFF
--- a/content/docs/latest/setup/releases/update-strategies.md
+++ b/content/docs/latest/setup/releases/update-strategies.md
@@ -143,7 +143,7 @@ storage:
       contents:
         inline: |
           REBOOT_STRATEGY=reboot
-          LOCKSMITHD_REBOOT_WINDOW_START=Thu 04:00
+          LOCKSMITHD_REBOOT_WINDOW_START="Thu 04:00"
           LOCKSMITHD_REBOOT_WINDOW_LENGTH=1h
       mode: 0420
 ```


### PR DESCRIPTION
Otherwise `motdgen` service can error with `command not found`.

To address https://github.com/coreos/bugs/issues/1902
