### PR TITLE
docs: document local kola host prerequisites

### DIFF
--- a/content/docs/latest/devguide/sdk-modifying-flatcar.md
+++ b/content/docs/latest/devguide/sdk-modifying-flatcar.md
@@ -730,6 +730,8 @@ For more granular control over testing or when you need to run specific test sui
 - Firewall configured to allow kola interfaces: `sudo firewall-cmd --zone=nm-shared --add-interface=kola-+`
 - Required packages: `swtmp`, `dnsmasq`, `go`, and `iptables` in `$PATH`
 - QEMU: `qemu-system-x86_64` for AMD64 and/or `qemu-system-aarch64` for ARM64
+- On Fedora, install `seabios-bin`. You can locate the firmware files with `rpm -ql seabios-bin`.
+- Ensure the host `iptables` `FORWARD` policy allows forwarding. Docker may change the default policy to `DROP`, preventing QEMU guests from accessing the network.
 
 #### Setting up kola
 You have two options for setting up kola:


### PR DESCRIPTION
# Docs Fix

- note the required QEMU firmware package on Fedora
- mention that Docker may set the iptables FORWARD policy to DROP, preventing guest network connectivity

fixes- https://github.com/flatcar/Flatcar/issues/2266

