### PR TITLE
Add the CNCF copyright footer to existing copyright

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,12 @@ pagination:
   pagerSize: 8
 theme: flatcar
 languageCode: en-us
-copyright: Copyright the Flatcar Project Contributors
+copyright: |
+  Copyright © The Flatcar Project Contributors.
+  
+  Copyright © Flatcar a Series of LF Projects, LLC.
+
+  For website terms of use, trademark policy and other project policies please see <a href="https://lfprojects.org/policies/">lfprojects.org/policies</a>.
 pluralizelisttitles: "false"
 permalinks:
   blog: "/blog/:year/:month/:title/"

--- a/themes/flatcar/assets/scss/partials/footer.scss
+++ b/themes/flatcar/assets/scss/partials/footer.scss
@@ -149,21 +149,15 @@
 }
 
 .footer__copyright {
-  > p {
-    @include media-breakpoint-up(sm) {
-      text-align: right;
-    }
-
-    @include media-breakpoint-down(sm) {
-      text-align: center;
-    }
-  }
-}
-
-.footer__copyright {
-  > p {
-    margin-top: 15px;
+  a {
     color: $white;
+  }
+  > p {
+    margin-top: 5px;
+    margin-bottom: 5px;
+    color: $white;
+    display: block;
+    width: 100%;
 
     @include media-breakpoint-up(sm) {
       text-align: center;

--- a/themes/flatcar/layouts/partials/footer.html
+++ b/themes/flatcar/layouts/partials/footer.html
@@ -103,7 +103,7 @@
       {{ partial "socials.html" . }}
       </div>
       <div class="footer__copyright row justify-content-center p-0 pt-4">
-        <p>{{ .Site.Copyright }}</p>
+        <p>{{ .Site.Copyright | .RenderString }}</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
# Add the CNCF copyright footer

The CNCF has moved to a [Series LLC model](https://github.com/cncf/foundation/tree/main/agreements), where each project is "containerized" under the LF Projects LLC. This footer is appended on to the existing copyright footer.

This text is in the Contribution Agreement instructions sent to Flatcar earlier this year.

## How to use

Run the static site generator locally with these changes.

## Testing done

I ran this locally and tweaked the style sheet to ensure that the two new lines are working as individual stacked and spaced paragraphs.

You may want to style things slightly differently, which is OK as long as the text remains the same.

<img width="727" height="265" alt="image" src="https://github.com/user-attachments/assets/9eb3b355-54ff-4d36-be77-81796bab2577" />

