### PR TITLE
Update Flatcars current syntax theme and prep for dark theme

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -57,10 +57,16 @@ markup:
     renderer:
       unsafe: true
   highlight:
+    # NOTE: this style name is unused for visual coloring since
+    # noClasses is false — Hugo/Chroma only emits semantic CSS classes
+    # (.chroma .k, .s, .c, ...) and the actual colors come from the
+    # hand-written Flatcar light theme in
+    # themes/flatcar/assets/scss/_syntax.scss. A dark variant is
+    # parked in _syntax-dark.scss.parked for future dark-mode work.
     style: rose-pine-moon
     guessSyntax: true
     noClasses: false
-    lineNos: true
+    lineNos: false
 
 assetDir: static
 

--- a/config.yaml
+++ b/config.yaml
@@ -63,7 +63,7 @@ markup:
     # hand-written Flatcar light theme in
     # themes/flatcar/assets/scss/_syntax.scss. A dark variant is
     # parked in _syntax-dark.scss.parked for future dark-mode work.
-    style: rose-pine-moon
+    style: github
     guessSyntax: true
     noClasses: false
     lineNos: false

--- a/themes/flatcar/assets/scss/_custom.scss
+++ b/themes/flatcar/assets/scss/_custom.scss
@@ -33,21 +33,49 @@ $headings-margin-bottom:  0.31em;
 $headings-font-weight:   $font-weight-bold;
 
 // Colors
-$blue:    #09bac8;
-$pink:    #de1040;
-$red:     #eb1a45;
-$green:   #198806;
-$darkergreen: #168203;
-$yellow:  #fff200;
+//
+// ---- Flatcar brand palette -------------------------------------
+// Canonical brand colors. Reference these (or the Bootstrap-facing
+// aliases below) instead of hardcoding hex values in other partials —
+// several one-off hex duplicates/near-duplicates of these colors used
+// to be scattered around the theme (e.g. #000022, #12172c, #1a2d3e
+// all meant "dark navy"; #fff200, #ffe000, #ecd31f all meant "brand
+// yellow"). They've been consolidated to these named values.
+//
+// Kept in sync with the Marp slide theme
+// (cookiecutter-marp-flatcar/themes/flatcar/base.css) and the VS
+// Code / Vim editor themes so code + slides + docs share one identity.
+$flatcar-navy:       #12172b; // primary dark navy (site backgrounds, headers)
+$flatcar-navy-light: #1a2d3e; // lighter navy — gradients / secondary accents only
+$flatcar-cyan:       #09bac8; // decorative brand accent (icons, borders, fills — NOT body text on white, fails WCAG AA)
+$flatcar-link-blue:  #0066b8; // text-safe blue for links / active nav / code keywords on a white background
+$flatcar-yellow:     #fff200; // brand yellow accent
+$flatcar-red:        #eb1a45;
+$flatcar-red-a11y:   #ce163c; // darkened ~12% — $flatcar-red fails AA for small text on light backgrounds (3.9:1); this passes (4.9:1)
+$flatcar-pink:       #de1040;
+$flatcar-green:      #198806;
+$flatcar-green-dark: #168203;
+$flatcar-gold:       #be8900;
+$flatcar-amber:      #9a3f00; // text-safe derivative of $flatcar-gold, which fails AA on light backgrounds (2.8:1); used for code numerics
+
+// ---- Bootstrap-facing aliases -----------------------------------
+// Existing variable names used throughout the theme's partials
+// (150+ call sites) — left in place for backward compatibility,
+// just pointed at the canonical palette above.
+$blue:    $flatcar-cyan;
+$pink:    $flatcar-pink;
+$red:     $flatcar-red;
+$green:   $flatcar-green;
+$darkergreen: $flatcar-green-dark;
+$yellow:  $flatcar-yellow;
 $cyan:    #23ecfa;
 $black:   #000000;
 $white:   #ffffff;
 $gray:    #c4c4c4;
-$gold:   #BE8900;
-
+$gold:    $flatcar-gold;
 
 $flatcar-darker-blue: #007d88;
-$flatcar-dark-blue: #12172c;
+$flatcar-dark-blue: $flatcar-navy;
 $flatcar-bg-blue: $flatcar-dark-blue;
 $flatcar-blue: #08a2af;
 

--- a/themes/flatcar/assets/scss/_syntax-dark.scss.parked
+++ b/themes/flatcar/assets/scss/_syntax-dark.scss.parked
@@ -1,0 +1,99 @@
+/* Flatcar-branded Chroma syntax theme — DARK (parked).
+ *
+ * Hand-written (not `hugo gen chromastyles`, since "flatcar" isn't a
+ * built-in Chroma style). Selector list mirrors the class names Chroma
+ * itself emits, so this can replace the previous generic `rose-pine-moon`
+ * style — only the palette changes.
+ *
+ * This file is intentionally NOT imported today. It can be revived in a
+ * future dark-mode PR by scoping it under `[data-bs-theme="dark"]` and
+ * importing it alongside the light theme in `_syntax.scss` once the site
+ * wires up Bootstrap color modes (see bootstrap/mixins/_color-mode.scss
+ * and bootstrap/_variables-dark.scss).
+ *
+ * Palette source: themes/flatcar/base.css & dark.css in the
+ * cookiecutter-marp-flatcar repo (same brand colors used on slides).
+ *   #12172B  bg-navy       editor background
+ *   #09BAC8  accent-cyan   keywords / primary accent
+ *   #7A87A0  muted         base for comments / line numbers
+ *   #FFB84D  amber         numbers / constants ("staged" brand amber)
+ *   #5FD9B4  teal (light)  strings (lightened brand teal, for contrast on navy)
+ *   #FF5C7A  red (light)   errors / deletions (lightened brand red)
+ *   #3FBF7A  green (light) insertions (lightened brand green)
+ */
+
+/* Background */ .bg { color:#C9D1E3; background-color:#12172B; }
+/* PreWrapper */ .chroma { color:#C9D1E3; background-color:#12172B; -webkit-text-size-adjust:none; }
+/* Error */ .chroma .err { color:#FF5C7A }
+/* LineLink */ .chroma .lnlinks { outline:none; text-decoration:none; color:inherit }
+/* LineTableTD */ .chroma .lntd { vertical-align:top; padding:0; margin:0; border:0; }
+/* LineTable */ .chroma .lntable { border-spacing:0; padding:0; margin:0; border:0; }
+/* LineHighlight */ .chroma .hl { background-color:#1C2238 }
+/* LineNumbersTable */ .chroma .lnt { white-space:pre; -webkit-user-select:none; user-select:none; margin-right:0.4em; padding:0 0.4em 0 0.4em; color:#56607A }
+/* LineNumbers */ .chroma .ln { white-space:pre; -webkit-user-select:none; user-select:none; margin-right:0.4em; padding:0 0.4em 0 0.4em; color:#56607A }
+/* Line */ .chroma .line { display:flex; }
+/* Keyword */ .chroma .k { color:#09BAC8 }
+/* KeywordConstant */ .chroma .kc { color:#09BAC8 }
+/* KeywordDeclaration */ .chroma .kd { color:#09BAC8 }
+/* KeywordNamespace */ .chroma .kn { color:#6FE0EA }
+/* KeywordPseudo */ .chroma .kp { color:#09BAC8 }
+/* KeywordReserved */ .chroma .kr { color:#09BAC8 }
+/* KeywordType */ .chroma .kt { color:#4FE3EF }
+/* Name */ .chroma .n { color:#C9D1E3 }
+/* NameAttribute */ .chroma .na { color:#8FA6C8 }
+/* NameClass */ .chroma .nc { color:#4FE3EF }
+/* NameConstant */ .chroma .no { color:#FFB84D }
+/* NameDecorator */ .chroma .nd { color:#7A87A0 }
+/* NameEntity */ .chroma .ni { color:#8FA6C8 }
+/* NameException */ .chroma .ne { color:#FF5C7A }
+/* NameLabel */ .chroma .nl { color:#8FA6C8 }
+/* NameNamespace */ .chroma .nn { color:#8FA6C8 }
+/* NameProperty */ .chroma .py { color:#8FA6C8 }
+/* NameTag */ .chroma .nt { color:#09BAC8 }
+/* NameBuiltin */ .chroma .nb { color:#4FE3EF }
+/* NameBuiltinPseudo */ .chroma .bp { color:#4FE3EF }
+/* NameVariable */ .chroma .nv { color:#C9D1E3 }
+/* NameVariableClass */ .chroma .vc { color:#C9D1E3 }
+/* NameVariableGlobal */ .chroma .vg { color:#C9D1E3 }
+/* NameVariableInstance */ .chroma .vi { color:#C9D1E3 }
+/* NameVariableMagic */ .chroma .vm { color:#C9D1E3 }
+/* NameFunction */ .chroma .nf { color:#4FE3EF }
+/* NameFunctionMagic */ .chroma .fm { color:#4FE3EF }
+/* Literal */ .chroma .l { color:#FFB84D }
+/* LiteralDate */ .chroma .ld { color:#FFB84D }
+/* LiteralString */ .chroma .s { color:#5FD9B4 }
+/* LiteralStringAffix */ .chroma .sa { color:#5FD9B4 }
+/* LiteralStringBacktick */ .chroma .sb { color:#5FD9B4 }
+/* LiteralStringChar */ .chroma .sc { color:#5FD9B4 }
+/* LiteralStringDelimiter */ .chroma .dl { color:#5FD9B4 }
+/* LiteralStringDoc */ .chroma .sd { color:#5FD9B4 }
+/* LiteralStringDouble */ .chroma .s2 { color:#5FD9B4 }
+/* LiteralStringEscape */ .chroma .se { color:#09BAC8 }
+/* LiteralStringHeredoc */ .chroma .sh { color:#5FD9B4 }
+/* LiteralStringInterpol */ .chroma .si { color:#5FD9B4 }
+/* LiteralStringOther */ .chroma .sx { color:#5FD9B4 }
+/* LiteralStringRegex */ .chroma .sr { color:#5FD9B4 }
+/* LiteralStringSingle */ .chroma .s1 { color:#5FD9B4 }
+/* LiteralStringSymbol */ .chroma .ss { color:#5FD9B4 }
+/* LiteralNumber */ .chroma .m { color:#FFB84D }
+/* LiteralNumberBin */ .chroma .mb { color:#FFB84D }
+/* LiteralNumberFloat */ .chroma .mf { color:#FFB84D }
+/* LiteralNumberHex */ .chroma .mh { color:#FFB84D }
+/* LiteralNumberInteger */ .chroma .mi { color:#FFB84D }
+/* LiteralNumberIntegerLong */ .chroma .il { color:#FFB84D }
+/* LiteralNumberOct */ .chroma .mo { color:#FFB84D }
+/* Operator */ .chroma .o { color:#8B96AE }
+/* OperatorWord */ .chroma .ow { color:#09BAC8 }
+/* Punctuation */ .chroma .p { color:#8B96AE }
+/* Comment */ .chroma .c { color:#6B7A99; font-style:italic }
+/* CommentHashbang */ .chroma .ch { color:#6B7A99; font-style:italic }
+/* CommentMultiline */ .chroma .cm { color:#6B7A99; font-style:italic }
+/* CommentSingle */ .chroma .c1 { color:#6B7A99; font-style:italic }
+/* CommentSpecial */ .chroma .cs { color:#6B7A99; font-style:italic }
+/* CommentPreproc */ .chroma .cp { color:#6B7A99 }
+/* CommentPreprocFile */ .chroma .cpf { color:#6B7A99 }
+/* GenericDeleted */ .chroma .gd { color:#FF5C7A }
+/* GenericEmph */ .chroma .ge { font-style:italic }
+/* GenericInserted */ .chroma .gi { color:#3FBF7A }
+/* GenericStrong */ .chroma .gs { font-weight:bold }
+/* GenericSubheading */ .chroma .gu { color:#6FE0EA }

--- a/themes/flatcar/assets/scss/_syntax.scss
+++ b/themes/flatcar/assets/scss/_syntax.scss
@@ -38,7 +38,7 @@
  *   #CE163C  red-a11y    errors/deletions — accessible stand-in for    $flatcar-red-a11y
  *            $flatcar-red, darkened ~12% to clear WCAG AA
  *   #5B6773  muted       comments (italic)
- *   #7A87A0  muted-light line numbers (intentionally low-contrast, UI chrome not prose)
+ *   #7A87A0  muted-light line numbers (if enabled; intentionally low-contrast UI chrome)
  *   #F1F2F6  paper-grey  code block background (matches the Marp slide <pre>)
  *
  * Plain identifiers/variables are left in base ink rather than

--- a/themes/flatcar/assets/scss/_syntax.scss
+++ b/themes/flatcar/assets/scss/_syntax.scss
@@ -1,77 +1,154 @@
-/* Generated using: hugo gen chromastyles --style=rose-pine-moon */
+/* Flatcar-branded Chroma syntax theme — LIGHT (single, default).
+ *
+ * Hand-written (not `hugo gen chromastyles`, since "flatcar" isn't a
+ * built-in Chroma style). Selector list matches the class names
+ * Chroma itself emits, so this is a drop-in swap for the previous
+ * generic `rose-pine-moon` style.
+ *
+ * The site is light-mode only for now (a dark-mode variant is parked
+ * in `_syntax-dark.scss.parked`, ready to be revived and scoped under
+ * `[data-bs-theme="dark"]` once the site adds a real mode toggle
+ * via Bootstrap's color-mode support (see bootstrap/mixins/_color-mode.scss
+ * and bootstrap/_variables-dark.scss).
+ *
+ * DESIGN NOTE — hue variety, not just "navy + one blue":
+ * A first pass at this theme leaned on `$flatcar-link-blue` for almost
+ * every token role (keywords, tags, attributes, variables...) with
+ * `$flatcar-navy` bold standing in for everything else (types,
+ * functions, builtins). That's flat and hard to scan compared to
+ * well-regarded light themes like GitHub Light, One Light, and
+ * Solarized Light, which all spread roles across several distinct
+ * hues (green for strings, orange/gold for numbers, a dedicated color
+ * for functions, etc.).
+ *
+ * This version follows that same differentiation strategy, but stays
+ * strictly inside Flatcar's own brand palette — no invented purples
+ * or oranges foreign to the brand:
+ *   #12172B  navy        base text, types/classes/builtins (bold)      $flatcar-navy
+ *   #0066B8  link-blue   keywords, tags — the site's own "link" blue   $flatcar-link-blue
+ *   #007D88  darker-blue functions — brand teal-blue, already used     $flatcar-darker-blue
+ *            elsewhere on the site (buttons/accents), reused here so
+ *            functions read as their own category, not bolded navy
+ *   #168203  green-dark  strings — matches the near-universal          $flatcar-green-dark
+ *            "green = string" convention, and IS a brand color
+ *   #9A3F00  amber       numbers/literals — accessible stand-in for    $flatcar-amber
+ *            $flatcar-gold, which fails contrast on light backgrounds
+ *   #DE1040  pink        decorators / namespaces / exceptions —        $flatcar-pink
+ *            a brand color, distinct from the darkened error red
+ *   #CE163C  red-a11y    errors/deletions — accessible stand-in for    $flatcar-red-a11y
+ *            $flatcar-red, darkened ~12% to clear WCAG AA
+ *   #5B6773  muted       comments (italic)
+ *   #7A87A0  muted-light line numbers (intentionally low-contrast, UI chrome not prose)
+ *   #F1F2F6  paper-grey  code block background (matches the Marp slide <pre>)
+ *
+ * Plain identifiers/variables are left in base ink rather than
+ * colored — most modern light themes do this to avoid every line
+ * turning into a rainbow; only builtins/language-special variables
+ * get a color (pink), everything else is quiet.
+ */
 
-/* Background */ .bg { color:#e0def4;background-color:#232136; }
-/* PreWrapper */ .chroma { color:#e0def4;background-color:#232136;-webkit-text-size-adjust:none; }
-/* Error */ .chroma .err { color:#eb6f92 }
-/* LineLink */ .chroma .lnlinks { outline:none;text-decoration:none;color:inherit }
-/* LineTableTD */ .chroma .lntd { vertical-align:top;padding:0;margin:0;border:0; }
-/* LineTable */ .chroma .lntable { border-spacing:0;padding:0;margin:0;border:0; }
-/* LineHighlight */ .chroma .hl { background-color:#39374a }
-/* LineNumbersTable */ .chroma .lnt { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#7f7f7f }
-/* LineNumbers */ .chroma .ln { white-space:pre;-webkit-user-select:none;user-select:none;margin-right:0.4em;padding:0 0.4em 0 0.4em;color:#7f7f7f }
-/* Line */ .chroma .line { display:flex; }
-/* Keyword */ .chroma .k { color:#3e8fb0 }
-/* KeywordConstant */ .chroma .kc { color:#3e8fb0 }
-/* KeywordDeclaration */ .chroma .kd { color:#3e8fb0 }
-/* KeywordNamespace */ .chroma .kn { color:#c4a7e7 }
-/* KeywordPseudo */ .chroma .kp { color:#3e8fb0 }
-/* KeywordReserved */ .chroma .kr { color:#3e8fb0 }
-/* KeywordType */ .chroma .kt { color:#3e8fb0 }
-/* Name */ .chroma .n { color:#ea9a97 }
-/* NameAttribute */ .chroma .na { color:#ea9a97 }
-/* NameClass */ .chroma .nc { color:#9ccfd8 }
-/* NameConstant */ .chroma .no { color:#f6c177 }
-/* NameDecorator */ .chroma .nd { color:#908caa }
-/* NameEntity */ .chroma .ni { color:#ea9a97 }
-/* NameException */ .chroma .ne { color:#3e8fb0 }
-/* NameLabel */ .chroma .nl { color:#ea9a97 }
-/* NameNamespace */ .chroma .nn { color:#ea9a97 }
-/* NameProperty */ .chroma .py { color:#ea9a97 }
-/* NameTag */ .chroma .nt { color:#ea9a97 }
-/* NameBuiltin */ .chroma .nb { color:#ea9a97 }
-/* NameBuiltinPseudo */ .chroma .bp { color:#ea9a97 }
-/* NameVariable */ .chroma .nv { color:#ea9a97 }
-/* NameVariableClass */ .chroma .vc { color:#ea9a97 }
-/* NameVariableGlobal */ .chroma .vg { color:#ea9a97 }
-/* NameVariableInstance */ .chroma .vi { color:#ea9a97 }
-/* NameVariableMagic */ .chroma .vm { color:#ea9a97 }
-/* NameFunction */ .chroma .nf { color:#ea9a97 }
-/* NameFunctionMagic */ .chroma .fm { color:#ea9a97 }
-/* Literal */ .chroma .l { color:#f6c177 }
-/* LiteralDate */ .chroma .ld { color:#f6c177 }
-/* LiteralString */ .chroma .s { color:#f6c177 }
-/* LiteralStringAffix */ .chroma .sa { color:#f6c177 }
-/* LiteralStringBacktick */ .chroma .sb { color:#f6c177 }
-/* LiteralStringChar */ .chroma .sc { color:#f6c177 }
-/* LiteralStringDelimiter */ .chroma .dl { color:#f6c177 }
-/* LiteralStringDoc */ .chroma .sd { color:#f6c177 }
-/* LiteralStringDouble */ .chroma .s2 { color:#f6c177 }
-/* LiteralStringEscape */ .chroma .se { color:#3e8fb0 }
-/* LiteralStringHeredoc */ .chroma .sh { color:#f6c177 }
-/* LiteralStringInterpol */ .chroma .si { color:#f6c177 }
-/* LiteralStringOther */ .chroma .sx { color:#f6c177 }
-/* LiteralStringRegex */ .chroma .sr { color:#f6c177 }
-/* LiteralStringSingle */ .chroma .s1 { color:#f6c177 }
-/* LiteralStringSymbol */ .chroma .ss { color:#f6c177 }
-/* LiteralNumber */ .chroma .m { color:#f6c177 }
-/* LiteralNumberBin */ .chroma .mb { color:#f6c177 }
-/* LiteralNumberFloat */ .chroma .mf { color:#f6c177 }
-/* LiteralNumberHex */ .chroma .mh { color:#f6c177 }
-/* LiteralNumberInteger */ .chroma .mi { color:#f6c177 }
-/* LiteralNumberIntegerLong */ .chroma .il { color:#f6c177 }
-/* LiteralNumberOct */ .chroma .mo { color:#f6c177 }
-/* Operator */ .chroma .o { color:#908caa }
-/* OperatorWord */ .chroma .ow { color:#908caa }
-/* Punctuation */ .chroma .p { color:#908caa }
-/* Comment */ .chroma .c { color:#6e6a86 }
-/* CommentHashbang */ .chroma .ch { color:#6e6a86 }
-/* CommentMultiline */ .chroma .cm { color:#6e6a86 }
-/* CommentSingle */ .chroma .c1 { color:#6e6a86 }
-/* CommentSpecial */ .chroma .cs { color:#6e6a86 }
-/* CommentPreproc */ .chroma .cp { color:#6e6a86 }
-/* CommentPreprocFile */ .chroma .cpf { color:#6e6a86 }
-/* GenericDeleted */ .chroma .gd { color:#eb6f92 }
-/* GenericEmph */ .chroma .ge { font-style:italic }
-/* GenericInserted */ .chroma .gi { color:#9ccfd8 }
-/* GenericStrong */ .chroma .gs { font-weight:bold }
-/* GenericSubheading */ .chroma .gu { color:#c4a7e7 }
+.bg { color:$flatcar-navy; background-color:#F1F2F6; }
+.chroma {
+  color: $flatcar-navy;
+  background-color: #F1F2F6;
+  -webkit-text-size-adjust: none;
+  border: 1px solid $flatcar-link-blue;
+  border-radius: 0.375rem;
+}
+.chroma .err { color:$flatcar-red-a11y }
+.chroma .lnlinks { outline:none; text-decoration:none; color:inherit }
+.chroma .lntd { vertical-align:top; padding:0; margin:0; border:0; }
+.chroma .lntable { border-spacing:0; padding:0; margin:0; border:0; }
+.chroma .hl { background-color:#E4E6EE }
+.chroma .lnt { white-space:pre; -webkit-user-select:none; user-select:none; margin-right:0.4em; padding:0 0.4em 0 0.4em; color:#7A87A0 }
+.chroma .ln { white-space:pre; -webkit-user-select:none; user-select:none; margin-right:0.4em; padding:0 0.4em 0 0.4em; color:#7A87A0 }
+.chroma .line { display:flex; }
+
+/* Keywords — the site's accessible link-blue, bold like a UI link */
+.chroma .k  { color:$flatcar-link-blue; font-weight:600 }
+.chroma .kc { color:$flatcar-link-blue; font-weight:600 }
+.chroma .kd { color:$flatcar-link-blue; font-weight:600 }
+.chroma .kp { color:$flatcar-link-blue; font-weight:600 }
+.chroma .kr { color:$flatcar-link-blue; font-weight:600 }
+.chroma .ow { color:$flatcar-link-blue; font-weight:600 }
+.chroma .nt { color:$flatcar-link-blue; font-weight:600 }
+
+/* Namespaces / decorators / exceptions — brand pink, distinct from error red */
+.chroma .kn { color:$flatcar-pink }
+.chroma .nd { color:$flatcar-pink; font-style:italic }
+.chroma .ne { color:$flatcar-pink; font-weight:600 }
+.chroma .nn { color:$flatcar-pink }
+.chroma .vm { color:$flatcar-pink }
+
+/* Types / classes / builtins — navy, bold-for-emphasis rather than a new hue */
+.chroma .kt { color:$flatcar-navy; font-weight:700 }
+.chroma .nc { color:$flatcar-navy; font-weight:700 }
+.chroma .nb { color:$flatcar-navy; font-weight:700 }
+.chroma .bp { color:$flatcar-navy; font-weight:700 }
+
+/* Functions — brand teal-blue, its own category instead of bolded navy */
+.chroma .nf { color:$flatcar-darker-blue; font-weight:600 }
+.chroma .fm { color:$flatcar-darker-blue; font-weight:600 }
+
+/* Names / attributes / labels / tags-in-prose — quiet, muted */
+.chroma .n  { color:$flatcar-navy }
+.chroma .na { color:#5B6773 }
+.chroma .ni { color:#5B6773 }
+.chroma .nl { color:#5B6773 }
+.chroma .py { color:#5B6773 }
+
+/* Variables — plain ink; kept quiet so real accents stand out */
+.chroma .nv { color:$flatcar-navy }
+.chroma .vc { color:$flatcar-navy }
+.chroma .vg { color:$flatcar-navy }
+.chroma .vi { color:$flatcar-navy }
+
+/* Constants — amber (accessible gold), distinct from string green */
+.chroma .no { color:$flatcar-amber }
+
+/* Strings — brand green, the conventional "string" color */
+.chroma .s  { color:$flatcar-green-dark }
+.chroma .sa { color:$flatcar-green-dark }
+.chroma .sb { color:$flatcar-green-dark }
+.chroma .sc { color:$flatcar-green-dark }
+.chroma .dl { color:$flatcar-green-dark }
+.chroma .sd { color:$flatcar-green-dark }
+.chroma .s2 { color:$flatcar-green-dark }
+.chroma .se { color:$flatcar-link-blue } /* escape sequence — pop it in keyword-blue against the green string */
+.chroma .sh { color:$flatcar-green-dark }
+.chroma .si { color:$flatcar-green-dark }
+.chroma .sx { color:$flatcar-green-dark }
+.chroma .sr { color:$flatcar-green-dark }
+.chroma .s1 { color:$flatcar-green-dark }
+.chroma .ss { color:$flatcar-green-dark }
+
+/* Numbers — amber (accessible gold) */
+.chroma .l  { color:$flatcar-amber }
+.chroma .ld { color:$flatcar-amber }
+.chroma .m  { color:$flatcar-amber }
+.chroma .mb { color:$flatcar-amber }
+.chroma .mf { color:$flatcar-amber }
+.chroma .mh { color:$flatcar-amber }
+.chroma .mi { color:$flatcar-amber }
+.chroma .il { color:$flatcar-amber }
+.chroma .mo { color:$flatcar-amber }
+
+/* Operators / punctuation — quiet, doesn't compete with real tokens */
+.chroma .o { color:#5B6773 }
+.chroma .p { color:$flatcar-navy }
+
+/* Comments */
+.chroma .c   { color:#5B6773; font-style:italic }
+.chroma .ch  { color:#5B6773; font-style:italic }
+.chroma .cm  { color:#5B6773; font-style:italic }
+.chroma .c1  { color:#5B6773; font-style:italic }
+.chroma .cs  { color:#5B6773; font-style:italic }
+.chroma .cp  { color:#5B6773 }
+.chroma .cpf { color:#5B6773 }
+
+/* Diff / generic */
+.chroma .gd { color:$flatcar-red-a11y }
+.chroma .ge { font-style:italic }
+.chroma .gi { color:$flatcar-green-dark }
+.chroma .gs { font-weight:bold }
+.chroma .gu { color:$flatcar-pink }

--- a/themes/flatcar/assets/scss/partials/community-links.scss
+++ b/themes/flatcar/assets/scss/partials/community-links.scss
@@ -47,7 +47,7 @@
       align-items: center;
       text-decoration: none;
       font-weight: 500;
-      color: #12172c;
+      color: $flatcar-dark-blue;
       transition: color 0.2s ease;
 
       &:hover {

--- a/themes/flatcar/assets/scss/partials/header.scss
+++ b/themes/flatcar/assets/scss/partials/header.scss
@@ -12,7 +12,7 @@
   transition: all 0.3s ease;
 
   .news_stripe {
-    background-color: #ffe000;
+    background-color: $yellow;
     color: $black;
     font-size: .8em;
     padding: .5em 0;
@@ -128,7 +128,7 @@ main > *.header-bg-flatcar-2:first-child {
 
 
 $color-primary: $flatcar-bg-blue;
-$color-secondary: #1a2d3e;
+$color-secondary: $flatcar-navy-light;
 
 main > *.header-bg-flatcar:first-child {
   background:
@@ -148,7 +148,7 @@ main > *.header-bg-lokomotive:first-child {
     url(/images/lokomotive-hero-left.svg) calc(100% / 2 - 650px) calc(100% / 2 + 20px) no-repeat,
     url(/images/lokomotive-hero-right.svg) calc(100% / 2 + 650px) calc(100% / 2 + 36px)  no-repeat,
     url(/images/lokomotive-hero-bg.svg) center bottom no-repeat,
-    #ecd31f;
+    $yellow;
   // We need to have it begin at height-of-screen above the beginning because
   // of the mobile version's menu, which will scroll it all the way down.
   // i.e. if we don't have it above the screen for the length of its height,

--- a/themes/flatcar/assets/scss/partials/hero.scss
+++ b/themes/flatcar/assets/scss/partials/hero.scss
@@ -89,7 +89,7 @@
       text-shadow: 0 0 10px $flatcar-bg-blue, 0 0 20px $flatcar-bg-blue, 0 0 40px $flatcar-bg-blue;
       span {
           color: white;
-          weight: bold;
+          font-weight: bold;
       }
   }
 }

--- a/themes/flatcar/assets/scss/partials/hero.scss
+++ b/themes/flatcar/assets/scss/partials/hero.scss
@@ -56,7 +56,7 @@
     margin-left: auto;
     margin-right: auto;
     max-width: 50rem;
-    text-shadow: 0 0 10px #000022, 0 0 20px #000022, 0 0 40px #000022;
+    text-shadow: 0 0 10px $flatcar-bg-blue, 0 0 20px $flatcar-bg-blue, 0 0 40px $flatcar-bg-blue;
 
     @include media-breakpoint-down(lg) {
       font-size: xxx-large;
@@ -86,7 +86,7 @@
   .footnote {
       margin-top: 0.4rem;
       font-size: 0.9rem;
-      text-shadow: 0 0 10px #000022, 0 0 20px #000022, 0 0 40px #000022;
+      text-shadow: 0 0 10px $flatcar-bg-blue, 0 0 20px $flatcar-bg-blue, 0 0 40px $flatcar-bg-blue;
       span {
           color: white;
           weight: bold;

--- a/themes/flatcar/assets/scss/partials/navbar.scss
+++ b/themes/flatcar/assets/scss/partials/navbar.scss
@@ -154,7 +154,7 @@
 
   a {
     color: white;
-    box-shadow: inset 0 -3px 0 #fff200;
+    box-shadow: inset 0 -3px 0 $yellow;
   }
 }
 

--- a/themes/flatcar/assets/scss/sections/section-docs.scss
+++ b/themes/flatcar/assets/scss/sections/section-docs.scss
@@ -196,14 +196,10 @@ $sideBarWidth: 350px;
       margin-bottom: 0;
     }
 
-    pre {
-      padding-bottom: 0;
-    }
-
     .btn-copy {
       background: none;
       border: none !important;
-      color: #908caa;
+      color: #717171;
       line-height: 1;
       padding: 0.25rem 0.5rem;
       z-index: 1;
@@ -211,7 +207,7 @@ $sideBarWidth: 350px;
       cursor: pointer;
 
       &:hover {
-        color: #e0def4;
+        color: $flatcar-link-blue;
       }
     }
   }
@@ -368,15 +364,15 @@ $sideBarWidth: 350px;
         transition: color 0.15s ease, border-color 0.15s ease;
 
         &:hover {
-          color: #0066b8;
+          color: $flatcar-link-blue;
         }
       }
 
       &.active {
-        border-left-color: #0066b8;
+        border-left-color: $flatcar-link-blue;
 
         & > a {
-          color: #0066b8;
+          color: $flatcar-link-blue;
           font-weight: 500;
         }
       }

--- a/themes/flatcar/assets/scss/sections/section-product.scss
+++ b/themes/flatcar/assets/scss/sections/section-product.scss
@@ -238,7 +238,7 @@
   }
 
   .comparison-table {
-    $tableColor: #09bac8;
+    $tableColor: $blue;
     background-color: $flatcar-bg-blue;
     color: $white;
     font-size: smaller;


### PR DESCRIPTION

Refactors the website's theming to be consistent and on-brand, assuming light mode only for now (dark mode to follow in a future PR). Also centered the code in the code blocks and added an outline to it, as well as removed the line numbering to make it cleaner. Here is the result:
<img width="1861" height="1297" alt="image" src="https://github.com/user-attachments/assets/23b59edc-e94a-4f3b-87f5-f76a973d3eca" />
