### PR TITLE
docs: add Discord link and logo to community section

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,11 +28,13 @@ params:
   Email: hello@kinvolk.io
   Subtitle: Linux for containers
   social:
-    - title: bluesky
-      url: "https://bsky.app/profile/flatcar.org"
     - title: github
       url: "https://github.com/flatcar"
       image: "github-icon"
+    - title: discord
+      url: "https://discord.gg/WzcVxuhYHX"
+    - title: bluesky
+      url: "https://bsky.app/profile/flatcar.org"
     - title: mastodon
       url: "https://hachyderm.io/@flatcar"
     - title: x-twitter

--- a/config.yaml
+++ b/config.yaml
@@ -32,7 +32,7 @@ params:
       url: "https://github.com/flatcar"
       image: "github-icon"
     - title: discord
-      url: "https://discord.gg/WzcVxuhYHX"
+      url: "https://discord.gg/PMYjFUsJyq"
     - title: bluesky
       url: "https://bsky.app/profile/flatcar.org"
     - title: mastodon

--- a/content/_index.md
+++ b/content/_index.md
@@ -59,7 +59,7 @@ community_links:
       items:
         - title: "Discord"
           icon: "discord"
-          link: "https://discord.gg/WzcVxuhYHX"
+          link: "https://discord.gg/PMYjFUsJyq"
         - title: "Matrix"
           svg_path: "/images/matrix-icon.svg"
           link: "https://app.element.io/#/room/#flatcar:matrix.org"

--- a/content/_index.md
+++ b/content/_index.md
@@ -57,6 +57,9 @@ community_links:
           link: "https://x.com/flatcar"
     - title: "Ask Questions & Connect"
       items:
+        - title: "Discord"
+          icon: "discord"
+          link: "https://discord.gg/WzcVxuhYHX"
         - title: "Matrix"
           svg_path: "/images/matrix-icon.svg"
           link: "https://app.element.io/#/room/#flatcar:matrix.org"


### PR DESCRIPTION
This pull request updates the project's social and community links to add Discord as a new communication channel and adjusts the order of social links for consistency.

Additions and updates to social and community links:

* Added a Discord link to the `params:social` section in `config.yaml`, and reordered the Bluesky link for consistency.
* Added Discord as an option in the "Ask Questions & Connect" section in `content/_index.md`.