### PR TITLE
docs: add missing rm /etc/flatcar-cgroupv1 to cgroups migration guide

### DIFF
--- a/content/docs/latest/orchestrate/containers/switching-to-unified-cgroups.md
+++ b/content/docs/latest/orchestrate/containers/switching-to-unified-cgroups.md
@@ -29,8 +29,11 @@ To undo the changes performed by the post update script, execute the following c
 rm /etc/systemd/system/containerd.service.d/10-use-cgroupfs.conf
 sed -i -e '/systemd.unified_cgroup_hierarchy=0/d' /usr/share/oem/grub.cfg
 sed -i -e '/systemd.legacy_systemd_cgroup_controller/d' /usr/share/oem/grub.cfg
+rm -f /etc/flatcar-cgroupv1
 reboot
 ```
+
+The `rm -f /etc/flatcar-cgroupv1` step removes the marker file that enables legacy cgroups without a reboot. If your node was provisioned using the [no-reboot Ignition snippet](#starting-new-nodes-with-legacy-cgroups) that creates this file, it must be removed as well to fully complete the migration.
 
 ## Starting new nodes with legacy cgroups
 


### PR DESCRIPTION
## Add missing rm /etc/flatcar-cgroupv1 to cgroups migration guide

The unified cgroups migration guide was missing the step to remove the `/etc/flatcar-cgroupv1` marker file. Users who provisioned their nodes using the no-reboot Ignition snippet to enable legacy cgroups would still see the system reporting legacy cgroups as active after following the migration instructions, because the marker file was left in place.

This patch adds `rm -f /etc/flatcar-cgroupv1` to the migration commands and includes an explanatory note.

- Fixes flatcar/Flatcar#1789

## How to use

Reviewers can read the updated instructions in the "Migrating old nodes to unified cgroups" section of `content/docs/latest/orchestrate/containers/switching-to-unified-cgroups.md`. The instructions now explicitly mention removing `/etc/flatcar-cgroupv1` along with the other systemd drop-ins and grub configurations.

## Testing done

Built the website locally using Hugo to verify the markdown syntax and rendering. Verified that the rendered HTML at `docs/latest/container-runtimes/switching-to-unified-cgroups/` successfully includes the new step and explanation.
