### PR TITLE
Update config.ign example to 3.3.0

### DIFF
--- a/content/docs/latest/installing/bare-metal/raspberry-pi.md
+++ b/content/docs/latest/installing/bare-metal/raspberry-pi.md
@@ -124,14 +124,8 @@ The options that we will be using with the scripts are:
 ```json
 {
   "ignition": {
-    "config": {},
-    "security": {
-      "tls": {}
-    },
-    "timeouts": {},
-    "version": "2.3.0"
+    "version": "3.3.0"
   },
-  "networkd": {},
   "passwd": {
     "users": [
       {
@@ -145,27 +139,15 @@ The options that we will be using with the scripts are:
   "storage": {
     "files": [
       {
-        "filesystem": "OEM",
-        "path": "/grub.cfg",
-        "append": true,
+        "path": "/oem/grub.cfg",
         "contents": {
-          "source": "data:,set%20linux_console%3D%22console%3DttyAMA0%2C115200n8%20console%3Dtty1%22%0Aset%20linux_append%3D%22flatcar.autologin%20usbcore.autosuspend%3D-1%22%0A",
-          "verification": {}
+          "compression": "",
+          "source": "data:,set%20linux_console%3D%22console%3DttyAMA0%2C115200n8%20console%3Dtty1%22%0Aset%20linux_append%3D%22flatcar.autologin%20usbcore.autosuspend%3D-1%22%0A"
         },
         "mode": 420
       }
-    ],
-    "filesystems": [
-      {
-        "mount": {
-          "device": "/dev/disk/by-label/OEM",
-          "format": "btrfs"
-        },
-        "name": "OEM"
-      }
     ]
-  },
-  "systemd": {}
+  }
 }
 ```
 


### PR DESCRIPTION
# Update config.ign example from 2.3.0 to 3.3.0

2.3.0 is a deprecated version, and butane doesn't output anything but 3.x. The existing 2.3.0 example is not a 1-to-1 translation, and will get newbies (like me) confused as to why a 1-to-1 translation doesn't work. (reason: defining OEM in 3.x appears to overwrite it)

## How to use

1. Add changed text to `config.ign`, plus valid SSH key
2. `sudo flatcar-install -d ${DISK} -i config.ign -f flatcar_production_image.bin.bz2 -C stable -B arm64-usr -o ''`

## Testing done

Verified this `config.ign` resulted in a basic working RPi4 installation.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
