### PR TITLE
Refactor code blocks in documentation to use custom highlight shortcode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,20 @@ all: getdeps docs presentations
 	hugo --theme=flatcar
 	npx -y pagefind@1.4.0 --site public
 
+PYTHON ?= python3
+
 getdeps:
-	pip3 install --upgrade pyyaml
+	@if $(PYTHON) -c 'import yaml' 2>/dev/null; then \
+		echo "pyyaml already installed for $(PYTHON)"; \
+	elif command -v uv >/dev/null 2>&1; then \
+		uv pip install --system pyyaml; \
+	else \
+		$(PYTHON) -m pip install --upgrade --user pyyaml; \
+	fi
 
 .PHONY: docs
 docs:
-	@python3 ./tools/fcl-fetch-version-data.py ./content/docs/_index.md.in > ./content/docs/_index.md
+	@$(PYTHON) ./tools/fcl-fetch-version-data.py ./content/docs/_index.md.in > ./content/docs/_index.md
 
 # Build all presentations (idempotent)
 .PHONY: presentations
@@ -31,14 +39,16 @@ presentations:
 	done
 
 run:
-	hugo server --theme=flatcar --buildFuture --watch --disableFastRender --config ./config.yaml\,./tmp_modules.yaml
+	@echo "Hugo dev server: http://localhost:1313/"
+	hugo server --theme=flatcar --buildFuture --watch --disableFastRender --baseURL http://localhost:1313/ --config ./config.yaml\,./tmp_modules.yaml
 
 # Like 'run' but builds to disk first so pagefind search works locally.
 # Note: no live-reload; re-run after content changes.
 serve: docs
 	hugo --theme=flatcar --buildFuture
 	npx -y pagefind@1.4.0 --site public
-	cd public && python3 -m http.server 1313
+	@echo "Static server: http://localhost:1313/"
+	cd public && $(PYTHON) -m http.server 1313
 
 build-preview: getdeps docs
 	hugo --theme=flatcar -F -b ${DEPLOY_PRIME_URL}

--- a/README.md
+++ b/README.md
@@ -60,6 +60,34 @@ categories:
 
 *TODO: Add more content sections (events, job postings, etc.)*
 
+### Code snippets
+
+Code snippets are syntax-highlighted with Chroma (configured under `markup.highlight` in [`config.yaml`](./config.yaml)) and wrapped in a `.code-block` container that provides a copy-to-clipboard button. Two authoring forms render identically; pick the one that fits the surrounding markup.
+
+**1. Fenced code blocks (preferred)** — use these in normal Markdown:
+
+````markdown
+```bash
+echo "hello"
+```
+````
+
+These go through the [`render-codeblock.html`](./themes/flatcar/layouts/_default/_markup/render-codeblock.html) Markdown render hook, which adds the `.code-block` wrapper and copy button automatically.
+
+**2. The `highlight` shortcode** — use this inside raw HTML blocks (for example `<div class="tab-pane">`, where Goldmark treats the contents as opaque HTML and will not parse fenced blocks):
+
+```text
+<div class="tab-pane" id="stable">
+  {{< highlight bash >}}
+echo "hello"
+  {{< /highlight >}}
+</div>
+```
+
+The theme overrides Hugo's built-in `highlight` shortcode at [`themes/flatcar/layouts/shortcodes/highlight.html`](./themes/flatcar/layouts/shortcodes/highlight.html) so it emits the same `.code-block` wrapper, copy button, and padding as fenced blocks. The first positional argument is the language (use `bash`, `yaml`, `go`, …); `shell` is aliased to `bash`.
+
+Do **not** add raw `<pre>…</pre>` blocks — they bypass both Chroma and the copy-button wrapper.
+
 ### Presentations
 
 Create HTML presentations from screenshots using Marp (requires Docker):

--- a/content/docs/latest/container-runtimes/getting-started-with-kubernetes.md
+++ b/content/docs/latest/container-runtimes/getting-started-with-kubernetes.md
@@ -56,7 +56,7 @@ Here are two examples to setup a control plane with [Butane][butane]. The first 
         This is an example using systemd-sysext and systemd-sysupdate. NOTE: We are using <a href="https://kured.dev/docs/">Kured</a> to coordinate nodes reboot when there is a new Kubernetes sysext image available (or if Flatcar has been updated), hence the /run/reboot-required file.
         **Note:** In these examples, the hostname is manually set via initial provisioning (`/etc/hostname`).
         In cloud environments, the hostname can be set dynamically from metadata exposed at `/run/metadata/flatcar`
-        <pre>
+        {{< highlight yaml >}}
 ---
 version: 1.0.0
 variant: flatcar
@@ -110,13 +110,13 @@ systemd:
         ExecStart=/usr/bin/chown -R core:core /home/core/.kube
         [Install]
         WantedBy=multi-user.target
-        </pre>
+{{< /highlight >}}
       </div>
     </div>
     <div class="tab-pane" id="no-sysext">
       <div class="channel-info">
         :warning: To ease the reading, we voluntarily omitted the checksums of the downloaded artifacts.
-        <pre>
+        {{< highlight yaml >}}
 ---
 version: 1.0.0
 variant: flatcar
@@ -185,7 +185,7 @@ systemd:
         ExecStart=/usr/bin/chown -R core:core /home/core/.kube
         [Install]
         WantedBy=multi-user.target
-        </pre>
+{{< /highlight >}}
       </div>
     </div>
   </div>
@@ -232,7 +232,7 @@ Here's are two examples for a [butane][butane] configuration to setup the nodes.
     <div class="tab-pane active" id="sysext-nodes">
       <div class="channel-info">
         This is an example using systemd-sysext and systemd-sysupdate. NOTE: We are using <a href="https://kured.dev/docs/">Kured</a> to coordinate nodes reboot when there is a new Kubernetes sysext image available (or if Flatcar has been updated), hence the /run/reboot-required file.
-        <pre>
+        {{< highlight yaml >}}
 ---
 version: 1.0.0
 variant: flatcar
@@ -283,13 +283,13 @@ systemd:
         ExecStart=/usr/bin/kubeadm join $(output from 'kubeadm token create --print-join-command')
         [Install]
         WantedBy=multi-user.target
-        </pre>
+{{< /highlight >}}
       </div>
     </div>
     <div class="tab-pane" id="no-sysext-nodes">
       <div class="channel-info">
         :warning: To ease the reading, we voluntarily omitted the checksums of the downloaded artifacts.
-        <pre>
+        {{< highlight yaml >}}
 ---
 version: 1.0.0
 variant: flatcar
@@ -336,7 +336,7 @@ systemd:
         ExecStart=/opt/bin/kubeadm join $(output from 'kubeadm token create --print-join-command')
         [Install]
         WantedBy=multi-user.target
-        </pre>
+{{< /highlight >}}
       </div>
     </div>
   </div>

--- a/content/docs/latest/installing/bare-metal/booting-with-ipxe.md
+++ b/content/docs/latest/installing/bare-metal/booting-with-ipxe.md
@@ -48,35 +48,38 @@ Flatcar Container Linux is designed to be updated automatically with different s
     <div class="tab-pane" id="alpha-create">
       <p>The Alpha channel closely tracks master and is released frequently. The newest versions of system libraries and utilities will be available for testing. The current version is Flatcar Container Linux {{< param alpha_channel >}}.</p>
       <p>iPXE downloads a boot script from a publicly available URL. You will need to host this URL somewhere public and replace the example SSH key with your own. You can also run a <a href="https://github.com/kelseyhightower/coreos-ipxe-server">custom iPXE server</a>.</p>
-      <pre>
+      {{< highlight bash >}}
 #!ipxe
 
 set base-url http://alpha.release.flatcar-linux.net/amd64-usr/current
 kernel ${base-url}/flatcar_production_pxe.vmlinuz initrd=flatcar_production_pxe_image.cpio.gz flatcar.first_boot=1 ignition.config.url=https://example.com/pxe-config.ign
 initrd ${base-url}/flatcar_production_pxe_image.cpio.gz
-boot</pre>
+boot
+{{< /highlight >}}
     </div>
     <div class="tab-pane" id="beta-create">
       <p>The Beta channel consists of promoted Alpha releases. The current version is Flatcar Container Linux {{< param beta_channel >}}.</p>
       <p>iPXE downloads a boot script from a publicly available URL. You will need to host this URL somewhere public and replace the example SSH key with your own. You can also run a <a href="https://github.com/kelseyhightower/coreos-ipxe-server">custom iPXE server</a>.</p>
-      <pre>
+      {{< highlight bash >}}
 #!ipxe
 
 set base-url http://beta.release.flatcar-linux.net/amd64-usr/current
 kernel ${base-url}/flatcar_production_pxe.vmlinuz initrd=flatcar_production_pxe_image.cpio.gz flatcar.first_boot=1 ignition.config.url=https://example.com/pxe-config.ign
 initrd ${base-url}/flatcar_production_pxe_image.cpio.gz
-boot</pre>
+boot
+{{< /highlight >}}
     </div>
     <div class="tab-pane active" id="stable-create">
       <p>The Stable channel should be used by production clusters. Versions of Flatcar Container Linux are battle-tested within the Beta and Alpha channels before being promoted. The current version is Flatcar Container Linux {{< param stable_channel >}}.</p>
       <p>iPXE downloads a boot script from a publicly available URL. You will need to host this URL somewhere public and replace the example SSH key with your own. You can also run a <a href="https://github.com/kelseyhightower/coreos-ipxe-server">custom iPXE server</a>.</p>
-      <pre>
+      {{< highlight bash >}}
 #!ipxe
 
 set base-url http://stable.release.flatcar-linux.net/amd64-usr/current
 kernel ${base-url}/flatcar_production_pxe.vmlinuz initrd=flatcar_production_pxe_image.cpio.gz flatcar.first_boot=1 ignition.config.url=https://example.com/pxe-config.ign
 initrd ${base-url}/flatcar_production_pxe_image.cpio.gz
-boot</pre>
+boot
+{{< /highlight >}}
     </div>
   </div>
 </div>

--- a/content/docs/latest/installing/bare-metal/booting-with-pxe.md
+++ b/content/docs/latest/installing/bare-metal/booting-with-pxe.md
@@ -104,7 +104,7 @@ PXE booted machines cannot currently update themselves when new versions are rel
       <p>The Alpha channel closely tracks master and is released frequently. The newest versions of system libraries and utilities will be available for testing. The current version is Flatcar Container Linux {{< param alpha_channel >}}.</p>
       <p>In the config above you can see that a Kernel image and a initramfs file is needed. Download these two files into your tftp root.</p>
       <p>The <code>flatcar_production_pxe.vmlinuz.sig</code> and <code>flatcar_production_pxe_image.cpio.gz.sig</code> files can be used to <a href="../../community-platforms/notes-for-distributors#importing-images">verify the downloaded files</a>.</p>
-      <pre>
+      {{< highlight bash >}}
 cd /var/lib/tftpboot
 wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe.vmlinuz
 wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe.vmlinuz.sig
@@ -112,13 +112,13 @@ wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_productio
 wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe_image.cpio.gz.sig
 gpg --verify flatcar_production_pxe.vmlinuz.sig
 gpg --verify flatcar_production_pxe_image.cpio.gz.sig
-      </pre>
+{{< /highlight >}}
     </div>
     <div class="tab-pane" id="beta-create">
       <p>The Beta channel consists of promoted Alpha releases. The current version is Flatcar Container Linux {{< param beta_channel >}}.</p>
       <p>In the config above you can see that a Kernel image and a initramfs file is needed. Download these two files into your tftp root.</p>
       <p>The <code>flatcar_production_pxe.vmlinuz.sig</code> and <code>flatcar_production_pxe_image.cpio.gz.sig</code> files can be used to <a href="../../community-platforms/notes-for-distributors#importing-images">verify the downloaded files</a>.</p>
-      <pre>
+      {{< highlight bash >}}
 cd /var/lib/tftpboot
 wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe.vmlinuz
 wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe.vmlinuz.sig
@@ -126,13 +126,13 @@ wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production
 wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe_image.cpio.gz.sig
 gpg --verify flatcar_production_pxe.vmlinuz.sig
 gpg --verify flatcar_production_pxe_image.cpio.gz.sig
-      </pre>
+{{< /highlight >}}
     </div>
     <div class="tab-pane active" id="stable-create">
       <p>The Stable channel should be used by production clusters. Versions of Flatcar Container Linux are battle-tested within the Beta and Alpha channels before being promoted. The current version is Flatcar Container Linux {{< param stable_channel >}}.</p>
       <p>In the config above you can see that a Kernel image and a initramfs file is needed. Download these two files into your tftp root.</p>
       <p>The <code>flatcar_production_pxe.vmlinuz.sig</code> and <code>flatcar_production_pxe_image.cpio.gz.sig</code> files can be used to <a href="../../community-platforms/notes-for-distributors#importing-images">verify the downloaded files</a>.</p>
-      <pre>
+      {{< highlight bash >}}
 cd /var/lib/tftpboot
 wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe.vmlinuz
 wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe.vmlinuz.sig
@@ -140,7 +140,7 @@ wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_producti
 wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe_image.cpio.gz.sig
 gpg --verify flatcar_production_pxe.vmlinuz.sig
 gpg --verify flatcar_production_pxe_image.cpio.gz.sig
-      </pre>
+{{< /highlight >}}
     </div>
   </div>
 </div>

--- a/content/docs/latest/installing/bare-metal/installing-to-disk.md
+++ b/content/docs/latest/installing/bare-metal/installing-to-disk.md
@@ -58,17 +58,23 @@ Flatcar Container Linux is designed to be [updated automatically][update-strateg
     <div class="tab-pane" id="alpha-create">
       <p>The Alpha channel closely tracks master and is released frequently. The newest versions of system libraries and utilities will be available for testing. The current version is Flatcar Container Linux {{< param alpha_channel >}}.</p>
       <p>If you want to ensure you are installing the latest alpha version, use the <code>-C</code> option:</p>
-      <pre>flatcar-install -d /dev/sda -C alpha</pre>
+      {{< highlight bash >}}
+flatcar-install -d /dev/sda -C alpha
+{{< /highlight >}}
     </div>
     <div class="tab-pane" id="beta-create">
       <p>The Beta channel consists of promoted Alpha releases. The current version is Flatcar Container Linux {{< param beta_channel >}}.</p>
       <p>If you want to ensure you are installing the latest beta version, use the <code>-C</code> option:</p>
-      <pre>flatcar-install -d /dev/sda -C beta</pre>
+      {{< highlight bash >}}
+flatcar-install -d /dev/sda -C beta
+{{< /highlight >}}
     </div>
     <div class="tab-pane active" id="stable-create">
       <p>The Stable channel should be used by production clusters. Versions of Flatcar Container Linux are battle-tested within the Beta and Alpha channels before being promoted. The current version is Flatcar Container Linux {{< param stable_channel >}}.</p>
       <p>If you want to ensure you are installing the latest stable version, use the <code>-C</code> option:</p>
-      <pre>flatcar-install -d /dev/sda -C stable</pre>
+      {{< highlight bash >}}
+flatcar-install -d /dev/sda -C stable
+{{< /highlight >}}
     </div>
   </div>
 </div>

--- a/content/docs/latest/installing/cloud/azure.md
+++ b/content/docs/latest/installing/cloud/azure.md
@@ -41,7 +41,7 @@ The following command will create a single instance through the Azure CLI.
       <div class="channel-info">
         <p>The Stable channel should be used by production clusters. Versions of Flatcar Container Linux are battle-tested within
         the Beta and Alpha channels before being promoted. The current version is Flatcar Container Linux {{< param stable_channel >}}.</p>
-        <pre>
+        {{< highlight bash >}}
 $ az vm image list --all -p kinvolk -f flatcar -s stable-gen2 --query '[-1]'  # Query the image name urn specifier
 {
   "architecture": "x64",
@@ -52,13 +52,13 @@ $ az vm image list --all -p kinvolk -f flatcar -s stable-gen2 --query '[-1]'  # 
   "version": "{{< param stable_channel >}}"
 }
 $ az vm create --name node-1 --resource-group group-1 --admin-username core --user-data config.ign --image kinvolk:flatcar-container-linux-free:stable-gen2:{{< param stable_channel >}}
-        </pre>
+{{< /highlight >}}
       </div>
     </div>
     <div class="tab-pane" id="beta">
       <div class="channel-info">
         <p>The Beta channel consists of promoted Alpha releases. The current version is Flatcar Container Linux {{< param beta_channel >}}.</p>
-        <pre>
+        {{< highlight bash >}}
 $ az vm image list --all -p kinvolk -f flatcar -s beta-gen2 --query '[-1]'  # Query the image name urn specifier
 {
   "architecture": "x64",
@@ -69,14 +69,14 @@ $ az vm image list --all -p kinvolk -f flatcar -s beta-gen2 --query '[-1]'  # Qu
   "version": "{{< param beta_channel >}}"
 }
 $ az vm create --name node-1 --resource-group group-1 --admin-username core --user-data config.ign --image kinvolk:flatcar-container-linux-free:beta-gen2:{{< param beta_channel >}}
-        </pre>
+{{< /highlight >}}
       </div>
     </div>
     <div class="tab-pane" id="alpha">
       <div class="channel-info">
         <p>The Alpha channel closely tracks the master branch and is released frequently. The newest versions of system
         libraries and utilities are available for testing in this channel. The current version is Flatcar Container Linux {{< param alpha_channel >}}.</p>
-        <pre>
+        {{< highlight bash >}}
 $ az vm image list --all -p kinvolk -f flatcar -s alpha-gen2 --query '[-1]'
 {
   "architecture": "x64",
@@ -87,13 +87,13 @@ $ az vm image list --all -p kinvolk -f flatcar -s alpha-gen2 --query '[-1]'
   "version": "{{< param alpha_channel >}}"
 }
 $ az vm create --name node-1 --resource-group group-1 --admin-username core --user-data config.ign --image kinvolk:flatcar-container-linux-free:alpha-gen2:{{< param alpha_channel >}}
-        </pre>
+{{< /highlight >}}
       </div>
     </div>
     <div class="tab-pane" id="lts">
       <div class="channel-info">
         <p>LTS release streams are maintained for an extended lifetime of 18 months. The yearly LTS streams have an overlap of 6 months. The current version is Flatcar Container Linux {{< param lts_channel >}}.</p>
-        <pre>
+        {{< highlight bash >}}
 $ az vm image list --all -p kinvolk -f flatcar -s {{< param lts_azure_sku >}}-gen2 --query '[-1]'
 {
   "architecture": "x64",
@@ -104,7 +104,7 @@ $ az vm image list --all -p kinvolk -f flatcar -s {{< param lts_azure_sku >}}-ge
   "version": "{{< param lts_channel >}}"
 }
 $ az vm create --name node-1 --resource-group group-1 --admin-username core --user-data config.ign --image kinvolk:flatcar-container-linux-free:{{< param lts_azure_sku >}}-gen2:{{< param lts_channel >}}
-        </pre>
+{{< /highlight >}}
       </div>
     </div>
   </div>

--- a/content/docs/latest/installing/cloud/gcp.md
+++ b/content/docs/latest/installing/cloud/gcp.md
@@ -33,19 +33,27 @@ Create 3 instances from the image above using our Ignition from `example.ign`:
   <div class="tab-content coreos-docs-image-table">
     <div class="tab-pane active" id="stable-create">
       <p>The Stable channel should be used by production clusters. Versions of Flatcar Container Linux are battle-tested within the Beta and Alpha channels before being promoted. The current version is Flatcar Container Linux {{< param stable_channel >}}.</p>
-      <pre>gcloud compute instances create flatcar1 flatcar2 flatcar3 --image-project kinvolk-public --image-family flatcar-stable --zone us-central1-a --machine-type n1-standard-1 --metadata-from-file user-data=config.ign</pre>
+      {{< highlight bash >}}
+gcloud compute instances create flatcar1 flatcar2 flatcar3 --image-project kinvolk-public --image-family flatcar-stable --zone us-central1-a --machine-type n1-standard-1 --metadata-from-file user-data=config.ign
+{{< /highlight >}}
     </div>
     <div class="tab-pane" id="beta-create">
       <p>The Beta channel consists of promoted Alpha releases. The current version is Flatcar Container Linux {{< param beta_channel >}}.</p>
-      <pre>gcloud compute instances create flatcar1 flatcar2 flatcar3 --image-project kinvolk-public --image-family flatcar-beta --zone us-central1-a --machine-type n1-standard-1 --metadata-from-file user-data=config.ign</pre>
+      {{< highlight bash >}}
+gcloud compute instances create flatcar1 flatcar2 flatcar3 --image-project kinvolk-public --image-family flatcar-beta --zone us-central1-a --machine-type n1-standard-1 --metadata-from-file user-data=config.ign
+{{< /highlight >}}
     </div>
     <div class="tab-pane" id="alpha-create">
       <p>The Alpha channel closely tracks master and is released frequently. The newest versions of system libraries and utilities will be available for testing. The current version is Flatcar Container Linux {{< param alpha_channel >}}.</p>
-      <pre>gcloud compute instances create flatcar1 flatcar2 flatcar3 --image-project kinvolk-public --image-family flatcar-alpha --zone us-central1-a --machine-type n1-standard-1 --metadata-from-file user-data=config.ign</pre>
+      {{< highlight bash >}}
+gcloud compute instances create flatcar1 flatcar2 flatcar3 --image-project kinvolk-public --image-family flatcar-alpha --zone us-central1-a --machine-type n1-standard-1 --metadata-from-file user-data=config.ign
+{{< /highlight >}}
     </div>
     <div class="tab-pane" id="lts-create">
       <p>LTS release streams are maintained for an extended lifetime of 18 months. The yearly LTS streams have an overlap of 6 months. The current version is Flatcar Container Linux {{< param lts_channel >}}.</p>
-      <pre>gcloud compute instances create flatcar1 flatcar2 flatcar3 --image-project kinvolk-public --image-family flatcar-lts --zone us-central1-a --machine-type n1-standard-1 --metadata-from-file user-data=config.ign</pre>
+      {{< highlight bash >}}
+gcloud compute instances create flatcar1 flatcar2 flatcar3 --image-project kinvolk-public --image-family flatcar-lts --zone us-central1-a --machine-type n1-standard-1 --metadata-from-file user-data=config.ign
+{{< /highlight >}}
     </div>
   </div>
 </div>

--- a/content/docs/latest/installing/cloud/openstack.md
+++ b/content/docs/latest/installing/cloud/openstack.md
@@ -26,24 +26,24 @@ Flatcar Container Linux is designed to be updated automatically with different s
   <div class="tab-content coreos-docs-image-table">
     <div class="tab-pane" id="alpha-create">
       <p>The Alpha channel closely tracks master and is released frequently. The newest versions of system libraries and utilities will be available for testing. The current version is Flatcar Container Linux {{< param alpha_channel >}}.</p>
-<pre>
+{{< highlight bash >}}
 $ wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_openstack_image.img.bz2
 $ bunzip2 flatcar_production_openstack_image.img.bz2
-</pre>
+{{< /highlight >}}
     </div>
     <div class="tab-pane" id="beta-create">
       <p>The Beta channel consists of promoted Alpha releases. The current version is Flatcar Container Linux {{< param beta_channel >}}.</p>
-<pre>
+{{< highlight bash >}}
 $ wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_openstack_image.img.bz2
 $ bunzip2 flatcar_production_openstack_image.img.bz2
-</pre>
+{{< /highlight >}}
     </div>
   <div class="tab-pane active" id="stable-create">
       <p>The Stable channel should be used by production clusters. Versions of Flatcar Container Linux are battle-tested within the Beta and Alpha channels before being promoted. The current version is Flatcar Container Linux {{< param stable_channel >}}.</p>
-<pre>
+{{< highlight bash >}}
 $ wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_openstack_image.img.bz2
 $ bunzip2 flatcar_production_openstack_image.img.bz2
-</pre>
+{{< /highlight >}}
     </div>
   </div>
 </div>

--- a/content/docs/latest/installing/community-platforms/eucalyptus.md
+++ b/content/docs/latest/installing/community-platforms/eucalyptus.md
@@ -26,7 +26,7 @@ Flatcar Container Linux is designed to be updated automatically with different s
   <div class="tab-content coreos-docs-image-table">
     <div class="tab-pane" id="alpha-create">
       <p>The Alpha channel closely tracks master and is released frequently. The newest versions of system libraries and utilities will be available for testing. The current version is Flatcar Container Linux {{< param alpha_channel >}}.</p>
-      <pre>
+      {{< highlight bash >}}
 $ wget -q https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_openstack_image.img.bz2
 $ bunzip2 flatcar_production_openstack_image.img.bz2
 $ qemu-img convert -O raw flatcar_production_openstack_image.img flatcar_production_openstack_image.raw
@@ -37,11 +37,11 @@ $ euca-upload-bundle -m /var/tmp/flatcar_production_openstack_image.raw.manifest
 Uploaded flatcar-production/flatcar_production_openstack_image.raw.manifest.xml
 $ euca-register flatcar-production/flatcar_production_openstack_image.raw.manifest.xml --virtualization-type hvm --name "Flatcar Container Linux-Production"
 emi-E4A33D45
-      </pre>
+{{< /highlight >}}
     </div>
     <div class="tab-pane" id="beta-create">
       <p>The Beta channel consists of promoted Alpha releases. The current version is Flatcar Container Linux {{< param beta_channel >}}.</p>
-      <pre>
+      {{< highlight bash >}}
 $ wget -q https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_openstack_image.img.bz2
 $ bunzip2 flatcar_production_openstack_image.img.bz2
 $ qemu-img convert -O raw flatcar_production_openstack_image.img flatcar_production_openstack_image.raw
@@ -52,11 +52,11 @@ $ euca-upload-bundle -m /var/tmp/flatcar_production_openstack_image.raw.manifest
 Uploaded flatcar-production/flatcar_production_openstack_image.raw.manifest.xml
 $ euca-register flatcar-production/flatcar_production_openstack_image.raw.manifest.xml --virtualization-type hvm --name "Flatcar Container Linux-Production"
 emi-E4A33D45
-      </pre>
+{{< /highlight >}}
     </div>
     <div class="tab-pane active" id="stable-create">
       <p>The Stable channel should be used by production clusters. Versions of Flatcar Container Linux are battle-tested within the Beta and Alpha channels before being promoted. The current version is Flatcar Container Linux {{< param stable_channel >}}.</p>
-      <pre>
+      {{< highlight bash >}}
 $ wget -q https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_openstack_image.img.bz2
 $ bunzip2 flatcar_production_openstack_image.img.bz2
 $ qemu-img convert -O raw flatcar_production_openstack_image.img flatcar_production_openstack_image.raw
@@ -67,7 +67,7 @@ $ euca-upload-bundle -m /var/tmp/flatcar_production_openstack_image.raw.manifest
 Uploaded flatcar-production/flatcar_production_openstack_image.raw.manifest.xml
 $ euca-register flatcar-production/flatcar_production_openstack_image.raw.manifest.xml --virtualization-type hvm --name "Flatcar Container Linux-Production"
 emi-E4A33D45
-      </pre>
+{{< /highlight >}}
     </div>
   </div>
 </div>

--- a/content/docs/latest/installing/community-platforms/proxmoxve.md
+++ b/content/docs/latest/installing/community-platforms/proxmoxve.md
@@ -21,21 +21,21 @@ Flatcar Container Linux is designed to be updated automatically with different s
   <div class="tab-content coreos-docs-image-table">
     <div class="tab-pane" id="alpha-create">
       <p>The Alpha channel closely tracks master and is released frequently. The newest versions of system libraries and utilities will be available for testing. The current version is Flatcar Container Linux {{< param alpha_channel >}}.</p>
-<pre>
+{{< highlight bash >}}
 $ wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_proxmoxve_image.img
-</pre>
+{{< /highlight >}}
     </div>
     <div class="tab-pane" id="beta-create">
       <p>The Beta channel consists of promoted Alpha releases. The current version is Flatcar Container Linux {{< param beta_channel >}}.</p>
-<pre>
+{{< highlight bash >}}
 $ wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_proxmoxve_image.img
-</pre>
+{{< /highlight >}}
     </div>
   <div class="tab-pane active" id="stable-create">
       <p>The Stable channel should be used by production clusters. Versions of Flatcar Container Linux are battle-tested within the Beta and Alpha channels before being promoted. The current version is Flatcar Container Linux {{< param stable_channel >}}.</p>
-<pre>
+{{< highlight bash >}}
 $ wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_proxmoxve_image.img
-</pre>
+{{< /highlight >}}
     </div>
   </div>
 </div>

--- a/content/docs/latest/installing/community-platforms/rackspace.md
+++ b/content/docs/latest/installing/community-platforms/rackspace.md
@@ -24,21 +24,27 @@ Flatcar Container Linux is designed to be updated automatically with different s
       <div class="channel-info">
         <p>The Alpha channel closely tracks master and is released frequently. The newest versions of system libraries and utilities will be available for testing. The current version is Flatcar Container Linux {{< param alpha_channel >}}.</p>
         <p>The following command can be used to determine the image IDs for Alpha:</p>
-        <pre>supernova production image-list | grep 'Flatcar Container Linux (Alpha)'</pre>
+        {{< highlight bash >}}
+supernova production image-list | grep 'Flatcar Container Linux (Alpha)'
+{{< /highlight >}}
       </div>
     </div>
     <div class="tab-pane" id="beta">
       <div class="channel-info">
         <p>The Beta channel consists of promoted Alpha releases. The current version is Flatcar Container Linux {{< param beta_channel >}}.</p>
         <p>The following command can be used to determine the image IDs for Beta:</p>
-        <pre>supernova production image-list | grep 'Flatcar Container Linux (Beta)'</pre>
+        {{< highlight bash >}}
+supernova production image-list | grep 'Flatcar Container Linux (Beta)'
+{{< /highlight >}}
       </div>
     </div>
     <div class="tab-pane active" id="stable">
       <div class="channel-info">
         <p>The Stable channel should be used by production clusters. Versions of Flatcar Container Linux are battle-tested within the Beta and Alpha channels before being promoted. The current version is Flatcar Container Linux {{< param stable_channel >}}.</p>
         <p>The following command can be used to determine the image IDs for Stable:</p>
-        <pre>supernova production image-list | grep 'Flatcar Container Linux (Stable)'</pre>
+        {{< highlight bash >}}
+supernova production image-list | grep 'Flatcar Container Linux (Stable)'
+{{< /highlight >}}
       </div>
     </div>
   </div>
@@ -158,17 +164,25 @@ Check you make sure the key is in your list by running `supernova production key
   <div class="tab-content coreos-docs-image-table">
     <div class="tab-pane" id="alpha-create">
       <p>Boot a new Cloud Server with our new keypair and specify optional cloud-config data:</p>
-      <pre>supernova production boot --image &lt;image-id&gt; --flavor performance1-2 --key-name flatcar-key --user-data ~/cloud_config.yml --config-drive true My_Flatcar_Server</pre>
+      {{< highlight bash >}}
+supernova production boot --image &lt;image-id&gt; --flavor performance1-2 --key-name flatcar-key --user-data ~/cloud_config.yml --config-drive true My_Flatcar_Server
+{{< /highlight >}}
       <p>Boot a new OnMetal Server with our new keypair and specify optional cloud-config data:</p>
-      <pre>supernova production boot --image &lt;image-id&gt; --flavor onmetal-compute1 --key-name flatcar-key --user-data ~/cloud_config.yml --config-drive true My_Flatcar_Server</pre>
+      {{< highlight bash >}}
+supernova production boot --image &lt;image-id&gt; --flavor onmetal-compute1 --key-name flatcar-key --user-data ~/cloud_config.yml --config-drive true My_Flatcar_Server
+{{< /highlight >}}
     </div>
     <div class="tab-pane" id="beta-create">
       <p>Boot a new Cloud Server with our new keypair and specify optional cloud-config data:</p>
-      <pre>supernova production boot --image &lt;image-id&gt; --flavor performance1-2 --key-name flatcar-key --user-data ~/cloud_config.yml --config-drive true My_Flatcar_Server</pre>
+      {{< highlight bash >}}
+supernova production boot --image &lt;image-id&gt; --flavor performance1-2 --key-name flatcar-key --user-data ~/cloud_config.yml --config-drive true My_Flatcar_Server
+{{< /highlight >}}
     </div>
     <div class="tab-pane active" id="stable-create">
       <p>Boot a new Cloud Server with our new keypair and specify optional cloud-config data:</p>
-      <pre>supernova production boot --image &lt;image-id&gt; --flavor performance1-2 --key-name flatcar-key --user-data ~/cloud_config.yml --config-drive true My_Flatcar_Server</pre>
+      {{< highlight bash >}}
+supernova production boot --image &lt;image-id&gt; --flavor performance1-2 --key-name flatcar-key --user-data ~/cloud_config.yml --config-drive true My_Flatcar_Server
+{{< /highlight >}}
     </div>
   </div>
 </div>

--- a/content/docs/latest/installing/community-platforms/vmware.md
+++ b/content/docs/latest/installing/community-platforms/vmware.md
@@ -27,25 +27,33 @@ Flatcar Container Linux is designed to be updated automatically with different s
       <div class="channel-info">
         <p>The Stable channel should be used by production clusters. Versions of Flatcar Container Linux are battle-tested within the Beta and Alpha channels before being promoted. The current version is Flatcar Container Linux {{< param stable_channel >}}.</p>
        </div>
-      <pre>curl -LO https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vmware_ova.ova</pre>
+      {{< highlight bash >}}
+curl -LO https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vmware_ova.ova
+{{< /highlight >}}
     </div>
     <div class="tab-pane" id="beta">
       <div class="channel-info">
         <p>The Beta channel consists of promoted Alpha releases. The current version is Flatcar Container Linux {{< param beta_channel >}}.</p>
       </div>
-      <pre>curl -LO https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vmware_ova.ova</pre>
+      {{< highlight bash >}}
+curl -LO https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vmware_ova.ova
+{{< /highlight >}}
     </div>
     <div class="tab-pane" id="alpha">
       <div class="channel-info">
         <p>The Alpha channel closely tracks master and is released frequently. The newest versions of system libraries and utilities will be available for testing. The current version is Flatcar Container Linux {{< param alpha_channel >}}.</p>
       </div>
-      <pre>curl -LO https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vmware_ova.ova</pre>
+      {{< highlight bash >}}
+curl -LO https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vmware_ova.ova
+{{< /highlight >}}
     </div>
     <div class="tab-pane" id="lts">
       <div class="channel-info">
         <p>LTS release streams are maintained for an extended lifetime of 18 months. The yearly LTS streams have an overlap of 6 months. The current version is Flatcar Container Linux {{< param lts_channel >}}.</p>
       </div>
-      <pre>curl -LO https://lts.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vmware_ova.ova</pre>
+      {{< highlight bash >}}
+curl -LO https://lts.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vmware_ova.ova
+{{< /highlight >}}
     </div>
   </div>
 </div>

--- a/content/docs/latest/installing/community-platforms/vultr.md
+++ b/content/docs/latest/installing/community-platforms/vultr.md
@@ -55,7 +55,8 @@ Flatcar Container Linux is designed to be updated automatically with different s
       </div>
       <p>A sample script will look like this:</p>
 
-<pre>#!ipxe
+{{< highlight bash >}}
+#!ipxe
 
 # Location of your shell script.
 set cloud-config-url http://example.com/cloud-config-bootstrap.sh
@@ -64,7 +65,7 @@ set base-url https://alpha.release.flatcar-linux.net/amd64-usr/current
 kernel ${base-url}/flatcar_production_pxe.vmlinuz cloud-config-url=${cloud-config-url}
 initrd ${base-url}/flatcar_production_pxe_image.cpio.gz
 boot
-</pre>
+{{< /highlight >}}
   </div>
     <div class="tab-pane" id="beta">
       <div class="channel-info">
@@ -72,7 +73,8 @@ boot
       </div>
       <p>A sample script will look like this:</p>
 
-<pre>#!ipxe
+{{< highlight bash >}}
+#!ipxe
 
 # Location of your shell script.
 set cloud-config-url http://example.com/cloud-config-bootstrap.sh
@@ -80,7 +82,8 @@ set cloud-config-url http://example.com/cloud-config-bootstrap.sh
 set base-url https://beta.release.flatcar-linux.net/amd64-usr/current
 kernel ${base-url}/flatcar_production_pxe.vmlinuz cloud-config-url=${cloud-config-url}
 initrd ${base-url}/flatcar_production_pxe_image.cpio.gz
-boot</pre>
+boot
+{{< /highlight >}}
   </div>
     <div class="tab-pane active" id="stable">
       <div class="channel-info">
@@ -88,7 +91,8 @@ boot</pre>
       </div>
       <p>A sample script will look like this:</p>
 
-<pre>#!ipxe
+{{< highlight bash >}}
+#!ipxe
 
 # Location of your shell script.
 set cloud-config-url http://example.com/cloud-config-bootstrap.sh
@@ -96,7 +100,8 @@ set cloud-config-url http://example.com/cloud-config-bootstrap.sh
 set base-url https://stable.release.flatcar-linux.net/amd64-usr/current
 kernel ${base-url}/flatcar_production_pxe.vmlinuz cloud-config-url=${cloud-config-url}
 initrd ${base-url}/flatcar_production_pxe_image.cpio.gz
-boot</pre>
+boot
+{{< /highlight >}}
   </div>
   </div>
 </div>

--- a/content/docs/latest/installing/vms/libvirt.md
+++ b/content/docs/latest/installing/vms/libvirt.md
@@ -35,29 +35,32 @@ Flatcar Container Linux is designed to be updated automatically with different s
     <div class="tab-pane" id="alpha-create">
       <p>The Alpha channel closely tracks master and is released frequently. The newest versions of system libraries and utilities will be available for testing. The current version is Flatcar Container Linux {{< param alpha_channel >}}.</p>
       <p>We start by downloading the most recent disk image:</p>
-      <pre>
+{{< highlight bash >}}
 mkdir -p /var/lib/libvirt/images/flatcar-linux
 cd /var/lib/libvirt/images/flatcar-linux
 wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img{,.sig}
-gpg --verify flatcar_production_qemu_image.img.sig</pre>
+gpg --verify flatcar_production_qemu_image.img.sig
+{{< /highlight >}}
     </div>
     <div class="tab-pane" id="beta-create">
       <p>The Beta channel consists of promoted Alpha releases. The current version is Flatcar Container Linux {{< param beta_channel >}}.</p>
       <p>We start by downloading the most recent disk image:</p>
-      <pre>
+{{< highlight bash >}}
 mkdir -p /var/lib/libvirt/images/flatcar-linux
 cd /var/lib/libvirt/images/flatcar-linux
 wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img{,.sig}
-gpg --verify flatcar_production_qemu_image.img.sig</pre>
+gpg --verify flatcar_production_qemu_image.img.sig
+{{< /highlight >}}
     </div>
     <div class="tab-pane active" id="stable-create">
       <p>The Stable channel should be used by production clusters. Versions of Flatcar Container Linux are battle-tested within the Beta and Alpha channels before being promoted. The current version is Flatcar Container Linux {{< param stable_channel >}}.</p>
       <p>We start by downloading the most recent disk image:</p>
-      <pre>
+{{< highlight bash >}}
 mkdir -p /var/lib/libvirt/images/flatcar-linux
 cd /var/lib/libvirt/images/flatcar-linux
 wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img{,.sig}
-gpg --verify flatcar_production_qemu_image.img.sig</pre>
+gpg --verify flatcar_production_qemu_image.img.sig
+{{< /highlight >}}
     </div>
   </div>
 </div>

--- a/content/docs/latest/installing/vms/qemu.md
+++ b/content/docs/latest/installing/vms/qemu.md
@@ -79,14 +79,16 @@ Flatcar Container Linux is designed to be updated automatically with different s
        </div>
       <p>There are two files you need: the disk image (provided in qcow2
       format) and the wrapper shell script to start QEMU.</p>
-      <pre>mkdir flatcar; cd flatcar
+      {{< highlight bash >}}
+mkdir flatcar; cd flatcar
 wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu.sh
 wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu.sh.sig
 wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img
 wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.sig
 gpg --verify flatcar_production_qemu.sh.sig
 gpg --verify flatcar_production_qemu_image.img.sig
-chmod +x flatcar_production_qemu.sh</pre>
+chmod +x flatcar_production_qemu.sh
+{{< /highlight >}}
     </div>
     <div class="tab-pane" id="alpha">
       <div class="channel-info">
@@ -94,14 +96,16 @@ chmod +x flatcar_production_qemu.sh</pre>
       </div>
       <p>There are two files you need: the disk image (provided in qcow2
       format) and the wrapper shell script to start QEMU.</p>
-      <pre>mkdir flatcar; cd flatcar
+      {{< highlight bash >}}
+mkdir flatcar; cd flatcar
 wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu.sh
 wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu.sh.sig
 wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img
 wget https://alpha.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.sig
 gpg --verify flatcar_production_qemu.sh.sig
 gpg --verify flatcar_production_qemu_image.img.sig
-chmod +x flatcar_production_qemu.sh</pre>
+chmod +x flatcar_production_qemu.sh
+{{< /highlight >}}
     </div>
     <div class="tab-pane" id="beta">
       <div class="channel-info">
@@ -109,14 +113,16 @@ chmod +x flatcar_production_qemu.sh</pre>
       </div>
       <p>There are two files you need: the disk image (provided in qcow2
       format) and the wrapper shell script to start QEMU.</p>
-      <pre>mkdir flatcar; cd flatcar
+      {{< highlight bash >}}
+mkdir flatcar; cd flatcar
 wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu.sh
 wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu.sh.sig
 wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img
 wget https://beta.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img.sig
 gpg --verify flatcar_production_qemu.sh.sig
 gpg --verify flatcar_production_qemu_image.img.sig
-chmod +x flatcar_production_qemu.sh</pre>
+chmod +x flatcar_production_qemu.sh
+{{< /highlight >}}
     </div>
   </div>
 </div>

--- a/content/docs/latest/installing/vms/virtualbox.md
+++ b/content/docs/latest/installing/vms/virtualbox.md
@@ -43,23 +43,23 @@ Flatcar Container Linux is designed to be updated automatically with different s
     <div class="tab-pane" id="alpha-create">
       <p>The Alpha channel closely tracks master and is released frequently. The newest versions of system libraries and utilities will be available for testing. The current version is Flatcar Container Linux {{< param alpha_channel >}}.</p>
       <p>Create a disk image from this channel by running:</p>
-<pre>
+{{< highlight bash >}}
 ./create-coreos-vdi -V alpha
-</pre>
+{{< /highlight >}}
     </div>
     <div class="tab-pane" id="beta-create">
       <p>The Beta channel consists of promoted Alpha releases. The current version is Flatcar Container Linux {{< param beta_channel >}}.</p>
       <p>Create a disk image from this channel by running:</p>
-<pre>
+{{< highlight bash >}}
 ./create-coreos-vdi -V beta
-</pre>
+{{< /highlight >}}
     </div>
   <div class="tab-pane active" id="stable-create">
       <p>The Stable channel should be used by production clusters. Versions of Flatcar Container Linux are battle-tested within the Beta and Alpha channels before being promoted. The current version is Flatcar Container Linux {{< param stable_channel >}}.</p>
       <p>Create a disk image from this channel by running:</p>
-<pre>
+{{< highlight bash >}}
 ./create-coreos-vdi -V stable
-</pre>
+{{< /highlight >}}
     </div>
   </div>
 </div>

--- a/themes/flatcar/layouts/shortcodes/highlight.html
+++ b/themes/flatcar/layouts/shortcodes/highlight.html
@@ -1,0 +1,12 @@
+{{- /* Override built-in highlight shortcode to match render-codeblock.html so
+       in-HTML snippets (e.g. inside <div class="tab-pane">) get the same
+       .code-block wrapper, copy button, and padding as fenced code blocks. */ -}}
+{{- $lang := .Get 0 -}}
+{{- if eq $lang "shell" }}{{ $lang = "bash" }}{{ end -}}
+{{- $opts := .Get 1 | default "" -}}
+<div class="code-block position-relative">
+  <button class="btn btn-sm btn-copy position-absolute top-0 end-0 m-2" title="Copy to clipboard" aria-label="Copy to clipboard">
+    <i class="fa-regular fa-copy"></i>
+  </button>
+  {{ highlight (trim .Inner "\n") $lang $opts }}
+</div>


### PR DESCRIPTION
## Changes

- **`themes/flatcar/layouts/shortcodes/highlight.html`** (new) — shadows Hugo's built-in `highlight` shortcode so it emits the same `.code-block` wrapper + copy button as `render-codeblock.html`. Without this, every `{{< highlight >}}` call bypasses the render hook and ends up without a copy button and with extra bottom padding.
- **14 docs pages** — converts 50 raw `<pre>…</pre>` snippets inside `<div class="tab-pane">` tabs to `{{< highlight LANG >}}`. Fenced ```` ```bash ```` blocks don't work there because Goldmark treats raw HTML contents as opaque; the shortcode is expanded before Goldmark.
- **`README.md`** — new "Code snippets" subsection documenting both forms.
- **`Makefile`** (drive-by) — `PYTHON ?= python3`, `getdeps` prefers `uv` and falls back to `python -m pip` instead of hardcoded `pip3` (which isn't on PATH on Fedora). `run`/`serve` echo `http://localhost:1313/`.

## Testing

Built with Hugo Extended 0.162.1 (pinned in `.env`). Verified on the libvirt page: tab snippets now have Chroma highlighting, copy button, and matching padding. `make getdeps && make run` works on Fedora.

While setting the site up locally on Fedora I hit a few sharp edges in the Makefile taht I always do but I finally decided to fix them and folded the fixes into this PR:

- `PYTHON ?= python3` instead of hardcoded `python3` (overridable per env).
- `getdeps` now checks for `pyyaml` via `python -c 'import yaml'` first and prefers `uv pip install --system pyyaml` when `uv` is on PATH, falling back to `$(PYTHON) -m pip install --upgrade --user pyyaml`. This avoids the hardcoded `pip3` call, which doesn't exist on every distro.
- `run` and `serve` targets echo `http://localhost:1313/` so the URL is right there in the terminal, and `run` passes `--baseURL http://localhost:1313/`.