### PR TITLE
docs: update weight values for various documentation pages

### DIFF
--- a/content/docs/latest/container-runtimes/incus.md
+++ b/content/docs/latest/container-runtimes/incus.md
@@ -1,7 +1,7 @@
 ---
 title: Incus
 description: Operate Incus from Flatcar
-weight: 11
+weight: 13
 ---
 
 While Flatcar proposes Containerd and Docker by default, [Incus][incus] can be used to run containers. The goal of this guide is not to re-write the Incus documentation but to give key aspects of Incus usage on Flatcar.

--- a/content/docs/latest/installing/bare-metal/booting-with-ipxe.md
+++ b/content/docs/latest/installing/bare-metal/booting-with-ipxe.md
@@ -1,7 +1,7 @@
 ---
 title: Booting Flatcar Container Linux via iPXE
 linktitle: Booting via iPXE
-weight: 10
+weight: 30
 aliases:
     - ../../os/booting-with-ipxe
     - ../../bare-metal/booting-with-ipxe

--- a/content/docs/latest/installing/bare-metal/booting-with-pxe.md
+++ b/content/docs/latest/installing/bare-metal/booting-with-pxe.md
@@ -1,7 +1,7 @@
 ---
 title: Booting Flatcar Container Linux via PXE
 linktitle: Booting via PXE
-weight: 10
+weight: 20
 aliases:
     - ../../os/booting-with-pxe
     - ../../bare-metal/booting-with-pxe

--- a/content/docs/latest/installing/bare-metal/installing-to-disk.md
+++ b/content/docs/latest/installing/bare-metal/installing-to-disk.md
@@ -4,7 +4,7 @@ linktitle: Using flatcar-install script
 description: >
   How to use the flatcar-install script to install Flatcar from
   a running system.
-weight: 10
+weight: 40
 aliases:
     - ../../os/installing-to-disk
     - ../../bare-metal/installing-to-disk

--- a/content/docs/latest/installing/bare-metal/raspberry-pi.md
+++ b/content/docs/latest/installing/bare-metal/raspberry-pi.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar Container Linux on Raspberry Pi 4
 linktitle: Running on Raspberry Pi 4
-weight: 10
+weight: 50
 ---
 ### Hardware Requirements
 

--- a/content/docs/latest/installing/cloud/_index.md
+++ b/content/docs/latest/installing/cloud/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud Providers
-weight: 20
+weight: 10
 description: >
   This section provides information and guidance on running Flatcar
   instances in different cloud environments.

--- a/content/docs/latest/installing/cloud/akamai.md
+++ b/content/docs/latest/installing/cloud/akamai.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar on Akamai Connected Cloud (Linode)
 linktitle: Running on Akamai
-weight: 10
+weight: 50
 ---
 
 These instructions will walk you throug running Flatcar on [Akamai Connected

--- a/content/docs/latest/installing/cloud/azure.md
+++ b/content/docs/latest/installing/cloud/azure.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar Container Linux on Microsoft Azure
 linktitle: Running on Microsoft Azure
-weight: 10
+weight: 15
 aliases:
     - ../../os/booting-on-azure
     - ../../cloud-providers/booting-on-azure

--- a/content/docs/latest/installing/cloud/brightbox.md
+++ b/content/docs/latest/installing/cloud/brightbox.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar on Brightbox
 linktitle: Running on Brightbox
-weight: 10
+weight: 45
 ---
 
 These instructions will walk you through using Flatcar on Brightbox, importing a custom image, and running your first server using the command line interface. Please note that Brightbox is compatible with OpenStack: it is not a mistake if we refer to OpenStack images and specific variables.

--- a/content/docs/latest/installing/cloud/digitalocean.md
+++ b/content/docs/latest/installing/cloud/digitalocean.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar Container Linux on DigitalOcean
 linktitle: Running on DigitalOcean
-weight: 20
+weight: 30
 aliases:
     - ../../os/booting-on-digitalocean
     - ../../cloud-providers/booting-on-digitalocean

--- a/content/docs/latest/installing/cloud/gcp.md
+++ b/content/docs/latest/installing/cloud/gcp.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar Container Linux on Google Compute Engine
 linktitle: Running on Google Compute Engine
-weight: 15
+weight: 20
 aliases:
     - ../../os/booting-on-google-compute-engine
     - ../../cloud-providers/booting-on-google-compute-engine

--- a/content/docs/latest/installing/cloud/hetzner.md
+++ b/content/docs/latest/installing/cloud/hetzner.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar Container Linux on Hetzner
 linktitle: Running on Hetzner
-weight: 20
+weight: 35
 aliases:
     - ../../os/booting-on-hetzner
     - ../../cloud-providers/booting-on-hetzner

--- a/content/docs/latest/installing/cloud/openstack.md
+++ b/content/docs/latest/installing/cloud/openstack.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar Container Linux on OpenStack
 linktitle: Running on OpenStack
-weight: 10
+weight: 40
 aliases:
     - ../../os/booting-on-openstack
     - ../../cloud-providers/booting-on-openstack

--- a/content/docs/latest/installing/cloud/stackit.md
+++ b/content/docs/latest/installing/cloud/stackit.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar on STACKIT
 linktitle: Running on STACKIT
-weight: 10
+weight: 55
 aliases:
     - ../../os/booting-on-stackit
     - ../../cloud-providers/booting-on-stackit

--- a/content/docs/latest/installing/cloud/using-google-cloud-launcher.md
+++ b/content/docs/latest/installing/cloud/using-google-cloud-launcher.md
@@ -4,7 +4,7 @@ linktitle: Using Google Cloud Launcher
 description: >
   How to use the Google Cloud Launcher Marketplace feature to launch
   Flatcar Container Linux on GCP
-weight: 15
+weight: 21
 aliases:
     - ../../os/using-google-cloud-launcher
     - ../../cloud-providers/using-google-cloud-launcher

--- a/content/docs/latest/installing/cloud/vmware.md
+++ b/content/docs/latest/installing/cloud/vmware.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar Container Linux on VMware
 linktitle: Running on VMware
-weight: 10
+weight: 25
 aliases:
     - ../../os/booting-on-vmware
     - ../../cloud-providers/booting-on-vmware

--- a/content/docs/latest/installing/community-platforms/eucalyptus.md
+++ b/content/docs/latest/installing/community-platforms/eucalyptus.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar Container Linux on Eucalyptus 3.4
 linktitle: Running on Eucalyptus 3.4
-weight: 10
+weight: 35
 aliases:
     - ../../os/booting-on-eucalyptus
     - ../../community-platforms/booting-on-eucalyptus

--- a/content/docs/latest/installing/community-platforms/notes-for-distributors.md
+++ b/content/docs/latest/installing/community-platforms/notes-for-distributors.md
@@ -1,6 +1,6 @@
 ---
 title: Notes for distributors
-weight: 10
+weight: 50
 aliases:
     - ../../os/notes-for-distributors
     - ../../bare-metal/notes-for-distributors

--- a/content/docs/latest/installing/community-platforms/ovhcloud.md
+++ b/content/docs/latest/installing/community-platforms/ovhcloud.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar on OVHcloud
 linktitle: Running on OVHcloud
-weight: 10
+weight: 15
 ---
 
 These instructions will walk you through using Flatcar on [OVHcloud][ovhcloud], importing an image, and running your first server using the OpenStack command line interface. Please note that OVHcloud is a community supported platform at the moment which means that the CI does not run on OpenStack images in OVHcloud environment.

--- a/content/docs/latest/installing/community-platforms/proxmoxve.md
+++ b/content/docs/latest/installing/community-platforms/proxmoxve.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar Container Linux on Proxmox VE
 linktitle: Running on Proxmox VE
-weight: 30
+weight: 40
 ---
 
 _Please note that Proxmox VE is not an officially supported platform at this time because the release tests don't run for it._

--- a/content/docs/latest/installing/community-platforms/rackspace.md
+++ b/content/docs/latest/installing/community-platforms/rackspace.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar Container Linux on Rackspace
 linktitle: Running on Rackspace
-weight: 10
+weight: 20
 aliases:
     - ../../os/booting-on-rackspace
     - ../../community-platforms/booting-on-rackspace

--- a/content/docs/latest/installing/community-platforms/scaleway.md
+++ b/content/docs/latest/installing/community-platforms/scaleway.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar on Scaleway
 linktitle: Running on Scaleway
-weight: 10
+weight: 25
 ---
 
 These instructions will walk you through using Flatcar on [Scaleway][scaleway], importing an image, and running your first server using the command line interface. Please note that Scaleway is a community supported platform at the moment which means that the CI does not run on Scaleway images.

--- a/content/docs/latest/installing/community-platforms/vultr.md
+++ b/content/docs/latest/installing/community-platforms/vultr.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar Container Linux on a Vultr VPS
 linktitle: Running on a Vultr VPS
-weight: 10
+weight: 30
 aliases:
     - ../../os/booting-on-vultr
     - ../../community-platforms/booting-on-vultr

--- a/content/docs/latest/installing/customizing-the-image/_index.md
+++ b/content/docs/latest/installing/customizing-the-image/_index.md
@@ -3,5 +3,5 @@ title: Customizing the image
 description: >
   This section provides information and guidance on customizing
   Flatcar images by placing files on the root or OEM filesystem or embedding an Ignition config.
-weight: 20
+weight: 35
 ---

--- a/content/docs/latest/installing/vms/hyper-v.md
+++ b/content/docs/latest/installing/vms/hyper-v.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar Container Linux on Hyper-V
 linktitle: Running on Hyper-V
-weight: 30
+weight: 50
 ---
 
 _While we always welcome community contributions and fixes, please note that Hyper-V is not an officially supported platform at this time because the release tests don't run for it. (See the [platform overview](/#installing-flatcar).)_

--- a/content/docs/latest/installing/vms/kubevirt.md
+++ b/content/docs/latest/installing/vms/kubevirt.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar Container Linux on KubeVirt
 linktitle: Running on KubeVirt
-weight: 30
+weight: 60
 ---
 
 _While we always welcome community contributions and fixes, please note that KubeVirt is not an officially supported platform at this time because the release tests don't run for it. (See the [platform overview](/#installing-flatcar).)_

--- a/content/docs/latest/installing/vms/libvirt.md
+++ b/content/docs/latest/installing/vms/libvirt.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar Container Linux on libvirt
 linktitle: Running on libvirt
-weight: 30
+weight: 20
 aliases:
     - ../../os/booting-with-libvirt
     - ../../cloud-providers/booting-with-libvirt

--- a/content/docs/latest/installing/vms/qemu.md
+++ b/content/docs/latest/installing/vms/qemu.md
@@ -1,6 +1,6 @@
 ---
 title: Running on QEMU
-weight: 30
+weight: 10
 aliases:
     - ../../os/booting-with-qemu
     - ../../cloud-providers/booting-with-qemu

--- a/content/docs/latest/installing/vms/vagrant.md
+++ b/content/docs/latest/installing/vms/vagrant.md
@@ -1,7 +1,7 @@
 ---
 title: Running Flatcar Container Linux on Vagrant
 linktitle: Running on Vagrant
-weight: 30
+weight: 40
 aliases:
     - ../../os/booting-on-vagrant
     - ../../cloud-providers/booting-on-vagrant

--- a/content/docs/latest/reference/constants-and-ids.md
+++ b/content/docs/latest/reference/constants-and-ids.md
@@ -1,6 +1,6 @@
 ---
 title: Constants and IDs
-weight: 10
+weight: 30
 aliases:
     - ../os/constants-and-ids
 ---

--- a/content/docs/latest/reference/developer-guides/kernel-modules.md
+++ b/content/docs/latest/reference/developer-guides/kernel-modules.md
@@ -1,6 +1,6 @@
 ---
 title: Building custom kernel modules
-weight: 10
+weight: 20
 aliases:
     - ../../os/kernel-modules
 ---

--- a/content/docs/latest/reference/developer-guides/sdk-bootstrapping.md
+++ b/content/docs/latest/reference/developer-guides/sdk-bootstrapping.md
@@ -1,6 +1,6 @@
 ---
 title: SDK bootstrap process
-weight: 10
+weight: 40
 ---
 
 ## Introduction

--- a/content/docs/latest/reference/developer-guides/sdk-disk-partitions.md
+++ b/content/docs/latest/reference/developer-guides/sdk-disk-partitions.md
@@ -1,6 +1,6 @@
 ---
 title: Flatcar Container Linux disk layout
-weight: 10
+weight: 50
 aliases:
     - ../../os/sdk-disk-partitions
 ---

--- a/content/docs/latest/reference/developer-guides/sdk-modifying-flatcar.md
+++ b/content/docs/latest/reference/developer-guides/sdk-modifying-flatcar.md
@@ -1,6 +1,6 @@
 ---
 title: Guide to building custom Flatcar images from source
-weight: 10
+weight: 5
 aliases:
     - ../../os/sdk-modifying-flatcar
     - ../../os/sdk-modifying-coreos

--- a/content/docs/latest/reference/developer-guides/sdk-tips-and-tricks.md
+++ b/content/docs/latest/reference/developer-guides/sdk-tips-and-tricks.md
@@ -1,6 +1,6 @@
 ---
 title: Tips and tricks
-weight: 10
+weight: 30
 aliases:
     - ../../os/sdk-tips-and-tricks
 ---

--- a/content/docs/latest/reference/integrations.md
+++ b/content/docs/latest/reference/integrations.md
@@ -1,6 +1,6 @@
 ---
 title: Integrations
-weight: 10
+weight: 20
 aliases:
     - ../os/integrations
 ---

--- a/content/docs/latest/reference/supply-chain.md
+++ b/content/docs/latest/reference/supply-chain.md
@@ -1,6 +1,6 @@
 ---
 title: Supply chain security mechanisms
-weight: 10
+weight: 40
 ---
 
 


### PR DESCRIPTION
Several doc sections had pages with the same `weight` in their frontmatter, causing Hugo to sort them alphabetically instead of matching the order on the overview pages.

Gave each page a unique weight so the sidebar matches the intended order defined in the `_index.md` listings.
