### PR TITLE
provisioning/sysext: mention podman and python

### DIFF
--- a/content/docs/latest/provisioning/sysext/_index.md
+++ b/content/docs/latest/provisioning/sysext/_index.md
@@ -32,6 +32,8 @@ The table below give an overview on the supported Flatcar extensions.
 
 | Extension Name | Availability        | Documentation           |
 |----------------|---------------------|-------------------------|
+| `podman`       | 3941.0.0 – …        |                         |
+| `python`       | 4011.0.0 – …        |                         |
 | `zfs`          | 3913.0.0 – …        | [Storage][zfsextension] |
 
 


### PR DESCRIPTION
Follow-up from: https://github.com/flatcar/scripts/pull/1979#issuecomment-2158209648

I'm not sure yet what we can write in the "documentation" column for those extensions (except maybe targeting the official upstream doc?)

But at least, we can point this documentation.