### PR TITLE
themes/releases.html: Add link to github release tracker

### DIFF
--- a/themes/flatcar/layouts/section/releases.html
+++ b/themes/flatcar/layouts/section/releases.html
@@ -10,6 +10,12 @@
     A Flatcar instance receives <b>automatic</b> updates from a specific release channel. The <i>Stable</i> channel is the default, and new major releases only appear there after passing through the <i>Alpha</i> and <i>Beta</i> channels. Each release channel always points to the latest release in that particular channel, linked as the <code>current</code> release. Each release has a version number and separate release notes. Learn more about updating and release channels in the <a href="https://www.flatcar.org/docs/latest/setup/releases/switching-channels/">channel docs</a>. Click <code>amd64</code> or <code>arm64</code> to download images for the channel's <code>current</code> release from the channel overview below, or for a particular version from the release notes below that. Then, you will be able to choose from many images for various platforms. The <a href="https://www.flatcar.org/docs/latest/installing/">installation docs</a> have a quick start guide and information about public images directly available at each cloud provider.
     </p>
     </div>
+    <div class="container" align="center">
+    <h4 >Release schedule</h4>
+    <p>
+    Release planning and schedules for upcoming releases are available on our <a href="https://github.com/orgs/flatcar/projects/7/views/24">GitHub project</a>.
+    </p>
+    </div>
     <div class="container">
       <h2 class="text-center mb-5 mt-3">Release Channels</h2>
       <div class="card-deck-wrapper">


### PR DESCRIPTION
We recently started tracking upcoming releases in a GitHub project "roadmap" board. This change adds a link to that board at the top of the "releases" page.