### PR TITLE
kubernetes: add kubernetes 1.34 to tested versions

### DIFF
--- a/content/docs/latest/container-runtimes/getting-started-with-kubernetes.md
+++ b/content/docs/latest/container-runtimes/getting-started-with-kubernetes.md
@@ -18,7 +18,7 @@ A Kubernetes basic scenario (deploy a simple Nginx) is being tested on Flatcar a
 One way to contribute to Flatcar would be to extend the covered CNIs (example: [kubenet][kubenet]) or to provide more complex scenarios (example: [cilium extension][cilium]).
 
 This is a compatibility matrix between Flatcar and Kubernetes deployed using vanilla components and Flatcar provided software:
-| :arrow_down: Flatcar channel \ Kubernetes Version :arrow_right: | 1.28               | 1.29               | 1.30               | 1.31 | 1.32 | 1.33 |
+| :arrow_down: Flatcar channel \ Kubernetes Version :arrow_right: | 1.29               | 1.30               | 1.31               | 1.32 | 1.33 | 1.34 |
 |--------------------------------------|--------------------|--------------------|--------------------|---------------------------------|------|------|
 | Alpha                                | :large_orange_diamond: | :large_orange_diamond: |:large_orange_diamond: |:white_check_mark: |:white_check_mark: |:white_check_mark: |
 | Beta                                 | :large_orange_diamond: | :large_orange_diamond: |:large_orange_diamond: |:white_check_mark: |:white_check_mark: |:white_check_mark: |


### PR DESCRIPTION
In this PR, we document that Kubernetes 1.34 is now tested and we exclude the old 1.28 Kubernetes release.

Needs:
- https://github.com/flatcar/mantle/pull/665
