### PR TITLE
Remove text and link to contributing document

### DIFF
--- a/content/docs/latest/nebraska/development.md
+++ b/content/docs/latest/nebraska/development.md
@@ -4,8 +4,6 @@ weight: 20
 ---
 
 This section shows how to set up a development environment for Nebraska.
-Be also sure to read the [contributing](./contributing) section for the
-general guidelines when contributing to Nebraska.
 
 Nebraska needs a running `PostgresSQL` database. Apart from that, the
 recommended way to work on it, is to run the backend with the `noop`


### PR DESCRIPTION
Remove text and link to contributing document, as those are already included in the development document.

Fixes https://github.com/flatcar/nebraska/issues/849