### PR TITLE
Added workaround to provide a config file when booting the .ISO

### DIFF
--- a/content/docs/latest/installing/bare-metal/booting-with-iso.md
+++ b/content/docs/latest/installing/bare-metal/booting-with-iso.md
@@ -50,7 +50,9 @@ The latest Flatcar Container Linux ISOs can be downloaded from the image storage
 
 1. UEFI boot is not currently supported. Boot the system in BIOS compatibility mode.
 2. There is no straightforward way to provide an [Ignition config][cl-configs].
-3. A minimum of 2 GB of RAM is required to boot Flatcar Container Linux via ISO.
+   As a workaround though, it is possible to leverage the vga console to assign a password to the core user (sudo passwd core).
+   Once a password is set, it would be possible to provide a Butane or an Ignition file via SSH/SCP.
+4. A minimum of 2 GB of RAM is required to boot Flatcar Container Linux via ISO.
 
 ## Install to disk
 


### PR DESCRIPTION
# [Title: describe the change in one sentence]
Added a workaround to be able to provide a config when booting the .ISO. 

[ describe the change in 1 - 3 paragraphs ]
It is possible to assign a password to the core user through the VGA console, then a Butane (or an Ignition) configuration file could be either copy/pasted via SSH, or copied over using SCP.

## How to use
1. Boot the ISO
2. Access the VGA console
3. Run `sudo passwd core`
4. Enter a password
5. Log into the distro with `ssh core@<IP>` and copy/paste a Butane file (or use scp to copy the file over)
6. Follow the normal installation instructions

## Testing done
Steps 1 through 6 followed.
