### PR TITLE
Add: alpha.release-current qcow2 file to arm64 doc

### DIFF
--- a/content/docs/latest/installing/_index.md
+++ b/content/docs/latest/installing/_index.md
@@ -58,9 +58,8 @@ ARM64:
 wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi.sh
 chmod +x flatcar_production_qemu_uefi.sh
 wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi_image.img
-wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi_efi_code.fd
-wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi_efi_vars.fd
 wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi_efi_vars.qcow2
+wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi_efi_code.qcow2
 ```
 For Ignition configurations to be recognized we have to make sure that we always boot an unmodified fresh image because Ignition only runs on first boot.
 Therefore, before trying to use an Ignition config we will always discard the image modifications by using a fresh copy.


### PR DESCRIPTION
# Add qcow2 UEFI file to ARM64 QEMU instructions

This PR updates the ARM64 QEMU documentation by including the flatcar_production_qemu_uefi_efi_vars.qcow2 download step:

`wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi_efi_vars.qcow2`

The AMD64 flow already works with .img alone, but ARM64 explicitly needs this additional file.