### PR TITLE
kernel-modules: Fix race condition in documented systemd mount unit

### DIFF
--- a/content/docs/latest/reference/developer-guides/kernel-modules.md
+++ b/content/docs/latest/reference/developer-guides/kernel-modules.md
@@ -41,8 +41,10 @@ Create a mount unit to use `/opt/modules` at boot - `/etc/systemd/system/usr-lib
 ```ini
 [Unit]
 Description=Custom Kernel Modules
-Before=local-fs.target
 ConditionPathExists=/opt/modules
+Before=sysinit.target
+After=systemd-sysext.service
+DefaultDependencies=no
 
 [Mount]
 Type=overlay
@@ -51,7 +53,7 @@ Where=/usr/lib/modules
 Options=lowerdir=/usr/lib/modules,upperdir=/opt/modules,workdir=/opt/modules.wd
 
 [Install]
-WantedBy=local-fs.target
+UpheldBy=systemd-sysext.service
 ```
 
 Enable the unit so this overlay becomes available:


### PR DESCRIPTION
The /usr/lib/modules overlay is seemingly mounted too early, preventing the overlaid files from appearing despite the mount being listed. The system claims that the mount does not exist when attempting to unmount.

It appears to be racing with systemd-sysext.service, so schedule it to start after that. This happens after local-fs.target, so run before sysinit.target instead.

Subsequently running `systemd-sysext refresh` causes the overlay to become unmounted, but `UpheldBy` automatically mounts it again immediately afterwards.

Applying mutable mode to /usr might be preferable, but that apparently requires more work. This will do in the meantime.