### PR TITLE
ci(github-actions): fix path specification

### DIFF
--- a/.github/workflows/hugo-updates.yml
+++ b/.github/workflows/hugo-updates.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: "update/hugo-modules-${{ github.run_number }}"
+          path: .
           commit-message: "chore: update Hugo modules"
           title: "Update Hugo Modules"
           body: |
@@ -98,13 +99,12 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: "update/hugo-${{ steps.hugo.outputs.latest }}"
+          path: .
           title: "Update Hugo to ${{ steps.hugo.outputs.latest }}"
           body: |
             This PR updates Hugo from ${{ steps.hugo-version.outputs.current }} to ${{ steps.hugo.outputs.latest }}.
 
             Please review the [Hugo release notes](https://github.com/gohugoio/hugo/releases/tag/v${{ steps.hugo.outputs.latest }}) for any breaking changes.
           commit-message: "chore: update Hugo to ${{ steps.hugo.outputs.latest }}"
-          path: |
-            .env
           committer: "Flatcar Buildbot <buildbot@flatcar-linux.org>"
           author: "Flatcar Buildbot <buildbot@flatcar-linux.org>"


### PR DESCRIPTION
New GH Action job fails due to invalid path. [See the whole log.](https://github.com/flatcar/flatcar-website/actions/runs/15587515781/job/43897546956)
```
Prepare git configuration
  /usr/bin/git config --global --name-only --get-regexp safe.directory /home/runner/work/flatcar-website/flatcar-website/.env
  node:internal/child_process:420
      throw new ErrnoException(err, 'spawn');
            ^
  
  Error: spawn ENOTDIR
      at ChildProcess.spawn (node:internal/child_process:420:11)
      at Object.spawn (node:child_process:762:9)
      at ToolRunner.<anonymous> (/home/runner/work/_actions/peter-evans/create-pull-request/v7/dist/index.js:3552:34)
      at Generator.next (<anonymous>)
      at fulfilled (/home/runner/work/_actions/peter-evans/create-pull-request/v7/dist/index.js:3163:58) {
    errno: -20,
    code: 'ENOTDIR',
    syscall: 'spawn'
  }
  
  Node.js v20.19.1
```