### PR TITLE
docs/nebraska: fix edit link

### DIFF
--- a/content/docs/latest/nebraska/_index.md
+++ b/content/docs/latest/nebraska/_index.md
@@ -4,7 +4,7 @@ title: Nebraska
 main_menu: true
 weight: 40
 cascade:
-  github_edit_url: https://github.com/flatcar/flatcar-website/tree/master/content/docs/latest/nebraska
+  github_edit_url: https://github.com/flatcar/flatcar-website/tree/master/content/docs/latest
   issues_url: https://github.com/flatcar/nebraska/issues/new
 ---
 


### PR DESCRIPTION
Otherwise it duplicates the `nebraska` path. Example: `https://github.com/flatcar/flatcar-website/tree/master/content/docs/latest/nebraska/nebraska/i18n/_index.md`