### PR TITLE
Easier setup for verification

### DIFF
--- a/content/docs/latest/installing/vms/qemu.md
+++ b/content/docs/latest/installing/vms/qemu.md
@@ -65,7 +65,7 @@ Once QEMU is installed you can download and start the latest Flatcar Container L
 
 ### Choosing a channel
 
-Flatcar Container Linux is designed to be updated automatically with different schedules per channel. You can [disable this feature][update-strategies], although we don't recommend it. Read the [release notes][release-notes] for specific features and bug fixes.
+Flatcar Container Linux is designed to be updated automatically with different schedules per channel. You can [disable this feature][update-strategies], although we don't recommend it. Read the [release notes][release-notes] for specific features and bug fixes. To verify the images and scripts, import the key as described here [image-signing-key][image-signing-key].
 
 <div id="qemu-images">
   <ul class="nav nav-tabs">
@@ -184,3 +184,4 @@ Now that you have a machine booted it is time to play around. Check out the [Fla
 [flatcar-dev]: https://groups.google.com/forum/#!forum/flatcar-linux-dev
 [matrix]: https://app.element.io/#/room/#flatcar:matrix.org
 [butane-configs]: ../../provisioning/config-transpiler
+[image-signing-key]: ../../../../security/image-signing-key.md


### PR DESCRIPTION
Linking to the signing key as otherwise the step to verify the images and scripts fails. And this surprises people not aware what this means.

# Make sure signing key is linked from setup tutorial

In the setup for qemu it is stated to verify the downloaded script and image. As this is in the setup section, it could be the first time people interact with flatcar. So linking to the signingkey helps people to find it.

## How to use



## Testing done

I ran make run and made sure, that the file got linked correctly. 
