### PR TITLE
docs: add comprehensive documentation about testing custom Flatcar modifications

### DIFF
--- a/content/docs/latest/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/content/docs/latest/reference/developer-guides/sdk-modifying-flatcar.md
@@ -715,7 +715,7 @@ For more granular control over testing or when you need to run specific test sui
 
 #### Requirements
 - IPv4 forwarding enabled: `sudo sysctl -w net.ipv4.ip_forward=1`
-- Firewall service stopped: `sudo systemctl stop firewalld.service`
+- Firewall configured to allow kola interfaces: `sudo firewall-cmd --zone=nm-shared --add-interface=kola-+`
 - Required packages: `swtmp`, `dnsmasq`, `go`, and `iptables` in `$PATH`
 - QEMU: `qemu-system-x86_64` for AMD64 and/or `qemu-system-aarch64` for ARM64
 

--- a/content/docs/latest/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/content/docs/latest/reference/developer-guides/sdk-modifying-flatcar.md
@@ -661,7 +661,7 @@ core@localhost ~ $ ...
 
 ## Testing images
 
-Testing your changes locally before submitting them is crucial for ensuring stability and correctness. Flatcar Container Linux utilizes the kola testing framework (part of mantle) for integration testing, primarily focused on QEMU virtual machine environments.
+Testing your changes locally before submitting them is crucial for ensuring stability and correctness. Flatcar Container Linux utilizes the kola testing framework (part of Mantle[mantle]) for integration testing, primarily focused on QEMU virtual machine environments.
 
 While the full CI pipeline runs a comprehensive set of tests, you can run these tests locally to validate your work, debug issues, or explore test behavior. This guide covers two primary methods:
 


### PR DESCRIPTION
I added documentation about testing custom Flatcar modifications using the kola testing framework. This includes both (1) automated and (2) manual testing approaches to help developers validate their changes effectively.

Should close [[RFE] Add documentation on running the test suite locally](https://github.com/flatcar/Flatcar/issues/1189)