### PR TITLE
incus: document subuid/subgid creation

### DIFF
--- a/content/docs/latest/container-runtimes/incus.md
+++ b/content/docs/latest/container-runtimes/incus.md
@@ -17,6 +17,14 @@ variant: flatcar
 version: 1.1.0
 storage:
   files:
+    - path: /etc/subuid
+      append:
+        - inline: |
+            root:1065536:65536
+    - path: /etc/subgid
+      append:
+        - inline: |
+            root:1065536:65536
     - path: /etc/flatcar/enabled-sysext.conf
       contents:
         inline: |
@@ -60,6 +68,14 @@ variant: flatcar
 version: 1.1.0
 storage:
   files:
+    - path: /etc/subuid
+      append:
+        - inline: |
+            root:1065536:65536
+    - path: /etc/subgid
+      append:
+        - inline: |
+            root:1065536:65536
     - path: /etc/flatcar/enabled-sysext.conf
       contents:
         inline: |
@@ -155,6 +171,14 @@ variant: flatcar
 version: 1.1.0
 storage:
   files:
+    - path: /etc/subuid
+      append:
+        - inline: |
+            root:1065536:65536
+    - path: /etc/subgid
+      append:
+        - inline: |
+            root:1065536:65536
     - path: /etc/flatcar/enabled-sysext.conf
       contents:
         inline: |


### PR DESCRIPTION
Related to: https://github.com/flatcar/scripts/pull/3028

---
This create more issues than it solves:
* override existing subuid / subgid
* not flexible for the end user
* it has to be created only once (while tmpfiles always try to create those files)

I think Flatcar should not be responsible to create this and it should
be documented on how to do it through Ignition.