### PR TITLE
fix: call raise_for_status on the Response, not on status_code

### DIFF
--- a/tools/release-scripts/flatcar_release_info.py
+++ b/tools/release-scripts/flatcar_release_info.py
@@ -149,7 +149,7 @@ def main(args):
     else:
         channels = ['stable', 'beta', 'alpha', 'edge', 'lts']
         lts_info = requests.get('https://lts.release.flatcar-linux.net/lts-info')
-        lts_info.status_code.raise_for_status()
+        lts_info.raise_for_status()
         for line in io.StringIO(lts_info.text):
             _, year, support = line.strip().split(':')
             if support != 'unsupported':


### PR DESCRIPTION
## Summary

In `tools/release-scripts/flatcar_release_info.py`, when `--channel` is not passed the script fetches LTS channel metadata and attempts to guard against HTTP errors:

```python
lts_info = requests.get('https://lts.release.flatcar-linux.net/lts-info')
lts_info.status_code.raise_for_status()
```

`lts_info.status_code` is a plain `int`, so `.raise_for_status()` raises `AttributeError` and the HTTP error guard never fires. Any run reaching this line crashes unconditionally regardless of the HTTP status.

## Fix

Call `raise_for_status()` on the `Response` object instead:

```python
lts_info = requests.get('https://lts.release.flatcar-linux.net/lts-info')
lts_info.raise_for_status()
```

Now a non-2xx response correctly raises `HTTPError` and a 2xx response proceeds as intended.

Fixes: #658