### PR TITLE
_index.md: Remove Docker 26 message, add CGroupsV1 retirement message

### DIFF
--- a/content/releases/_index.md
+++ b/content/releases/_index.md
@@ -5,22 +5,19 @@ draft: false
 announcement: true
 announcement_bg: "#12172b"
 announcement_text_class: "text-light"
-announcement_title: "Move to Docker 25"
+announcement_title: "⚠️ End of support for CGroupsV1 in early 2025 ⚠️"
 announcement_message: "
-We will begin moving to **Docker 25 (or newer)** in the near future. Among other changes, Docker 25 and above **remove the devicemapper** storage driver. While new provisionings should not be affected by the change, long-lived nodes which use this back-end will break after the update.
 
-* We plan to introduce Docker 25 (or a newer release) in the **Alpha release late July 2024**.
+Flatcar will stop supporting the cgroups v1 backwards compatibility mode in Q1 2025.
+With our adoption of systemd-256, support for legacy CGroupsV1 will end in Alpha, Beta, and eventually Stable.
+[Enabling legacy CGroupsV1 during deployment](https://www.flatcar.org/docs/latest/container-runtimes/switching-to-unified-cgroups/#starting-new-nodes-with-legacy-cgroups) will not be supported anymore.
+Nodes that use CGroupsV1 legacy mode will fail to update. This ensures your workloads will not be disrupted. Enable CGroupsV2 on your legacy CGroupsV1 nodes in order to successfully update.
 
-*  We expect the Docker upgrade to **hit Stable in October 2024 the earliest**.
+LTS-2024 will support CGroupsV1 until late 2025.
 
-
-Any nodes using the devicemapper storage driver will lose access to all docker state (local container images and stopped containers) after this update. Please *participate in Beta testing and run Beta canaries* if you suspect you might be affected.
-If you are reading this after Docker 25 hits stable in late 2024 and want to keep using Docker 24 while still updating to the latest OS release, please consider masking Docker 25 altogether and using the Docker 24 sysext from our [sysext-bakery](https://github.com/flatcar/sysext-bakery?tab=readme-ov-file#systemd-sysext).
-Please find a full, up-to-date list of deprecated and removed features across Docker versions here: [https://github.com/docker/cli/blob/master/docs/deprecated.md](https://github.com/docker/cli/blob/master/docs/deprecated.md)
-
-
-We will also discuss the docker upgrade and provide status updates in our [Office Hours](https://github.com/flatcar/Flatcar/discussions/categories/flatcar-office-hours?discussions_q=category%3A%22Flatcar+Office+Hours%22+is%3Aopen) and [Developer Sync](https://github.com/flatcar/Flatcar/discussions/categories/flatcar-developer-sync%22+is%3Aopen) calls.
+We will regularly call out and discuss CGroupsV1 retirement in our [Office Hours](https://github.com/flatcar/Flatcar/discussions/categories/flatcar-office-hours?discussions_q=category%3A%22Flatcar+Office+Hours%22+is%3Aopen) and [Developer Sync](https://github.com/flatcar/Flatcar/discussions/categories/flatcar-developer-sync%22+is%3Aopen) calls.
 "
+
 channels:
   - name: stable
     title: Stable


### PR DESCRIPTION
This change removes the scary Docker 26 upgrade message and replaces it with a scary message on CGroupsV1 retirement, to raise users' awareness.