### PR TITLE
fix: qualify get_external_docs_config via the docsfetcher module

### DIFF
--- a/tools/get-latest-version.py
+++ b/tools/get-latest-version.py
@@ -21,7 +21,7 @@ docsfetcher = __import__('docs-fetcher')
 
 def get_latest_version(file_path):
     latest_version = ''
-    external_docs = get_external_docs_config(file_path)
+    external_docs = docsfetcher.get_external_docs_config(file_path)
 
     if not external_docs:
         sys.stderr.write('Warning: No external docs in {}\n'.format(file_path))


### PR DESCRIPTION
## Summary

`tools/get-latest-version.py` calls `get_external_docs_config` as a bare name on line 24, but the function lives in the `docs-fetcher` module imported via `__import__` and bound to `docsfetcher`. `__import__` does not inject the module's symbols into the caller's namespace, so every run raised `NameError: name 'get_external_docs_config' is not defined`.

This qualifies the call through the module object so it resolves correctly.

## Changes

`tools/get-latest-version.py` line 24:

```python
external_docs = get_external_docs_config(file_path)
```

becomes

```python
external_docs = docsfetcher.get_external_docs_config(file_path)
```

## Verification

`python3 -m py_compile tools/get-latest-version.py` passes. `tools/docs-fetcher.py` defines `get_external_docs_config(file_path)` at line 23, so the qualified call resolves.

Fixes: #664
