### PR TITLE
docs: add step numbering and where-to-run guidance

### DIFF
--- a/content/docs/latest/diagnostics/install-debugging-tools.md
+++ b/content/docs/latest/diagnostics/install-debugging-tools.md
@@ -13,7 +13,9 @@ You can use common debugging tools like tcpdump or strace with Toolbox. Using th
 
 ## Quick debugging
 
-By default, Toolbox uses the stock Fedora Docker container. To start using it, simply run:
+By default, Toolbox uses the stock Fedora Docker container.
+
+1. On the Flatcar instance, start toolbox:
 
 ```bash
 /usr/bin/toolbox
@@ -21,7 +23,7 @@ By default, Toolbox uses the stock Fedora Docker container. To start using it, s
 
 _NOTE_: For Fedora, it's recommended to use at least 2048 MB RAM to avoid the following `dnf` operation being killed by the OOM manager.
 
-You're now in the namespace of Fedora and can install any software you'd like via `dnf`. For example, if you'd like to use `tcpdump`:
+2. Inside the toolbox, install and run the tools you need. For example, to use `tcpdump`:
 
 ```bash
 [root@srv-3qy0p ~]# dnf -y install tcpdump
@@ -32,12 +34,17 @@ listening on ens3, link-type EN10MB (Ethernet), capture size 65535 bytes
 
 ### Specify a custom Docker image
 
-Create a `.toolboxrc` in the user's home folder to use a specific Docker image:
+1. On the Flatcar instance, create a `.toolboxrc` in the user's home folder to use a specific Docker image:
 
 ```bash
 $ cat .toolboxrc
 TOOLBOX_DOCKER_IMAGE=index.example.com/debug
 TOOLBOX_USER=root
+```
+
+2. On the Flatcar instance, start toolbox with that configuration:
+
+```bash
 $ /usr/bin/toolbox
 Pulling repository index.example.com/debug
 ...
@@ -84,9 +91,8 @@ you need to start them via `systemd-run` because _process lingering_ is disabled
 by default in logind and all non-service user processes are killed on logout.
 Spawn a user service to persist the toolbox container with the `tmux` process
 even when you log out with SSH.
-The following command line will ensure `tmux`, `strace` and `pidof` are installed
-in the container, then create a new `tmux` session to which you can later attach,
-and keep the service active by waiting with `strace` until the `tmux` process exits.
+
+1. On the Flatcar instance, run the following command. It installs `tmux`, `strace`, and `pidof` in the container, creates a new `tmux` session you can later attach to, and keeps the service active by waiting with `strace` until the `tmux` process exits:
 
 ```bash
 systemd-run --user toolbox sh -c 'dnf install -y tmux strace procps-ng; TERM=tmux tmux new-session -d -s sharedsession; strace -p "$(pidof tmux)"'
@@ -97,7 +103,7 @@ new session in the background.
 Because `tmux` forks away, we cannot use `wait` in the shell to wait for children but need
 to use `strace` to have a foreground process running that prevents `toolbox` from quitting.
 
-Once this is running you can can attach to the `tmux` session as often as you want from any SSH connection.
+2. On the Flatcar instance, attach to the `tmux` session from any SSH connection:
 
 ```bash
 sudo nsenter -t "$(pidof tmux | cut -d ' ' -f 1)" -a tmux a
@@ -109,13 +115,15 @@ started with `systemd-run` will terminate and you'll have to start the service a
 
 ## SSH directly into a toolbox
 
-Advanced users can SSH directly into a toolbox by setting up an `/etc/passwd` entry:
+Advanced users can SSH directly into a toolbox by setting up an `/etc/passwd` entry.
+
+1. On the Flatcar instance, create a user whose login shell is toolbox:
 
 ```bash
 useradd bob -m -p '*' -s /usr/bin/toolbox -U -G sudo,docker,rkt
 ```
 
-To test, SSH as bob:
+2. From your client host, SSH as that user to confirm toolbox starts:
 
 ```bash
 ssh bob@hostname.example.com

--- a/content/docs/latest/getting-started/quickstart.md
+++ b/content/docs/latest/getting-started/quickstart.md
@@ -8,10 +8,12 @@ description: >
 This quickstart demonstrates provisioning a local QEMU VM with a Butane YAML config transpiled to Ignition. As an example, you create a systemd service that starts an NGINX container on the VM. This is a good starting point to modify the Butane YAML file and reprovision temporary QEMU VMs. This should work on most Linux systems and assumes you have an SSH key set up for ssh-agent.
 
 Begin by downloading the Flatcar QEMU image and the helper script to start it with QEMU, but don’t run it yet.
-
+ 
 ## Download image
 
 ### AMD64
+
+1. On the host, download the QEMU helper script and image:
 
 ```bash
 wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu.sh
@@ -21,7 +23,22 @@ chmod +x flatcar_production_qemu.sh
 wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_qemu_image.img
 ```
 
+2. On the host, keep a pristine copy of the image. Ignition only runs on first boot, so you will restore from this copy before each provisioning attempt:
+
+```bash
+mv flatcar_production_qemu_image.img flatcar_production_qemu_image.img.fresh
+```
+
+3. (Optional) On the host, make a working copy and boot it for a first look through the QEMU VGA console. Close the QEMU window or stop the script with `Ctrl-C` when finished:
+
+```bash
+cp -i --reflink=auto flatcar_production_qemu_image.img.fresh flatcar_production_qemu_image.img
+./flatcar_production_qemu.sh
+```
+
 ### ARM64 image
+
+1. On the host, download the UEFI QEMU helper script, image, and firmware files:
 
 ```bash
 wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi.sh
@@ -35,19 +52,13 @@ wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_productio
 wget https://alpha.release.flatcar-linux.net/arm64-usr/current/flatcar_production_qemu_uefi_efi_code.qcow2
 ```
 
-For Ignition configurations to be recognized, we have to make sure that we always boot an unmodified fresh image because Ignition only runs on first boot. Therefore, before trying to use an Ignition config, we will always discard the image modifications by using a fresh copy. You can already boot the image with `./flatcar_production_qemu.sh` and have a look around in the OS through the QEMU VGA console - you can close the QEMU window or stop the script with `Ctrl-C`.
-
-```bash
-mv flatcar_production_qemu_image.img flatcar_production_qemu_image.img.fresh
-
-# If you want to have a first look, boot it and wait for the autologin to give you a prompt:
-
-cp -i --reflink=auto flatcar_production_qemu_image.img.fresh flatcar_production_qemu_image.img
-```
+2. On the host, keep a pristine copy of the image the same way as in the AMD64 steps above (rename the downloaded `.img` to `.img.fresh`, then copy it back when you want a fresh first boot).
 
 ## Provision with Butane and Ignition
 
-Now we will provision the VM on first boot through Ignition. Instead of writing the JSON config, we use Butane YAML and transpile it. Save the following Butane YAML file as `cl.yaml` (or another name). It contains directives for setting up a systemd service that runs an NGINX Docker container:
+Now we will provision the VM on first boot through Ignition. Instead of writing the JSON config, we use Butane YAML and transpile it.
+
+1. On the host, save the following Butane YAML file as `cl.yaml` (or another name). It contains directives for setting up a systemd service that runs an NGINX Docker container:
 
 ```yaml
 variant: flatcar
@@ -72,7 +83,7 @@ systemd:
         WantedBy=multi-user.target
 ```
 
-Before we can use it, we have to transpile the Butane YAML to Ignition JSON:
+2. On the host, transpile the Butane YAML to Ignition JSON:
 
 ```bash
 cat cl.yaml | docker run --rm -i quay.io/coreos/butane:latest > ignition.json
@@ -101,6 +112,8 @@ The final step is to boot the VM and make the Ignition configuration available t
 
 ## Boot with a fresh copy
 
+- On the host, restore a fresh image and boot the VM with your Ignition config:
+
 ```bash
 cp -i --reflink=auto flatcar_production_qemu_image.img.fresh flatcar_production_qemu_image.img
 ./flatcar_production_qemu.sh -i ignition.json
@@ -108,11 +121,15 @@ cp -i --reflink=auto flatcar_production_qemu_image.img.fresh flatcar_production_
 
 ## Log in via SSH in a new terminal
 
+- On the host, open a new terminal and SSH into the VM:
+
 ```bash
 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -p 2222 core@127.0.0.1
 ```
 
 ## Check that NGINX is running
+
+- On the Flatcar instance, confirm the service and HTTP response:
 
 ```bash
 systemctl status nginx
@@ -140,17 +157,16 @@ passwd:
         - ssh-rsa AAAAB......xyz email@host.net
 ```
 
-Afterwards, transpile it again to Ignition JSON, overwrite `flatcar_production_qemu_image.img` with the fresh image file, and pass the ignition config to `./flatcar_production_qemu.sh` once again.
+Afterwards, on the host, transpile it again to Ignition JSON, overwrite `flatcar_production_qemu_image.img` with the fresh image file, and pass the ignition config to `./flatcar_production_qemu.sh` once again.
 
 ## Quick Iterations with QEMU
 
 When you boot the image file and apply the Ignition config, the image is set. You would have to reprovision the image to have a new state. However, you can take advantage of the QEMU -snapshot flag that starts up the image, but it does not save the changes to the image file. This can be useful if you want to quickly reprovision locally, without having to keep swapping the underlying image file to a fresh one.
 
-Here is an example of the syntax needed to use this flag:
+- On the host, use a snapshot boot like this:
 
 ```bash
 ./flatcar_production_qemu_uefi.sh -i config.ign -p 2224 -- -snapshot -m 4096
 ```
 
 See the [QEMU documentation](https://www.qemu.org/docs/master/system/qemu-manpage.html) for more information.
-

--- a/content/docs/latest/os-config/host-config/configuring-date-and-timezone.md
+++ b/content/docs/latest/os-config/host-config/configuring-date-and-timezone.md
@@ -14,6 +14,8 @@ By default, Flatcar Container Linux machines keep time in the Coordinated Univer
 
 The [`timedatectl(1)`][timedatectl] command displays and sets the date, time, and time zone.
 
+- On the Flatcar instance, check the current date, time, and time zone:
+
 ```bash
 $ timedatectl status
       Local time: Wed 2015-08-26 19:29:12 UTC
@@ -28,7 +30,9 @@ NTP synchronized: yes
 
 ### Recommended: UTC time
 
-To avoid time zone confusion and the complexities of adjusting clocks for daylight saving time (or not) in accordance with regional custom, we recommend that all machines in Flatcar Container Linux clusters use UTC. This is the default time zone. To reset a machine to this default:
+To avoid time zone confusion and the complexities of adjusting clocks for daylight saving time (or not) in accordance with regional custom, we recommend that all machines in Flatcar Container Linux clusters use UTC. This is the default time zone.
+
+- On the Flatcar instance, reset the machine to UTC:
 
 ```bash
 sudo timedatectl set-timezone UTC
@@ -36,7 +40,9 @@ sudo timedatectl set-timezone UTC
 
 ### Changing the time zone
 
-If your site or application requires a different system time zone, start by listing the available options:
+If your site or application requires a different system time zone:
+
+1. On the Flatcar instance, list the available time zones:
 
 ```bash
 $ timedatectl list-timezones
@@ -46,13 +52,13 @@ Africa/Addis_Ababa
 …
 ```
 
-Pick a time zone from the list and set it:
+2. Pick a time zone from the list and set it:
 
 ```bash
 sudo timedatectl set-timezone America/New_York
 ```
 
-Check the changes:
+3. Check the changes:
 
 ```bash
 $ timedatectl
@@ -74,7 +80,9 @@ NTP synchronized: yes
 
 ## Time synchronization
 
-Flatcar Container Linux clusters use NTP to synchronize the clocks of member nodes, and all machines start an NTP client at boot. The operating system uses [`systemd-timesyncd(8)`][systemd-timesyncd] as the default NTP client. Use `systemctl` to check which service is running:
+Flatcar Container Linux clusters use NTP to synchronize the clocks of member nodes, and all machines start an NTP client at boot. The operating system uses [`systemd-timesyncd(8)`][systemd-timesyncd] as the default NTP client.
+
+- On the Flatcar instance, use `systemctl` to check which service is running:
 
 ```bash
 $ systemctl status systemd-timesyncd ntpd
@@ -108,7 +116,9 @@ Unless you have a highly reliable and precise time server pool, use your cloud p
 
 `Systemd-timesyncd` can discover NTP servers from DHCP, individual [network][systemd.network] configs, the file [`timesyncd.conf`][timesyncd.conf], or the default `*.flatcar.pool.ntp.org` pool.
 
-The default behavior uses NTP servers provided by DHCP. To disable this, write a configuration listing your preferred NTP servers into the file `/etc/systemd/network/50-dhcp-no-ntp.conf`:
+The default behavior uses NTP servers provided by DHCP. To disable this:
+
+1. On the Flatcar instance, write a configuration listing your preferred NTP servers into `/etc/systemd/network/50-dhcp-no-ntp.conf`:
 
 ```ini
 [Network]
@@ -121,7 +131,7 @@ UseDomains=true
 UseNTP=false
 ```
 
-Then restart the network daemon:
+2. Restart the network daemon:
 
 ```bash
 sudo systemctl restart systemd-networkd
@@ -144,7 +154,9 @@ storage:
 
 ## Switching from timesyncd to ntpd
 
-You can switch from `systemd-timesyncd` to `ntpd` with the following commands:
+You can switch from `systemd-timesyncd` to `ntpd` with the following commands on the Flatcar instance:
+
+1. Stop and mask `systemd-timesyncd`, then enable and start `ntpd`:
 
 ```bash
 sudo systemctl stop systemd-timesyncd
@@ -170,7 +182,9 @@ Because `timesyncd` and `ntpd` are mutually exclusive, it's important to `mask` 
 
 ### Configuring ntpd
 
-The `ntpd` service reads all configuration from the file `/etc/ntp.conf`. It does not use DHCP or other configuration sources. To use a different set of NTP servers, replace the `/etc/ntp.conf` symlink with something like the following:
+The `ntpd` service reads all configuration from the file `/etc/ntp.conf`. It does not use DHCP or other configuration sources. To use a different set of NTP servers:
+
+1. On the Flatcar instance, replace the `/etc/ntp.conf` symlink with something like the following:
 
 ```text
 server 0.pool.example.com
@@ -181,7 +195,7 @@ restrict 127.0.0.1
 restrict [::1]
 ```
 
-Then ask `ntpd` to reload its configuration:
+2. Ask `ntpd` to reload its configuration:
 
 ```bash
 sudo systemctl reload ntpd


### PR DESCRIPTION
# Docs: add step numbering and where-to-run guidance

Polishes three docs for flatcar/Flatcar#2378: Quickstart, Debugging tools, and Date/timezone. Adds numbered multi-step procedures, clarifies host vs Flatcar vs toolbox where needed, and uses bullets for one-step procedures. No command changes.

## How to use

Review the three Markdown diffs (or skim the rendered pages) and confirm the wording matches flatcar/Flatcar#2378.

## Testing done

Manual review of the three files against flatcar/Flatcar#2378. 

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.