### PR TITLE
libvirt: refresh documentation

### DIFF
--- a/content/docs/latest/installing/vms/libvirt.md
+++ b/content/docs/latest/installing/vms/libvirt.md
@@ -129,9 +129,9 @@ virt-install --connect qemu:///system \
              --import \
              --name flatcar-linux1 \
              --ram 1024 --vcpus 1 \
-             --os-type=generic \
-             --disk path=/var/lib/libvirt/images/flatcar-linux/flatcar-linux1.qcow2,format=qcow2,bus=virtio \
-             --vnc --noautoconsole \
+             --os-variant=unknown \
+             --disk size=20,backing_store=/var/lib/libvirt/images/flatcar-linux/flatcar_production_qemu_image.img \
+             --graphics=none \
              --qemu-commandline='-fw_cfg name=opt/org.flatcar-linux/config,file=/var/lib/libvirt/flatcar-linux/flatcar-linux1/provision.ign'
 ```
 


### PR DESCRIPTION
While preparing KubeCon tutorial I noticed that some instructions were outdated. 