### PR TITLE
sysext: Python is available from 4012.0.0

### DIFF
--- a/content/docs/latest/provisioning/sysext/_index.md
+++ b/content/docs/latest/provisioning/sysext/_index.md
@@ -33,7 +33,7 @@ The table below give an overview on the supported Flatcar extensions.
 | Extension Name | Availability        | Documentation           |
 |----------------|---------------------|-------------------------|
 | `podman`       | 3941.0.0 – …        |                         |
-| `python`       | 4011.0.0 – …        |                         |
+| `python`       | 4012.0.0 – …        |                         |
 | `zfs`          | 3913.0.0 – …        | [Storage][zfsextension] |
 
 


### PR DESCRIPTION
Wrong calculation in the estimate of version 