### PR TITLE
lts-4081.3.1: update OpenSSH version

### DIFF
--- a/data/releases/lts/4081.3.1.yml
+++ b/data/releases/lts/4081.3.1.yml
@@ -27,7 +27,7 @@ github_release:
     user_view_type: public
   body: "_Changes since **LTS 4081.3.0**_\r\n\r\n #### Security fixes:\r\n - openssh\
     \ ([CVE-2025-26465](https://nvd.nist.gov/vuln/detail/CVE-2025-26465), [CVE-2025-26466](https://nvd.nist.gov/vuln/detail/CVE-2025-26466))\r\
-    \n \r\n #### Updates:\r\n - openssh(9.8_p1-r4)"
+    \n \r\n #### Updates:\r\n - openssh(9.7_p1-r7)"
   created_at: '2025-02-13T16:18:08Z'
   draft: false
   html_url: https://github.com/flatcar/scripts/releases/tag/lts-4081.3.1


### PR DESCRIPTION
OpenSSH version on LTS is 9.7 (and not 9.8)

---

See: https://github.com/flatcar/scripts/commit/d3242208d21cdee3f699a5b7dccc9b1f275fe83b and https://lts.release.flatcar-linux.net/amd64-usr/current/flatcar_production_image_packages.txt

I think there had a confusion as this OpenSSH version was actually shipped for other channels (Alpha, Beta, Stable) at this time.

NOTE: We need to update the release notes here as well: https://github.com/flatcar/scripts/releases/tag/lts-4081.3.1

Related to: https://github.com/flatcar/Flatcar/issues/1773