### PR TITLE
docs: Document new zram generator

### DIFF
--- a/content/docs/latest/setup/storage/adding-swap.md
+++ b/content/docs/latest/setup/storage/adding-swap.md
@@ -9,9 +9,50 @@ aliases:
 ---
 
 Swap is the process of moving pages of memory to a designated part of the hard disk, freeing up space when needed. Swap can be used to alleviate problems with low-memory environments.
-An alternative is to use RAM compression with zram.
+A modern alternative to slow swap partitions is to use RAM compression with zram.
 
-By default Flatcar Container Linux does not include a partition for swap, however one can configure their system to have swap, either by including a dedicated partition for it or creating a swapfile.
+By default Flatcar Container Linux does not include a partition for swap nor a zram configuration, however one can configure their system to have swap, either by including a dedicated partition for it, creating a swapfile, or setting up zram.
+
+## Using zram
+
+With zram a virtual `/dev/zram0` device acts as swap space which lives compressed in memory.
+One can activate zram by creating a `[zram0]` section in `/etc/systemd/zram-generator.conf`.
+Here are Butane config (YAML) that creates the file:
+
+```yaml
+variant: flatcar
+version: 1.0.0
+storage:
+  files:
+    - path: /etc/systemd/zram-generator.conf
+      contents:
+        inline: |
+          [zram0]
+```
+
+You can tweak the size by using the minimum of either 8 GB if one has a lot of RAM or the size of the RAM, e.g., 1 GB, by setting `zram-size`:
+
+```yaml
+variant: flatcar
+version: 1.0.0
+storage:
+  files:
+    - path: /etc/systemd/zram-generator.conf
+      contents:
+        inline: |
+          [zram0]
+          zram-size = min(ram, 8192)
+```
+
+Allocating a compressed RAM section that can hold an amount up to the size of the RAM itself works well because most RAM contents compress very well.
+
+After a reboot you can check the results:
+
+```shell
+$ zramctl
+NAME       ALGORITHM DISKSIZE DATA COMPR TOTAL STREAMS MOUNTPOINT
+/dev/zram0 lzo-rle         1G   4K   74B   12K       8 [SWAP]
+```
 
 ## Managing swap with systemd
 
@@ -161,18 +202,3 @@ NB the systemd unit name is created by
 path separator meaning that paths containing - have to be escaped. This
 leads to a file `'dev-disk-by\x2dpartlabel-swap.swap'` being created in
 `/etc/systemd/system`.
-
-## Using zram
-
-With zram a virtual `/dev/zram0` device acts as swap space which lives compressed in memory.
-At the moment there is no zram generator and instead, a manual setup needs to be done, similar to the creation of a swap file.
-
-```shell
-$ sudo modprobe zram
-$ sudo zramctl -f -s 1G
-$ sudo mkswap /dev/zram0
-$ sudo swapon /dev/zram0
-$ zramctl
-NAME       ALGORITHM DISKSIZE DATA COMPR TOTAL STREAMS MOUNTPOINT
-/dev/zram0 lzo-rle         1G   4K   74B   12K       8 [SWAP]
-```


### PR DESCRIPTION
With the generator added in https://github.com/flatcar/scripts/pull/1772 we don't need the manual setup anymore.

## How to use

## Testing done

Creating the config file worked, as also tested in the linked PR.

I think we could even add this config by default to prevent hitting out-of-memory errors with Kubernetes on small VM sizes.