### PR TITLE
Docs: Add Quickstart Guide 

### DIFF
--- a/content/docs/latest/_index.md
+++ b/content/docs/latest/_index.md
@@ -5,17 +5,13 @@ main_menu: true
 weight: 40
 ---
 
-Flatcar Container Linux is a container optimized OS that ships a minimal OS
-image, which includes only the tools needed to run containers. The OS is
-shipped through an immutable filesystem and includes automatic atomic
-updates.
+### What is Flatcar?
 
+Flatcar Container Linux is an immutable operating system (OS) that can securely host many different types of containers, ranging from Docker to Kubernetes and more. It uses an automated provisioning process that provides consistent installations for every machine. This process reduces human error and creates more stable containerization hosting than Windows, Mac, and general-purpose Linux distributions.
 
-### Getting Started
+### How does it work?
 
-If you're new to Flatcar and if you're looking for a brief introduction on getting Flatcar up and running, please have a look at our [quickstart guide][quick-start].
-
-Find more elaborate guides covering specific aspects of Flatcar use in our [Flatcar self-paced learning series][learning-series].
+Gentoo Linux is the core OS for Flatcar because it's extremely flexible and modular. Gentoo makes it possible to create a minimal, immutable OS that is just a container host and nothing else. As a result, the Flatcar OS is very lightweight, secure, and scales easily because it only provides components for containerization. It also has automatic updates that make it more convenient to use and ensures that instances are always up to date. 
 
 ### Core Tenets
 
@@ -42,156 +38,6 @@ Find more elaborate guides covering specific aspects of Flatcar use in our [Flat
    - Flatcar maintainers and contributors come from a variety of backgrounds and work for different employers, or participate privately in the project.
      Flatcar is not a vendor driven product nor aims to ever be one.
 
-### Installing Flatcar
-
-Flatcar Container Linux runs on most cloud providers, virtualization
-platforms and bare metal servers. 
-
-#### Cloud Providers
- * [Amazon EC2][ec2]
- * [Microsoft Azure][azure]
- * [Google Compute Engine][gce]
- * [VMware][vmware]
- * [DigitalOcean][digital-ocean]
- * [Hetzner][hetzner]
- * [OpenStack][openstack]
- * [Brightbox][brightbox]
- * [Scaleway][scaleway] (community support)
- * [OracleCloud][oraclecloud] (community support)
- * [OVHcloud][ovhcloud] (community support)
- * [Akamai/Linode][akamai]
- * [STACKIT][stackit]
-
-#### Virtualization options
-It's easy to run a local Flatcar VM on your laptop for testing and debugging
-purposes. You can use any of the following options.
-
- * [QEMU][qemu]
- * [libVirt][libvirt]
- * [VirtualBox][virtualbox] (community support)
- * [Vagrant][vagrant] (community support)
- * [Hyper-V][hyper-v] (community support)
- * [KubeVirt][kubevirt] (community support)
- * [Proxmox VE][proxmoxve] (community support)
-
-#### Bare Metal
-You can install Flatcar on bare metal machines in different ways: using ISO
-images, booting from PXE or iPXE, and even by running an installation
-script on an existing Linux system.
-
- * [Installing from ISO images][boot-iso]
- * [Booting with PXE][pxe]
- * [Booting with iPXE][ipxe]
- * [Installing with flatcar-install][install-to-disk]
-
-If you want to provide metadata to your baremetal machines, we recommend
-using [Matchbox][matchbox].
-
-#### Upgrading from CoreOS Container Linux
-
-Flatcar Container Linux is a drop-in replacement of CoreOS Container Linux.
-If you are a CoreOS Container Linux user looking for a replacement,
-checkout our guides to [migrate from CoreOS Container
-Linux][migrate-from-container-linux], or you can [update from CoreOS
-Container Linux][update-from-container-linux] directly.
-
-### Provisioning Tools
-
-[Ignition][ignition-what] is the recommended way to provision Flatcar
-Container Linux at first boot.  Ignition uses a JSON configuration file,
-and it is recommended to generate it from the [Container Linux
-Config][container-linux-config] YAML format, which has additional features.
-The [Container Linux Config Transpiler][config-transpiler] converts a
-Container Linux Config to an Ignition config.
-
- * [Understanding the Boot Process][ignition-boot]
- * [Configuring the Network with Ignition][ignition-network]
- * [Using metadata during provisioning][ignition-metadata]
- * [Getting started with Butane][config-intro]
- * [Examples of using Butane][config-examples]
- * [Using Terraform to provision Flatcar Container Linux][terraform]
- * [Extending the base OS with systemd-sysext images][sysext]
-
-### Setting Flatcar Up and Common Operations
-
-Follow these guides to connect your machines together as a cluster,
-configure machine parameters, create users, inject multiple SSH keys, and
-more.
-
-#### Customizing Flatcar
- * [Using networkd to customize networking][networkd-customize]
- * [Using systemd drop-in units][systemd-drop-in]
- * [Using environment variables in systemd units][environment-variables-systemd]
- * [Using systemd and udev rules][udev-rules]
- * [Using NVIDIA GPUs on Flatcar][using-nvidia]
- * [Scheduling tasks with systemd timers][tasks-with-systemd]
- * [Configuring DNS][dns]
- * [Configuring date & timezone][date-timezone]
- * [Adding users][users]
- * [Kernel modules / sysctl parameters][parameters]
- * [Adding swap][swap]
- * [Power management][power-management]
- * [ACPI][acpi]
-
-#### Managing Releases and Updates
- * [Switching release channels][release-channels]
- * [Configuring the update strategy][update-strategies]
- * [Flatcar update configuration specification][update-conf]
- * [Verifying Flatcar Images with GPG][verify-container-linux]
- * [Nebraska][nebraska]
-
-#### Creating Clusters
- * [Cluster architectures][cluster-architectures]
- * [Clustering machines][clustering-machines]
- * [Using Amazon EC2 Container Service][ec2-container-service]
-
-#### Managing Storage
- * [Using RAID for the root filesystem][filesystem-placement]
- * [Adding disk space][disk-space]
- * [Mounting storage][mounting-storage]
- * [iSCSI configuration][iscsi]
- * [ZFS Extension][zfsextension]
-
-#### Additional security options
- * [Setting up LUKS disk encryption][luks-encryption]
- * [Customizing the SSH daemon][ssh-daemon]
- * [Configuring SSSD on Flatcar Container Linux][sssd-container-linux]
- * [Hardening a Flatcar Container Linux machine][hardening-container-linux]
- * [Trusted Computing Hardware Requirements][hardware-requirements]
- * [Adding Cert Authorities][cert-authorities]
- * [Using SELinux][selinux]
- * [Disabling SMT][disabling-smt]
- * [Enabling FIPS][enabling-fips]
- * [Using the audit subsystem][audit-system]
-
-#### Debugging Flatcar
- * [Install debugging tools][debugging-tools]
- * [Working with btrfs][btrfs]
- * [Reading the system log][system-log]
- * [Collecting crash logs][crash-log]
- * [Manual Flatcar Container Linux rollbacks][container-linux-rollbacks]
-
-### Container Runtimes
-Flatcar Container Linux supports all of the popular methods for running
-containers, and you can choose to interact with the containers at a
-low-level, or use a higher level orchestration framework. Listed below are
-some guides to help you choose and make use of the different runtimes.
-
- * [Getting started with Docker][docker]
- * [Customizing Docker][customizing-docker]
- * [Using systemd to manage Docker containers][manage-docker-containers]
- * [Use a custom Docker or containerd version][use-a-custom-docker-or-containerd-version]
- * [Authenticating to Container registries][registry-authentication]
- * [Getting started with Kubernetes][kubernetes]
- * [High availability Kubernetes][ha-kubernetes]
-
-### Developer guides and Reference
-APIs and troubleshooting guides for working with Flatcar Container Linux.
-
-* [Developer guides][developer-guides]: Comprehensive guides on developing for Flatcar, working with the SDK, and on building and extending OS images.
-* [Integrations][integrations]
-* [Migrating from cloud-config to Container Linux Config][migrating-from-cloud-config]
-* [Flatcar Supply Chain Security (SLSA and SPDX SBOM)][supply-chain-security] detailing security mechanisms employed at build / release time as well as at run-time to ensure validity of inputs processed and outputs shipped.
 
 [quick-start]: ./getting-started
 [learning-series]: ./getting-started/learning-series

--- a/content/docs/latest/_index.md
+++ b/content/docs/latest/_index.md
@@ -11,7 +11,9 @@ Flatcar Container Linux is an immutable operating system (OS) that can securely 
 
 ### How does it work?
 
-Gentoo Linux is the core OS for Flatcar because it's extremely flexible and modular. Gentoo makes it possible to create a minimal, immutable OS that is just a container host and nothing else. As a result, the Flatcar OS is very lightweight, secure, and scales easily because it only provides components for containerization. It also has automatic updates that make it more convenient to use and ensures that instances are always up to date. 
+Gentoo Linux is the underlying technology of Flatcar. It was chosen because it's an extremely flexible and modular OS. With modifications from ChromeOS and CoreOS, the Flatcar team used Gentoo to create a minimal, immutable OS that is just a container host and nothing else.  
+
+As a result, the Flatcar OS is very lightweight, secure, and scales easily because it only provides components for containerization. It also has automatic updates that make it more convenient to use and ensures that instances are always up to date. 
 
 ### Core Tenets
 

--- a/content/docs/latest/getting-started/quickstart.md
+++ b/content/docs/latest/getting-started/quickstart.md
@@ -4,3 +4,46 @@ weight: 5
 description: >
   Get up and running quickly with Flatcar Container Linux.
 ---
+You can get started with Flatcar in 6 steps. The Flatcar documentation has separate sections that cover the concepts of each step in detail. This Quickstart guide only lists the basic steps and provides links to the relevant doc sections that contain the technical information required to get you up and running with Flatcar.
+
+### Step 1: First Boot & Provisioning
+
+This doc section explains how to automate provisioning to set up a Flatcar container with Butane and Ignition tools, and lists the supported Virtual Machines.
+
+[First Boot & Provisioning](https://lemon-wave-085522403-593.westeurope.1.azurestaticapps.net/docs/latest/fb-provision/)
+
+### Step 2: Deployment
+
+Three types of deployment covered: Cloud Providers, Bare Metal, and Virtualization Options.
+
+[Deployment](https://lemon-wave-085522403-593.westeurope.1.azurestaticapps.net/docs/latest/deploy/)
+
+### Step 3: Orchestration & Container Runtimes
+
+How to run Kubernetes, managed clusters, and supported container runtimes, such as Docker.
+
+[Orchestration & Container Runtimes](https://lemon-wave-085522403-593.westeurope.1.azurestaticapps.net/docs/latest/orchestrate/)
+
+### Step 4: Diagnostics and Fixing Issues
+
+Debugging and troubleshooting tips and techniques.
+
+[Diagnostics and Fixing Issues](https://lemon-wave-085522403-593.westeurope.1.azurestaticapps.net/docs/latest/diagnostics/)
+
+### Step 5: Nebraska Update Manager & Releases
+
+Guides for selecting Flatcar releases and managing updates with the Omaha protocol.
+
+[Nebraska Update Manager & Releases](https://lemon-wave-085522403-593.westeurope.1.azurestaticapps.net/docs/latest/updates-releases/)
+
+### Step 6: Security
+
+Linux security options for: hardening, encryption, authentication, and compliance.
+
+[Security](https://lemon-wave-085522403-593.westeurope.1.azurestaticapps.net/docs/latest/security/)
+
+### Additional Coverage on Optional Advanced Topics
+
+These additional doc sections cover: OS Configuration, System Extensions, & Migrating from CoreOS.
+
+

--- a/content/docs/latest/getting-started/quickstart.md
+++ b/content/docs/latest/getting-started/quickstart.md
@@ -46,4 +46,4 @@ Linux security options are included for: hardening, encryption, authentication, 
 
 These additional doc sections cover: OS Configuration, System Extensions, & Migrating from CoreOS.
 
-
+-

--- a/content/docs/latest/getting-started/quickstart.md
+++ b/content/docs/latest/getting-started/quickstart.md
@@ -4,41 +4,41 @@ weight: 5
 description: >
   Get up and running quickly with Flatcar Container Linux.
 ---
-You can get started with Flatcar in 6 steps. The Flatcar documentation has separate sections that cover the concepts of each step in detail. This Quickstart guide only lists the basic steps and provides links to the relevant doc sections that contain the technical information required to get you up and running with Flatcar.
+You can get started with Flatcar in 6 steps. This Quickstart Guide is just a list of the basic steps and provides links to the Flatcar documentation that covers the concepts of each step in detail and provides the technical information required to get you up and running with Flatcar.
 
 ### Step 1: First Boot & Provisioning
 
-This doc section explains how to automate provisioning to set up a Flatcar container with Butane and Ignition tools, and lists the supported Virtual Machines.
+This section of the docs explains how to automate provisioning to set up a Flatcar container with Butane and Ignition tools, and lists the supported Virtual Machines.
 
 [First Boot & Provisioning](https://lemon-wave-085522403-593.westeurope.1.azurestaticapps.net/docs/latest/fb-provision/)
 
 ### Step 2: Deployment
 
-Three types of deployment covered: Cloud Providers, Bare Metal, and Virtualization Options.
+Three types of deployment are covered in this section: Cloud Providers, Bare Metal, and Virtualization Options.
 
 [Deployment](https://lemon-wave-085522403-593.westeurope.1.azurestaticapps.net/docs/latest/deploy/)
 
 ### Step 3: Orchestration & Container Runtimes
 
-How to run Kubernetes, managed clusters, and supported container runtimes, such as Docker.
+Information on how to run Kubernetes, managed clusters, and supported container runtimes, such as Docker, is provided.
 
 [Orchestration & Container Runtimes](https://lemon-wave-085522403-593.westeurope.1.azurestaticapps.net/docs/latest/orchestrate/)
 
 ### Step 4: Diagnostics and Fixing Issues
 
-Debugging and troubleshooting tips and techniques.
+Debugging and troubleshooting tips and techniques are explained.
 
 [Diagnostics and Fixing Issues](https://lemon-wave-085522403-593.westeurope.1.azurestaticapps.net/docs/latest/diagnostics/)
 
 ### Step 5: Nebraska Update Manager & Releases
 
-Guides for selecting Flatcar releases and managing updates with the Omaha protocol.
+This section has guides for selecting Flatcar releases and managing updates with the Omaha protocol.
 
 [Nebraska Update Manager & Releases](https://lemon-wave-085522403-593.westeurope.1.azurestaticapps.net/docs/latest/updates-releases/)
 
 ### Step 6: Security
 
-Linux security options for: hardening, encryption, authentication, and compliance.
+Linux security options are included for: hardening, encryption, authentication, and compliance.
 
 [Security](https://lemon-wave-085522403-593.westeurope.1.azurestaticapps.net/docs/latest/security/)
 

--- a/content/docs/latest/getting-started/quickstart.md
+++ b/content/docs/latest/getting-started/quickstart.md
@@ -46,4 +46,3 @@ Linux security options are included for: hardening, encryption, authentication, 
 
 These additional doc sections cover: OS Configuration, System Extensions, & Migrating from CoreOS.
 
--


### PR DESCRIPTION
# Quickstart 

This new Quickstart Guide provides an outline of steps required to set up and configure Flatcar. Due to time limitations, it does not explain each step here, but provides a link to the section of the documentation that covers that step. If time and resources are available, this Quickstart could be expanded but that requires a lot of precision analysis and review. This linking outline design is a compromise solution that helps provide an overview of just the basic concepts, so the user can track down the details they need in the relevant doc sections.

This PR is based on ideas introduced in issue #612.

## How to use

See if this guide will be a quick start for people to help them understand Flatcar quickly.

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
