### PR TITLE
Add CNCF Slack link to release guide

### DIFF
--- a/content/docs/latest/reference/developer-guides/release-guide.md
+++ b/content/docs/latest/reference/developer-guides/release-guide.md
@@ -487,3 +487,4 @@ Post release notes to:
 * Social media accounts
 * [Discord](https://discord.gg/PMYjFUsJyq)
 * [Kubernetes Slack](https://kubernetes.slack.com/archives/C03GQ8B5XNJ)
+* [CNCF Slack](https://cloud-native.slack.com/archives/C07LW8GQ4F9)


### PR DESCRIPTION
This pull request adds the CNCF Slack channel to the list of places where release notes should be posted in the release guide documentation.

- Documentation update:
  * Added the CNCF Slack channel (`https://cloud-native.slack.com/archives/C07LW8GQ4F9`) to the "Post release notes to:" section in `release-guide.md`.
