### PR TITLE
Remove deis from integrations

### DIFF
--- a/content/docs/latest/reference/integrations.md
+++ b/content/docs/latest/reference/integrations.md
@@ -9,7 +9,6 @@ This document tracks projects that integrate with Flatcar Container Linux. Pleas
 
 ## Projects
 
-- [Deis Workflow](https://deis.com/workflow/): an open source PaaS for Kubernetes that runs on Flatcar Container Linux.
 - [Amazon Web Services](https://aws.amazon.com/marketplace/pp/B01H62FDJM): Amazon's cloud computing solution. Offers Flatcar Container Linux.
 - [Google Cloud Platform](https://cloud.google.com/compute/docs/images#os-compute-support): Google's cloud computing solution. Offers Flatcar Container Linux.
 - [Microsoft Azure](https://azuremarketplace.microsoft.com/en-us/marketplace/apps/category/compute?subcategories=operating-systems&page=1#): Microsoft's cloud computing solution. Offers Flatcar Container Linux.


### PR DESCRIPTION
Deis got integrated into Azure, therefore the link isn't helpful anymore.