### PR TITLE
docs: Replace fallocate in adding-swap docs

### DIFF
--- a/content/docs/latest/setup/storage/adding-swap.md
+++ b/content/docs/latest/setup/storage/adding-swap.md
@@ -64,9 +64,7 @@ The following commands, run as root, will make a 1GiB file suitable for use as s
 
 ```shell
 mkdir -p /var/vm
-fallocate -l 1024m /var/vm/swapfile1
-chmod 600 /var/vm/swapfile1
-mkswap /var/vm/swapfile1
+mkswap --size 1024m --file /var/vm/swapfile1
 ```
 
 ### Creating the systemd unit file
@@ -169,9 +167,7 @@ systemd:
         [Service]
         Type=oneshot
         ExecStart=/usr/bin/mkdir -p /var/vm
-        ExecStart=/usr/bin/fallocate -l 1024m /var/vm/swapfile1
-        ExecStart=/usr/bin/chmod 600 /var/vm/swapfile1
-        ExecStart=/usr/sbin/mkswap /var/vm/swapfile1
+        ExecStart=/usr/bin/mkswap --size 1024m --file /var/vm/swapfile1
         RemainAfterExit=true
 ```
 


### PR DESCRIPTION
# Replace `fallocate` usage with creating swap via `mkswap` directly.

`fallocate` is known to create files with holes, which is not recommended by the [swapon manpage](https://linux.die.net/man/8/swapon).

This PR replaces the potentially dangerous and incorrect usage of `fallocate` with `mkswap` being called directly, as `mkswap` is capable of handling creating swap and setting it's permissions without the need for `fallocate` or `dd` safely.


## How to use

Try running the commands on your local machine, running `free -h` before and after, to validate it's creation and usage as swap.

## Testing done

Tested this on a local machine.
```bash
$ free -h
Swap: 4GB Total
$ mkswap --size 1024m --file /var/vm/swapfile1
$ swapon /var/vm/swapfile1
$ free -h
Swap: 5GB Total


```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.