### PR TITLE
docs: update references to Flatcar in documentation style guide and help enforce is using custom instructions for Copilot

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,26 @@
+---
+applyTo: "**"
+---
+# Flatcar Container Linux project conventions
+
+## Project names
+- Project names are proper nouns with an initial capital letter: Ignition, Dex, Matchbox.
+- The Linux distribution is called **Flatcar Container Linux**.
+
+## Specifics
+- The singular possessive form of CoreOS is *CoreOS's*.
+- Deployments occur *on-premises* (never "on-premise").
+- Expand acronyms on first use, with the short form in parentheses: Trusted Platform Module (TPM).
+
+## File name extensions
+- YAML: use `.yaml` (not `.yml`)
+- HTML: use `.html` (not `.htm`)
+
+## File naming
+- Use lower case, hyphen-separated names for files: `configuring-dns.md`, not `configuring_dns.md`.
+
+## Hugo
+- This is a Hugo site (Extended edition) using the `flatcar` theme.
+- Documentation lives under `content/docs/latest/`.
+- Blog posts live under `content/blog/`.
+- Custom shortcodes are available: `note`, `warning`, `caution`, `tabs`, `tab`, `include`, `mermaid`, and others defined in `themes/flatcar/layouts/shortcodes/`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,6 @@ applyTo: "**"
 - The Linux distribution is called **Flatcar Container Linux**.
 
 ## Specifics
-- The singular possessive form of CoreOS is *CoreOS's*.
 - Deployments occur *on-premises* (never "on-premise").
 - Expand acronyms on first use, with the short form in parentheses: Trusted Platform Module (TPM).
 

--- a/.github/instructions/flatcar-docs.instructions.md
+++ b/.github/instructions/flatcar-docs.instructions.md
@@ -1,0 +1,47 @@
+---
+name: "Flatcar Docs Style"
+description: "Documentation style and formatting conventions for Flatcar Container Linux docs"
+applyTo: "content/docs/**/*.md"
+---
+# Flatcar documentation style and formatting
+
+Based on the project style guide at `content/docs/latest/contribute/docs.md`.
+
+## English style
+- Write short sentences. Use the active voice. Avoid jargon.
+- Avoid the second person ("you"). Use the imperative impersonal tone: "Reboot the system" not "You should reboot your system."
+- Italicize terms of art on first appearance: *Kubernetes*.
+- One space after all punctuation marks.
+
+## Markdown symbols
+- Headings: ATX style (`#`, `##`, etc.), not underline style.
+- Bulleted lists: use asterisk (`*`), not hyphen (`-`).
+- Hyperlinks: use reference style (`[text][label]`) with labels defined at the end of the file, sorted alphabetically. Prefer relative links over absolute.
+- Italic: `*italic*`. Bold: `**bold**`.
+- Inline code: backticks for commands, file paths, and literal values.
+- Code blocks: fenced with triple backticks and a language tag (e.g., ` ```yaml `).
+
+## Headings
+- Use Sentence case: capitalize only the first word and proper nouns.
+- Each heading is preceded and followed by a blank line.
+- `h1` (`#`) is reserved for the document title (set via front matter, so do not add `#` headings in body).
+- `h2` (`##`) for primary concepts, `h3`/`h4` for sub-details.
+
+## Code blocks and commands
+- Include the shell prompt `$` to distinguish input from output.
+- Break long command lines with backslash (`\`) continuations; do not indent wrapped lines.
+- Add comments inline when possible, or on the line before the referenced code.
+
+## Placeholders
+- URLs: use `example.com` (RFC 2606).
+- IP addresses: use `203.0.113.0/24` range (RFC 5737).
+
+## Source formatting
+- Do not manually wrap long lines with newlines.
+- Do not add a line break between sentences; write natural paragraphs separated by blank lines.
+- Files are UTF-8 encoded, named in lower case with hyphens, and suffixed with `.md`.
+
+## Links
+- Name hyperlinks with maximum context: "see the [style guide][style]" not "click [here][style]."
+- Use relative URLs where possible for portability.
+- Link to Markdown source (`.md` extension); deployment scripts rewrite to `.html`.

--- a/content/docs/latest/contribute/docs.md
+++ b/content/docs/latest/contribute/docs.md
@@ -104,7 +104,7 @@ Flatcar documentation is written in [Markdown][mdhome], a simple way to annotate
 
 ### Source file naming and encoding
 
-Write Markdown source in UTF-encoded plain text files, named with a reasonable, lower case short form of the document's title, and suffixed with ``. Prefer hyphens to underscores in file names with two or more words. For example, instructions for DNS configuration are written to a file named [`configuring-dns`][configuring-dns].
+Write Markdown source in UTF-encoded plain text files, named with a reasonable, lower case short form of the document's title, and suffixed with `.md`. Prefer hyphens to underscores in file names with two or more words. For example, instructions for DNS configuration are written to a file named [`configuring-dns`][configuring-dns].
 
 ### Line wrapping considered harmful
 
@@ -183,8 +183,6 @@ Most documents have a single `h1` (`#`) heading matching the title, two to five 
 
 If a document proves a great deal longer or more structurally complex than those simplistic rules of thumb, there should be a good reason.
 
-![headings styles](Styles.png)
-
 ## Hyperlink considerations
 
 ### Naming
@@ -216,7 +214,7 @@ For example, there are two ways to refer to the [Flatcar quick start guide][quic
 
 #### Hyperlink deployment automation
 
-CoreOS documents have two major publication targets: the [docs.flatcar-linux.org documentation][flatcar-docs], and [GitHub's Markdown presentation][githubmd]. The deployment scripts used to build the CoreOS site handle some of the wrinkles arising between the two targets. These scripts expect links to other CoreOS project documentation to refer to the Markdown source; that is, to end with the `.md` file extension. The deployment scripts rewrite hyperlinks to replace that extension with `.html` for presentation. This allows the links to be valid in either context. External links are not rewritten.
+Flatcar documents have two major publication targets: the [docs.flatcar-linux.org documentation][flatcar-docs], and [GitHub's Markdown presentation][githubmd]. The deployment scripts used to build the Flatcar site handle some of the wrinkles arising between the two targets. These scripts expect links to other Flatcar project documentation to refer to the Markdown source; that is, to end with the `.md` file extension. The deployment scripts rewrite hyperlinks to replace that extension with `.html` for presentation. This allows the links to be valid in either context. External links are not rewritten.
 
 ## Example: Documenting code blocks
 
@@ -247,7 +245,7 @@ Some file types are commonly identified with more than one file name extension. 
 * HTML: `file.html`, not `file.htm`
 
 
-[command-line-grammar]: #command-line-grammar
+[command-line-grammar]: #unix-style-command-line-grammar
 [configuring-dns]: ../../setup/customization/configuring-dns
 [flatcar-docs]: https://docs.flatcar-linux.org/
 [economist-hyphens]: http://www.economist.com/news/books-and-arts/21723088-hyphens-can-be-tricky-they-need-not-drive-you-crazy-hysteria-over-hyphens
@@ -259,4 +257,4 @@ Some file types are commonly identified with more than one file name extension. 
 [quickstart]: ../../installing "Relative link from here to Flatcar Quick Start"
 [rfc2606s3]: https://tools.ietf.org/html/rfc2606#section-3
 [rfc5737]: https://tools.ietf.org/html/rfc5737
-[style]: docs "CoreOS Documentation Style"
+[style]: docs "Flatcar Documentation Style"


### PR DESCRIPTION
Add VS Code custom instructions for Copilot to enforce Flatcar documentation conventions automatically. This includes a project-wide copilot-instructions.md covering naming, file extensions, and Hugo structure, plus a docs-specific flatcar-docs.instructions.md that applies the style guide rules (impersonal tone, ATX headings, asterisk bullets, reference-style links, sentence case, fenced code blocks) whenever Copilot edits files under docs. Also fixes several issues in the existing style guide: missing `.md` suffix, broken `Styles.png` image reference, stale CoreOS references, and an incorrect anchor link.