### PR TITLE
docs: Change IRC references to Matrix

### DIFF
--- a/content/docs/latest/installing/bare-metal/booting-with-pxe.md
+++ b/content/docs/latest/installing/bare-metal/booting-with-pxe.md
@@ -147,7 +147,7 @@ gpg --verify flatcar_production_pxe_image.cpio.gz.sig
 
 ## Booting the box
 
-After setting up the PXE server as outlined above you can start the target machine in PXE boot mode. The machine should grab the image from the server and boot into Flatcar Container Linux. If something goes wrong you can direct questions to the [IRC channel][irc] or [mailing list][flatcar-user].
+After setting up the PXE server as outlined above you can start the target machine in PXE boot mode. The machine should grab the image from the server and boot into Flatcar Container Linux. If something goes wrong you can direct questions to the [Matrix channel][matrix] or [mailing list][flatcar-user].
 
 ```shell
 This is localhost.unknown_domain (Linux x86_64 3.10.10+) 19:53:36
@@ -248,7 +248,7 @@ Now that you have a machine booted it is time to play around. Check out the [Fla
 
 [append-initrd]: http://www.syslinux.org/wiki/index.php?title=SYSLINUX#INITRD_initrd_file
 [flatcar-user]: https://groups.google.com/forum/#!forum/flatcar-linux-user
-[irc]: irc://irc.freenode.org:6667/#flatcar
+[matrix]: https://app.element.io/#/room/#flatcar:matrix.org
 [butane-configs]: ../../provisioning/config-transpiler
 [ignition]: ../../provisioning/ignition
 [ignition-kargs-ip]: ../../provisioning/ignition/network-configuration/#using-static-ip-addresses-with-ignition

--- a/content/docs/latest/installing/cloud/aws-ec2.md
+++ b/content/docs/latest/installing/cloud/aws-ec2.md
@@ -7,7 +7,7 @@ aliases:
     - ../../cloud-providers/booting-on-ec2
 ---
 
-The current AMIs for all Flatcar Container Linux channels and EC2 regions are listed below and updated frequently. Using CloudFormation is the easiest way to launch a cluster, but it is also possible to follow the manual steps at the end of the article. Questions can be directed to the Flatcar Container Linux [IRC channel][irc] or [user mailing list][flatcar-user].
+The current AMIs for all Flatcar Container Linux channels and EC2 regions are listed below and updated frequently. Using CloudFormation is the easiest way to launch a cluster, but it is also possible to follow the manual steps at the end of the article. Questions can be directed to the Flatcar Container Linux [Matrix channel][matrix] or [user mailing list][flatcar-user].
 
 At the end of the document there are instructions for deploying with Terraform.
 
@@ -498,8 +498,8 @@ You can find this Terraform module in the repository for [Flatcar Terraform exam
 [flatcar-user]: https://groups.google.com/forum/#!forum/flatcar-linux-user
 [docker-docs]: https://docs.docker.io
 [etcd-docs]: https://etcd.io/docs
-[irc]: irc://irc.freenode.org:6667/#flatcar
 [update-strategies]: ../../setup/releases/update-strategies
+[matrix]: https://app.element.io/#/room/#flatcar:matrix.org
 [release-notes]: https://flatcar-linux.org/releases
 [ec2-user-data]: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html
 [butane-configs]: ../../provisioning/config-transpiler

--- a/content/docs/latest/installing/vms/libvirt.md
+++ b/content/docs/latest/installing/vms/libvirt.md
@@ -13,7 +13,7 @@ that you already have a running libvirt setup and `virt-install` tool. If you
 don’t have that, other solutions are most likely easier.
 At the end of the document there are instructions for deploying with Terraform.
 
-You can direct questions to the [IRC channel][irc] or [mailing list][flatcar-dev].
+You can direct questions to the [Matrix channel][matrix] or [mailing list][flatcar-dev].
 
 ## Download the Flatcar Container Linux image
 
@@ -434,7 +434,7 @@ Log in via `ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null core
 When you make a change to `machine-mynode.yaml.tmpl` and run `terraform apply` again, the instance and its disk will be replaced.
 
 [flatcar-dev]: https://groups.google.com/forum/#!forum/flatcar-linux-dev
-[irc]: irc://irc.freenode.org:6667/#flatcar
+[matrix]: https://app.element.io/#/room/#flatcar:matrix.org
 [config-transpiler]: ../../provisioning/config-transpiler
 [update-strategies]: ../../setup/releases/update-strategies
 [release-notes]: https://flatcar-linux.org/releases

--- a/content/docs/latest/installing/vms/qemu.md
+++ b/content/docs/latest/installing/vms/qemu.md
@@ -9,7 +9,7 @@ aliases:
 
 These instructions will bring up a single Flatcar Container Linux instance under QEMU, the small Swiss Army knife of virtual machine and CPU emulators. If you need to do more such as [configuring networks][qemunet] differently refer to the [QEMU Wiki][qemuwiki] and [User Documentation][qemudoc].
 
-You can direct questions to the [IRC channel][irc] or [mailing list][flatcar-dev].
+You can direct questions to the [Matrix channel][matrix] or [mailing list][flatcar-dev].
 
 [qemunet]: http://wiki.qemu.org/Documentation/Networking
 [qemuwiki]: http://wiki.qemu.org/Manual
@@ -182,5 +182,5 @@ Now that you have a machine booted it is time to play around. Check out the [Fla
 [quickstart]: ../
 [doc-index]: ../../
 [flatcar-dev]: https://groups.google.com/forum/#!forum/flatcar-linux-dev
-[irc]: irc://irc.freenode.org:6667/#flatcar
+[matrix]: https://app.element.io/#/room/#flatcar:matrix.org
 [butane-configs]: ../../provisioning/config-transpiler

--- a/content/docs/latest/installing/vms/vagrant.md
+++ b/content/docs/latest/installing/vms/vagrant.md
@@ -11,7 +11,7 @@ _While we always welcome community contributions and fixes, please note that Vag
 
 Running Flatcar Container Linux with Vagrant is one way to bring up a single machine or virtualize an entire cluster on your laptop. Since the true power of Flatcar Container Linux can be seen with a cluster, we're going to concentrate on that. Instructions for a single machine can be found [towards the end](#single-machine) of the guide.
 
-You can direct questions to the [IRC channel][irc] or [mailing list][flatcar-dev].
+You can direct questions to the [Matrix channel][matrix] or [mailing list][flatcar-dev].
 
 ## Install Vagrant and VirtualBox
 
@@ -193,6 +193,6 @@ vagrant box add flatcar-alpha <path-to-box-file>
 Now that you have a machine booted it is time to play around. Check out the [Flatcar Container Linux Quickstart][quickstart] guide, learn about [CoreOS Container Linux clustering with Vagrant](https://coreos.com/blog/coreos-clustering-with-vagrant/), or dig into [more specific topics][doc-index].
 
 [flatcar-dev]: https://groups.google.com/forum/#!forum/flatcar-linux-dev
-[irc]: irc://irc.freenode.org:6667/#flatcar
+[matrix]: https://app.element.io/#/room/#flatcar:matrix.org
 [quickstart]: ../
 [doc-index]: ../../


### PR DESCRIPTION
IRC channel is mostly deprecated, and not used. The recommended platform is Matrix/Element now.