### PR TITLE
using-nvidia: initial documentation

### DIFF
--- a/content/docs/latest/provisioning/sysext/_index.md
+++ b/content/docs/latest/provisioning/sysext/_index.md
@@ -44,16 +44,16 @@ Official extensions provided as part of a Flatcar release make Flatcar more modu
 
 The table below give an overview on the supported Flatcar extensions.
 
-| Extension Name         | Availability        | Documentation           |   Enabled by default    |
-|------------------------|---------------------|-------------------------|-------------------------|
-| `docker-flatcar`       | 3794.0.0  – …       |                         |           ✅            |
-| `containerd-flatcar`   | 3794.0.0  – …       |                         |           ✅            |
-| `flatcar-incus`        | 4285.0.0  – …       | [Incus][incusextension] |                         |
-| `oem-*`                | 3760.2.0 – …        |                         |           ✅            |
-| `flatcar-podman`       | 3941.0.0 – …        |                         |                         |
-| `flatcar-python`       | 4012.0.0 – …        |                         |                         |
-| `flatcar-zfs`          | 3913.0.0 – …        | [Storage][zfsextension] |                         |
-
+| Extension Name                       | Availability        | Documentation             |   Enabled by default    |
+|--------------------------------------|---------------------|---------------------------|-------------------------|
+| `containerd-flatcar`                 | 3794.0.0  – …       |                           |           ✅            |
+| `docker-flatcar`                     | 3794.0.0  – …       |                           |           ✅            |
+| `flatcar-incus`                      | 4285.0.0  – …       | [Incus][incusextension]   |                         |
+| `flatcar-nvidia-drivers-*`           | 4344.0.0 – …        | [NVIDIA][nvidiaextension] |                         |
+| `flatcar-podman`                     | 3941.0.0 – …        |                           |                         |
+| `flatcar-python`                     | 4012.0.0 – …        |                           |                         |
+| `flatcar-zfs`                        | 3913.0.0 – …        | [Storage][zfsextension]   |                         |
+| `oem-*`                              | 3760.2.0 – …        |                           |           ✅            |
 
 Users can enable Flatcar extensions by writing one name per line to `/etc/flatcar/enabled-sysext.conf`.
 For now there are no pre-enabled release extensions but once Flatcar would move parts of the base image out into extensions, these would be pre-enabled as entries in `/usr/share/flatcar/enabled-sysext.conf`. They can be disabled with a `-NAME` entry in `/etc/flatcar/enabled-sysext.conf`.
@@ -211,4 +211,5 @@ sudo SYSTEMD_LOG_LEVEL=debug systemd-sysext refresh
 
 [incusextension]: ../../container-runtimes/incus
 [sysext-bakery]: https://flatcar.github.io/sysext-bakery
+[nvidiaextension]: ../../setup/customization/using-nvidia
 [zfsextension]: ../../setup/storage/zfs

--- a/content/docs/latest/setup/customization/using-nvidia.md
+++ b/content/docs/latest/setup/customization/using-nvidia.md
@@ -8,23 +8,19 @@ weight: 30
 
 Flatcar Container Linux offers support for the installation and customization of NVIDIA drivers for Tesla GPUs (both in VMs and on bare metal). Please take note that NVIDIA drivers have been migrated from being solely available on AWS and Azure to being accessible on all platforms with the release of version 3637.0.0. If you are using an older version, please be aware that it is restricted to AWS and Azure only.
 
-During the initial boot, the `nvidia.service` automates hardware detection and triggers driver installation within a dedicated Flatcar developer container, ensuring a streamlined process. The current version of the installed NVIDIA driver can be found in the `/usr/share/flatcar/nvidia-metadata` file, assuming it's a vanilla installation and the version hasn't been customized (see below).
+Currently, there are two ways of installing NVIDIA drivers. First is using the built in `nvidia.service`, which automatically compiles the drivers from source on the first boot. Second is via an [official][official-sysext] NVIDIA drivers sysext, which contains prebuilt drivers, speeding up the provisioning. When using secure boot, only the prebuilt sysext will work, as the modules are signed.
 
-It's important to note that Flatcar Container Linux adheres strictly to NVIDIA's distribution terms, and therefore does not include pre-installed support for NVIDIA drivers. However, Flatcar simplifies the installation process by seamlessly integrating it into the first boot experience. This approach allows users to quickly and effortlessly set up the NVIDIA driver environment, aligning with NVIDIA's guidelines for driver distribution.
+We recommend using the prebuilt sysexts, but the `nvidia.service` is kept for backwards compatibility.
+
+### `nvidia.service` method
+
+During the initial boot, the `nvidia.service` automates hardware detection and triggers driver installation within a dedicated Flatcar developer container, ensuring a streamlined process. The current version of the installed NVIDIA driver can be found in the `/usr/share/flatcar/nvidia-metadata` file, assuming it's a vanilla installation and the version hasn't been customized (see below).
 
 Since the installation is triggered after boot, the overall installation time is around 5-10 minutes. To check the installation status, use the following command:
 
 ```
 # journalctl -u nvidia -f
 ```
-
-Once the installation is complete, you will have access to various NVIDIA commands. To verify the installation, run the command:
-
-```
-# nvidia-smi
-```
-
-### Customization
 
 To customize the version number of the NVIDIA driver, you can override the value in the `/etc/flatcar/nvidia-metadata` file by specifying the desired version in the `NVIDIA_DRIVER_VERSION`. However, it's important to ensure that the chosen driver version is compatible with the GPU hardware present in the instance.
 E.g., for older GPUs the 460 driver series is needed because the latest drivers dropped support for them.
@@ -36,7 +32,7 @@ sudo systemctl restart nvidia
 
 **Butane Config**
 
-```
+```yaml
 variant: flatcar
 version: 1.0.0
 storage:
@@ -46,3 +42,36 @@ storage:
       contents:
         inline: |
           NVIDIA_DRIVER_VERSION=460.106.00
+```
+
+### Prebuilt sysext method
+
+Flatcar provides official NVIDIA drivers sysext, built with every Flatcar release. As the kernel modules are built together with the kernel, they are signed with the ephemeral kernel modules signing key, which is important for secure boot support. During provisioning, the NVIDIA drivers sysext is downloaded and activated. The `nvidia.service` automatically detects an NVIDIA sysext has already been loaded and skips downloading and building them from source (therefore the version specified in `NVIDIA_DRIVER_VERSION` will be ignored).
+
+The drivers come in two flavours: open and non-open for `amd64` architecture.
+
+To activate the NVIDIA sysext:
+```yaml
+---
+# config.yaml
+# butane < config.yaml > config.json
+variant: flatcar
+version: 1.0.0
+
+storage:
+  files:
+  - path: /etc/flatcar/enabled-sysext.conf
+    contents:
+      inline: |
+        nvidia-drivers-570-open
+```
+
+### Testing
+
+Once the installation is complete (either via `nvidia.service` or sysext), you will have access to various NVIDIA commands. To verify the installation, run the command:
+
+```
+# nvidia-smi
+```
+
+[official-sysext]: https://www.flatcar.org/docs/latest/provisioning/sysext/#flatcar-release-extensions-official


### PR DESCRIPTION
This documents differences between the original nvidia.service and prebuilt sysext. It also provides basic example of Butane config.

