### PR TITLE
fix: use 'current-STREAM' with dash in LTS skip-guard

### DIFF
--- a/tools/release-scripts/flatcar_release_info.py
+++ b/tools/release-scripts/flatcar_release_info.py
@@ -188,7 +188,7 @@ def main(args):
                 'architectures': release_info.architectures,
             }
             for target_dir in target_dirs:
-                if stream and target_dir == 'releases/lts/' and (release == 'current' or release == 'current' + stream):
+                if stream and target_dir == 'releases/lts/' and (release == 'current' or release == 'current-' + stream):
                     # Do not write "lts/current..." files when called for "lts-STREAM"
                     continue
                 os.makedirs(target_dir, exist_ok=True)


### PR DESCRIPTION
## Summary

`tools/release-scripts/flatcar_release_info.py` had a string-concatenation bug in the LTS skip-guard. The guard compared the release key against `'current' + stream` (e.g. `'current2023'`), but LTS stream release keys are consistently named `'current-2023'` (with a dash) everywhere else in the file (lines 167-171). Because the two strings never match, the `continue` was never reached and `releases/lts/current-STREAM.yml` was written unconditionally.

## Fix

Use the dashed form `'current-' + stream` so the guard actually matches and skips writing the LTS "current" file.

## Test plan

- `python3 -m py_compile tools/release-scripts/flatcar_release_info.py` passes.
- The guard now matches `release == 'current-2023'` when `stream == '2023'`, so the `continue` fires and the redundant file is skipped.

Fixes #668
