### PR TITLE
adding-swap: Fix the Butane swap file example

### DIFF
--- a/content/docs/latest/setup/storage/adding-swap.md
+++ b/content/docs/latest/setup/storage/adding-swap.md
@@ -152,7 +152,7 @@ systemd:
       contents: |
         [Unit]
         Description=Turn on swap
-        Requires=create-swapfile.service
+        BindsTo=create-swapfile.service
         After=create-swapfile.service
 
         [Swap]
@@ -169,8 +169,9 @@ systemd:
 
         [Service]
         Type=oneshot
-        ExecStart=/usr/bin/mkdir -p /var/vm
-        ExecStart=/usr/bin/mkswap --size 1024m --file /var/vm/swapfile1
+        ExecStartPre=mkdir -p /var/vm
+        ExecStartPre=rm -f /var/vm/swapfile1
+        ExecStart=mkswap --size 1024m --file /var/vm/swapfile1
         RemainAfterExit=true
 ```
 


### PR DESCRIPTION
Perhaps it worked properly in 2017, but the create-swapfile.service currently only works once because `mkswap` errors if you call it against an existing file, even if it is not being used.

Therefore remove the swap file before trying to create it. You cannot remove it when it is in use (contrary to Linux norms), so change `Requires` to `BindsTo`. This ensures the swap is disabled before create-swapfile.service (re)starts.

We could check for existence of the file instead, but swap file content becomes irrelevant once it is disabled. It is common practise to recreate encrypted swap partitions with a random key on every boot.

Tested against current stable and beta.

Bug: https://github.com/flatcar/Flatcar/issues/1847