### PR TITLE
docs: update contributing information and enhance GitHub link visibility

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -99,7 +99,7 @@ menu:
     - name: GitHub
       url: "https://github.com/flatcar"
       identifier: github
-      pre: <i class="fa-brands fa-github"></i>
+      pre: <i class="fa-brands fa-github fa-2x"></i>
       weight: -1
 
 enableEmoji: true

--- a/content/_index.md
+++ b/content/_index.md
@@ -38,10 +38,10 @@ hero:
 community_section: true
 community_links:
   groups:
-    - title: "Contribute & Collaborate"
+    - title: "Get Involved"
       items:
-        - title: "GitHub"
-          link: "https://github.com/flatcar"
+        - title: "Contributing Guide"
+          link: "https://github.com/flatcar/Flatcar/blob/main/CONTRIBUTING.md"
           icon: "github"
           class: "github-wordmark"
     - title: "Stay Updated & Follow Us"


### PR DESCRIPTION
Add link to the contributing guide in the community section and as a hero button. Make the GitHub icon in the navbar bigger.