### PR TITLE
ci(workflows): Add manual deployment trigger

### DIFF
--- a/.github/workflows/azure-static-web-apps-lemon-wave-085522403.yml
+++ b/.github/workflows/azure-static-web-apps-lemon-wave-085522403.yml
@@ -11,10 +11,16 @@ on:
   schedule:
     # Run at 00:01 daily
     - cron: '01 0 * * *'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull Request number to deploy'
+        required: true
+        type: string
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed') || github.event_name == 'schedule'
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed') || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:


### PR DESCRIPTION
# ci(workflows): Add manual deployment trigger

Detailed Description:  
This PR adds a `workflow_dispatch` trigger to our Azure Static Web Apps deployment workflow, enabling manual deployments from the GitHub Actions UI. The changes include:
- Adding an optional PR number input field for targeting specific pull requests
- Updating the trigger condition to include `workflow_dispatch` events
- Maintaining all existing automatic triggers (push, pull_request, schedule)

This enhancement gives developers more control over deployments, particularly useful for testing specific PRs.

## How to use
1. Navigate to GitHub Actions → Azure Static Web Apps workflow
2. Click "Run workflow" dropdown
3. Enter a PR number to deploy that specific branch
4. Click "Run workflow" button

## Testing to do after merge
- Trigger manual deployment with PR number
- Check if the workflow can be triggered without a PR number (it shouldn't be possilble)


