### PR TITLE
sysext: Document OEM extensions and Flatcar extensions

### DIFF
--- a/content/docs/latest/_index.md
+++ b/content/docs/latest/_index.md
@@ -115,6 +115,7 @@ more.
  * [Adding disk space][disk-space]
  * [Mounting storage][mounting-storage]
  * [iSCSI configuration][iscsi]
+ * [ZFS Extension][zfsextension]
 
 #### Additional security options
  * [Setting up LUKS disk encryption][luks-encryption]
@@ -210,6 +211,7 @@ Flatcar tutorial to deep dive into some Flatcar fundamental concepts.
 [registry-authentication]: container-runtimes/registry-authentication
 [iscsi]: setup/storage/iscsi
 [swap]: setup/storage/adding-swap
+[zfsextension]: setup/storage/zfs
 [ec2-container-service]: setup/clusters/booting-on-ecs/
 [manage-docker-containers]: setup/systemd/getting-started
 [udev-rules]: setup/systemd/udev-rules

--- a/content/docs/latest/setup/storage/zfs.md
+++ b/content/docs/latest/setup/storage/zfs.md
@@ -1,0 +1,13 @@
+---
+title: ZFS Extension for Flatcar Container Linux
+linktitle: ZFS Extension
+description: How to set up storage with the Flatcar ZFS extension.
+weight: 40
+---
+
+The Flatcar ZFS extension was the first Flatcar extension published, introduced with Flatcar version 3913.0.0 in the Alpha channel. It provides the ZFS Linux kernel modules and the ZFS CLI tools.
+Support for ZFS is experimental because the ZFS kernel module lives out-of-tree which means it is not part of the upstream Linux kernel and any delay in fixing incompatibilities in the ZFS code could mean that we would have to release a Flatcar version without the ZFS extension, meaning that ZFS users won't be able update until a follow-up Flatcar release brings ZFS support back.
+
+## Enabling the extension
+
+Users can enable a Flatcar extensions by writing one name per line to `/etc/flatcar/enabled-sysext.conf`. To enable the ZFS extension, one has to write the extension ID `zfs` as line into the file.


### PR DESCRIPTION
The use of systemd-sysext for OEM and Flatcar extensions was only documented in the release notes but not yet part of the docs. Add an overview about the systemd-sysext use in Flatcar and remove the Butane sysupdate config because the sysext-bakery is the better place to keep this up-to-date.

## How to use

@jepio wanted to document the ZFS extension and I think it would make sense to cover the ZFS specifics with examples under https://www.flatcar.org/docs/latest/setup/storage/

Improvements and additions to the topic of Flatcar extension in general are welcome and would go into this PR, while we can make a new PR for ZFS examples in the storage docs pages.

