### PR TITLE
ci(github-actions): Create dummy releases PR workflow ahead of real one

### DIFF
--- a/.github/workflows/flatcar-releases-pr.yml
+++ b/.github/workflows/flatcar-releases-pr.yml
@@ -1,0 +1,17 @@
+name: Create Flatcar releases PR
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout flatcar-website repository
+        uses: actions/checkout@v4
+        with:
+          path: flatcar-website


### PR DESCRIPTION
I cannot test the real one without a dummy workflow having already been run once. I tried to test it in a fork, but it lacked the permissions to access the private flatcar-linux-release-info repo.