### PR TITLE
theme: Add changes to migrate to Hugo v0.147

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,8 @@
 baseurl: "/"
 title: Flatcar Container Linux
 canonifyurls: true
-paginate: 8
+pagination:
+  pagerSize: 8
 theme: flatcar
 languageCode: en-us
 copyright: Copyright the Flatcar Project Contributors

--- a/themes/flatcar/layouts/docs/baseof.html
+++ b/themes/flatcar/layouts/docs/baseof.html
@@ -81,7 +81,7 @@
               {{ end }}
             </div>
 
-            {{ if (.Site.DisqusShortname) }}
+            {{ if (.Site.Config.Services.Disqus.Shortname) }}
               <br />
               {{ partial "disqus-comment.html" . }}
             {{ end }}

--- a/themes/flatcar/layouts/partials/head.html
+++ b/themes/flatcar/layouts/partials/head.html
@@ -85,7 +85,7 @@
 
     <!-- Custom CSS -->
     {{ $options := (dict "targetPath" "/css/style.css" "outputStyle" "compressed" "enableSourceMap" true) }}
-    {{ $style := resources.Get "scss/main.scss" | resources.ToCSS $options | fingerprint}}
+    {{ $style := resources.Get "scss/main.scss" | css.Sass $options | fingerprint}}
     <link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
 
     <!-- Favicon -->

--- a/themes/flatcar/layouts/partials/related-posts.html
+++ b/themes/flatcar/layouts/partials/related-posts.html
@@ -1,6 +1,6 @@
 <div class="article__related">
     {{ $page_link := .Permalink }}
-    {{ $posts := (where $.Site.Pages "Type" "blog").ByPublishDate.Reverse }}
+    {{ $posts := (where (where $.Site.Pages "Type" "blog") "Kind" "page").ByPublishDate.Reverse }}
     {{ $tags := default (slice) .Params.tags }}
     {{ $latestPosts := where $posts "Permalink" "!=" $page_link }}
     {{ $postsToDisplay := (slice) }}


### PR DESCRIPTION
Generating the website locally no longer works during releases and I've to push and rely on generating the preview link because Hugo fails with a couple of deprecation warnings.