### PR TITLE
fix mention of "Headlamp" to "Nebraska

### DIFF
--- a/content/docs/latest/nebraska/i18n/_index.md
+++ b/content/docs/latest/nebraska/i18n/_index.md
@@ -3,7 +3,7 @@ title: i18n Internationalization / Localization
 linkTitle: Internationalization
 ---
 
-Headlamp's internationalization uses the i18next, i18next-parser, and
+Nebraska's internationalization uses the i18next, i18next-parser, and
 react-i18next libraries.
 
 ## Default language, and locales


### PR DESCRIPTION
only changed the word "Headlamp" to "Nebraska"