### PR TITLE
docs(sys-ext): add comprehensive end-to-end sysext tutorial

### DIFF
--- a/content/docs/latest/sys-ext/_index.md
+++ b/content/docs/latest/sys-ext/_index.md
@@ -6,6 +6,9 @@ aliases:
   - /docs/latest/provisioning/sysext/
 ---
 
+> **New to sysext?** Start with the [sysext tutorial](./tutorial/) for a hands-on walkthrough from concept to custom extension deployment.
+
+
 Flatcar Container Linux bundles various software components with fixed versions together into one release.
 For users that require a particular version of a software component this means that the software needs to be supplied out of band and overwrite the built-in software copy.
 Another approach we recommended was to store binaries in `/opt/bin` and prefer them in the `PATH`.

--- a/content/docs/latest/sys-ext/tutorial/_index.md
+++ b/content/docs/latest/sys-ext/tutorial/_index.md
@@ -1,0 +1,28 @@
+---
+title: "Sysext Tutorial: From Concept to Custom Extension"
+linktitle: Tutorial
+description: A hands-on, end-to-end guide to systemd-sysext on Flatcar — from understanding the concept through building and deploying your own custom extension.
+weight: 5
+---
+
+This tutorial covers the full **systemd-sysext** lifecycle on Flatcar Container Linux. By the end you will know how to:
+
+- Use official and community extensions shipped with Flatcar
+- Build your own custom sysext image from scratch
+- Test extensions locally in a QEMU VM before deploying
+- Deploy extensions automatically at boot with Ignition
+
+## Who this is for
+
+Anyone comfortable with Linux who is new to image-based, immutable operating systems and systemd-sysext. No prior Flatcar experience is required.
+
+## Tutorial parts
+
+| Part | Topic |
+|------|-------|
+| [1 — Understanding sysext](./understanding-sysext/) | What sysext is, extension types, how overlays work |
+| [2 — Using official extensions](./using-official-extensions/) | Enabling, deploying, and verifying official extensions |
+| [3 — Building your first custom extension](./building-custom-extension/) | Step-by-step: package a tool into a `.raw` image |
+| [4 — Testing locally](./testing-locally/) | Boot QEMU, load your extension, debug failures |
+| [5 — Production deployment](./production-deployment/) | Ignition provisioning, hosting, and auto-updates |
+| [6 — Contributing to sysext-bakery](./contributing-to-bakery/) | Turn your recipe into a reusable bakery extension |

--- a/content/docs/latest/sys-ext/tutorial/building-custom-extension.md
+++ b/content/docs/latest/sys-ext/tutorial/building-custom-extension.md
@@ -1,0 +1,153 @@
+---
+title: "Part 3: Building Your First Custom Extension"
+linktitle: "3 — Building a custom extension"
+description: Step-by-step guide to packaging a static binary into a sysext image from scratch.
+weight: 30
+---
+
+This part walks through building a custom sysext image that ships `jq` — a lightweight, statically-linked JSON processor. The same steps apply to any static binary.
+
+## Prerequisites
+
+You need the following tools on your **local machine** (not inside Flatcar):
+
+```bash
+# Debian/Ubuntu
+sudo apt install squashfs-tools curl
+
+# macOS (via Homebrew)
+brew install squashfs
+```
+
+## Step 1 — Create the sysext directory structure
+
+A sysext image is just a directory (or filesystem image) with a specific layout:
+
+```
+my-jq.raw  (squashfs image of the directory below)
+└── usr/
+    ├── bin/
+    │   └── jq                          ← the binary
+    └── lib/
+        └── extension-release.d/
+            └── extension-release.my-jq ← required metadata file
+```
+
+Create the directory structure:
+
+```bash
+mkdir -p my-jq/usr/bin
+mkdir -p my-jq/usr/lib/extension-release.d
+```
+
+## Step 2 — Download the static binary
+
+Download the `jq` static binary for `x86-64`:
+
+```bash
+curl -fsSL -o my-jq/usr/bin/jq \
+  https://github.com/jqlang/jq/releases/latest/download/jq-linux-amd64
+
+chmod +x my-jq/usr/bin/jq
+```
+
+For `arm64`:
+
+```bash
+curl -fsSL -o my-jq/usr/bin/jq \
+  https://github.com/jqlang/jq/releases/latest/download/jq-linux-arm64
+
+chmod +x my-jq/usr/bin/jq
+```
+
+> **Important:** Never place binaries in `usr/sbin/`. On Flatcar, `/usr/sbin` is a symlink to `/usr/bin`. Shipping a `usr/sbin/` directory in a sysext would overwrite that symlink and break the host. Always use `usr/bin/`.
+
+## Step 3 — Write the extension-release metadata file
+
+This file tells `systemd-sysext` that the extension is compatible with Flatcar. The name of the file must match the extension name exactly.
+
+```bash
+cat > my-jq/usr/lib/extension-release.d/extension-release.my-jq << 'EOF'
+ID=flatcar
+SYSEXT_LEVEL=1.0
+EOF
+```
+
+`SYSEXT_LEVEL=1.0` means the extension works with any Flatcar version — the right choice for static binaries that have no OS-level dependencies.
+
+If your binary links against Flatcar's glibc or other OS libraries, use `VERSION_ID` instead:
+
+```ini
+ID=flatcar
+VERSION_ID=3975.2.0
+```
+
+This couples the extension to that specific Flatcar release. The extension will stop loading after an OS update, so always prefer static binaries when possible.
+
+## Step 4 — Build the squashfs image
+
+```bash
+mksquashfs my-jq my-jq.raw
+```
+
+You now have `my-jq.raw` — a squashfs sysext image ready to be loaded on Flatcar.
+
+Verify it looks correct:
+
+```bash
+# List contents
+sudo systemd-dissect --list my-jq.raw
+
+# Check the extension-release metadata
+sudo systemd-dissect --with my-jq.raw \
+  cat usr/lib/extension-release.d/extension-release.my-jq
+```
+
+Expected output of the metadata check:
+
+```
+ID=flatcar
+SYSEXT_LEVEL=1.0
+```
+
+## Adding a systemd service (optional)
+
+If your extension ships a daemon, add its unit file under `usr/lib/systemd/system/`:
+
+```bash
+mkdir -p my-service/usr/lib/systemd/system/multi-user.target.d
+
+# The service unit
+cat > my-service/usr/lib/systemd/system/my-service.service << 'EOF'
+[Unit]
+Description=My custom service
+
+[Service]
+ExecStart=/usr/bin/my-service --config /etc/my-service/config.yaml
+Restart=on-failure
+EOF
+
+# Drop-in to start it automatically on merge
+# (do NOT use symlinks — use Upholds= drop-ins instead)
+cat > my-service/usr/lib/systemd/system/multi-user.target.d/10-my-service.conf << 'EOF'
+[Unit]
+Upholds=my-service.service
+EOF
+```
+
+> **Why `Upholds=` and not a symlink?** Flatcar recommends using `Upholds=` drop-ins rather than shipping `WantedBy` symlinks inside the sysext. Drop-ins are the safe, supported approach; symlinks in sysexts can cause unit activation to fail in subtle ways.
+
+## Recap: what you built
+
+```
+my-jq.raw
+├── usr/bin/jq                                     ← static binary
+└── usr/lib/extension-release.d/extension-release.my-jq
+                                                   ← SYSEXT_LEVEL=1.0
+```
+
+In [Part 4](../testing-locally/) you will load this image into a live Flatcar QEMU VM and verify it works.
+
+## Next
+
+[Part 4 — Testing locally →](../testing-locally/)

--- a/content/docs/latest/sys-ext/tutorial/contributing-to-bakery.md
+++ b/content/docs/latest/sys-ext/tutorial/contributing-to-bakery.md
@@ -1,0 +1,173 @@
+---
+title: "Part 6: Contributing to sysext-bakery"
+linktitle: "6 — Contributing to bakery"
+description: Turn your custom extension into a reusable bakery recipe so others can use and benefit from your work.
+weight: 60
+---
+
+The [sysext-bakery](https://github.com/flatcar/sysext-bakery) repository is the central hub for **community-supported** sysext images. If your custom extension could be useful to others, consider contributing it as a bakery recipe.
+
+## What is a bakery recipe?
+
+A "recipe" is a `create.sh` shell script that automates building an extension image for a given upstream project release. The script:
+
+- Fetches binaries from the upstream project's GitHub releases (or other source)
+- Places them in the correct sysext directory structure
+- Bundles any required systemd unit files
+- Produces a `.raw` squashfs image
+
+Example structure:
+
+```
+sysext-bakery/
+├── my-tool.sysext/
+│   ├── create.sh         ← build script (required)
+│   ├── files/            ← static files like systemd units (optional)
+│   │   └── usr/lib/systemd/system/my-tool.service
+│   └── test.sh           ← smoke tests (optional but encouraged)
+└── bakery.sh             ← main build tool
+```
+
+## Step-by-step: Turn jq into a bakery recipe
+
+### 1. Fork and clone sysext-bakery
+
+```bash
+gh repo fork flatcar/sysext-bakery --clone
+cd sysext-bakery
+```
+
+### 2. Create the extension directory
+
+```bash
+cp -r _skel.sysext jq.sysext
+```
+
+### 3. Implement `create.sh`
+
+Open `jq.sysext/create.sh` and replace the TODO sections:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Called by bakery.sh to list all available upstream releases
+function list_available_versions() {
+  list_github_releases "jqlang" "jq" | sed 's/^jq-//'
+}
+
+# Called by bakery.sh to build the extension for a specific version
+function populate_sysext_root() {
+  local sysextroot="$1"
+  local arch="$2"
+  local version="$3"
+
+  # Transform arch: x86-64 → amd64, arm64 → arm64
+  local rel_arch="$(arch_transform "x86-64" "amd64" "$arch")"
+
+  echo "Downloading jq ${version} for ${arch}"
+
+  mkdir -p "${sysextroot}/usr/bin"
+
+  curl -fsSL -o "${sysextroot}/usr/bin/jq" \
+    "https://github.com/jqlang/jq/releases/download/jq-${version}/jq-linux-${rel_arch}"
+
+  chmod +x "${sysextroot}/usr/bin/jq"
+}
+```
+
+The `list_github_releases` and `arch_transform` helper functions are provided by `lib/libbakery.sh` — you do not need to implement them.
+
+### 4. Test your recipe locally
+
+```bash
+# List all available versions
+./bakery.sh list jq
+
+# Build the latest version for x86-64
+./bakery.sh create jq "$(./bakery.sh list jq --latest true)"
+# Produces: jq-<version>-x86-64.raw
+
+# Boot a test VM with the extension loaded
+./bakery.sh boot jq-*.raw
+```
+
+Inside the VM:
+
+```bash
+which jq
+echo '{"test":true}' | jq .
+```
+
+### 5. Add smoke tests (recommended)
+
+Edit `jq.sysext/test.sh`:
+
+```bash
+#!/usr/bin/env bash
+
+function run_tests() {
+  test_extension_release_present "jq"
+  test_no_usr_sbin
+  test_binary_exists "jq"
+}
+```
+
+Run the tests:
+
+```bash
+# Extract the sysext root from the .raw image
+mkdir -p /tmp/jq-root
+sudo mount -o loop,ro jq-*.raw /tmp/jq-root
+
+# Run tests
+./bakery.sh test /tmp/jq-root jq
+
+# Cleanup
+sudo umount /tmp/jq-root
+```
+
+### 6. Open a pull request
+
+```bash
+git checkout -b add-jq-sysext
+git add jq.sysext
+git commit -s -m "jq.sysext: add jq JSON processor extension"
+git push -u origin add-jq-sysext
+gh pr create --repo flatcar/sysext-bakery --fill
+```
+
+In your PR description:
+
+- Link to the upstream project (e.g. `https://github.com/jqlang/jq`)
+- Note that binaries are statically linked (or if not, explain why `VERSION_ID` coupling is required)
+- Confirm you tested the extension on Flatcar (include output of `jq --version`)
+
+## Bakery conventions
+
+| Convention | Why |
+|------------|-----|
+| **Static binaries preferred** | Avoid coupling to Flatcar release versions |
+| **No `/usr/sbin`** | Flatcar's `/usr/sbin` is a symlink; shipping it breaks the host |
+| **Use `Upholds=` drop-ins for units** | Shipping WantedBy symlinks in sysexts is brittle |
+| **Fetch from GitHub releases** | Predictable, versioned, and easy to automate |
+| **Test coverage encouraged** | Even minimal smoke tests catch regressions |
+
+## After your PR is merged
+
+- Your extension will be built and published automatically on every new upstream release
+- It will appear at `https://extensions.flatcar.org/<your-extension>.raw`
+- It will be listed on the [bakery documentation site](https://flatcar.github.io/sysext-bakery/)
+- Other users can provision it with `systemd-sysupdate` or Ignition
+
+## Next steps
+
+You have now completed the full sysext tutorial. You know how to:
+
+- Use official and bakery extensions
+- Build custom sysext images from scratch
+- Test extensions locally with QEMU
+- Deploy extensions in production with Ignition and systemd-sysupdate
+- Contribute reusable recipes back to sysext-bakery
+
+For deeper reference material and advanced topics, return to the [main sysext documentation page](../../).

--- a/content/docs/latest/sys-ext/tutorial/production-deployment.md
+++ b/content/docs/latest/sys-ext/tutorial/production-deployment.md
@@ -1,0 +1,196 @@
+---
+title: "Part 5: Production Deployment"
+linktitle: "5 — Production deployment"
+description: Deploy custom sysext images via Ignition, host them on object storage, and configure automatic updates with systemd-sysupdate.
+weight: 50
+---
+
+## Hosting your extension image
+
+Your extension image needs to be reachable over HTTPS from your Flatcar nodes. Any static file host works:
+
+- AWS S3 / S3-compatible (MinIO, Cloudflare R2)
+- Azure Blob Storage
+- GCP Cloud Storage
+- A plain HTTPS web server (nginx, caddy)
+- GitHub Releases
+
+Example: Upload to S3:
+
+```bash
+aws s3 cp my-jq.raw s3://my-flatcar-assets/extensions/my-jq.raw --acl public-read
+```
+
+Note the public HTTPS URL — you will use it in the Butane config below.
+
+## Provisioning via Ignition at first boot
+
+### Basic — download at first boot
+
+This Butane config downloads `my-jq.raw` from your server during Ignition provisioning:
+
+```yaml
+variant: flatcar
+version: 1.0.0
+storage:
+  files:
+    - path: /etc/extensions/my-jq.raw
+      mode: 0644
+      contents:
+        source: https://my-flatcar-assets.example.com/extensions/my-jq.raw
+```
+
+Transpile and use as user data for your cloud instance or VM.
+
+### With checksum verification (recommended)
+
+Always verify the image integrity in production:
+
+```bash
+# Generate the sha512 hash of your image
+sha512sum my-jq.raw
+# abc123...  my-jq.raw
+```
+
+Add the `verification` field to your Butane config:
+
+```yaml
+variant: flatcar
+version: 1.0.0
+storage:
+  files:
+    - path: /etc/extensions/my-jq.raw
+      mode: 0644
+      contents:
+        source: https://my-flatcar-assets.example.com/extensions/my-jq.raw
+        verification:
+          hash: sha512-abc123...
+```
+
+Ignition will refuse to boot if the downloaded file does not match the hash.
+
+### Multiple extensions
+
+Provision multiple bakery or custom extensions in one config:
+
+```yaml
+variant: flatcar
+version: 1.0.0
+storage:
+  files:
+    - path: /etc/extensions/my-jq.raw
+      mode: 0644
+      contents:
+        source: https://my-flatcar-assets.example.com/extensions/my-jq.raw
+
+    - path: /etc/extensions/tailscale.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/tailscale.raw
+
+    # Disable built-in docker if this node uses a custom containerd
+  links:
+    - path: /etc/extensions/docker-flatcar.raw
+      target: /dev/null
+      overwrite: true
+```
+
+## Automatic updates with systemd-sysupdate
+
+From Flatcar **3510.2.0** onwards, `systemd-sysupdate` can update your extension images in the background — the same way Flatcar updates the OS itself.
+
+### How it works
+
+You publish new versions of your extension at a predictable URL pattern:
+
+```
+https://my-flatcar-assets.example.com/extensions/my-jq-1.7.1-x86-64.raw
+https://my-flatcar-assets.example.com/extensions/my-jq-1.8.0-x86-64.raw
+                                                         ↑
+                                                  version in the filename
+```
+
+And a `SHA256SUMS` file listing all available versions.
+
+`systemd-sysupdate` checks the manifest on a schedule, downloads new versions, and atomically swaps the extension file.
+
+### sysupdate configuration file
+
+Place this file at `/etc/sysupdate.my-jq.d/my-jq.conf`:
+
+```ini
+[Transfer]
+Verify=false
+
+[Source]
+Type=url-file
+Path=https://my-flatcar-assets.example.com/extensions/
+MatchPattern=my-jq-@v-%a.raw
+
+[Target]
+Type=regular-file
+Path=/etc/extensions
+MatchPattern=my-jq-@v-%a.raw
+CurrentSymlink=/etc/extensions/my-jq.raw
+```
+
+`@v` is replaced by the version and `%a` by the architecture (`x86-64` or `arm64`).
+
+### Provision the sysupdate config via Butane
+
+```yaml
+variant: flatcar
+version: 1.0.0
+storage:
+  directories:
+    - path: /etc/sysupdate.my-jq.d
+      mode: 0755
+  files:
+    - path: /etc/sysupdate.my-jq.d/my-jq.conf
+      mode: 0644
+      contents:
+        inline: |
+          [Transfer]
+          Verify=false
+
+          [Source]
+          Type=url-file
+          Path=https://my-flatcar-assets.example.com/extensions/
+          MatchPattern=my-jq-@v-%a.raw
+
+          [Target]
+          Type=regular-file
+          Path=/etc/extensions
+          MatchPattern=my-jq-@v-%a.raw
+          CurrentSymlink=/etc/extensions/my-jq.raw
+
+systemd:
+  units:
+    - name: systemd-sysupdate.timer
+      enabled: true
+```
+
+The `systemd-sysupdate.timer` unit runs the update check periodically (default: once a day).
+
+### Trigger an update manually
+
+```bash
+sudo systemd-sysupdate --component=my-jq update
+sudo systemctl restart systemd-sysext
+```
+
+## Baking extensions into a custom Flatcar image
+
+If you manage your own image pipeline, you can pre-bake extension images into the Flatcar root filesystem so they are available on first boot without any network download.
+
+The [`bake_flatcar_image.sh`](https://flatcar.github.io/sysext-bakery/#baking-sysexts-into-flatcar-os-images) helper in sysext-bakery handles this:
+
+```bash
+./tools/bake_flatcar_image.sh \
+  --image flatcar_production_image.bin \
+  --extension my-jq.raw
+```
+
+## Next
+
+[Part 6 — Contributing to sysext-bakery →](../contributing-to-bakery/)

--- a/content/docs/latest/sys-ext/tutorial/testing-locally.md
+++ b/content/docs/latest/sys-ext/tutorial/testing-locally.md
@@ -1,0 +1,166 @@
+---
+title: "Part 4: Testing Locally"
+linktitle: "4 — Testing locally"
+description: Boot a Flatcar QEMU VM, load your custom extension, and debug merge failures.
+weight: 40
+---
+
+This part shows how to test the `my-jq.raw` image you built in [Part 3](../building-custom-extension/) using a local Flatcar QEMU VM before deploying to production.
+
+## Prerequisites
+
+- `my-jq.raw` in your current directory
+- `qemu` installed (`qemu-system-x86_64` or `qemu-system-aarch64`)
+- `docker` installed and running (used by the `bakery.sh boot` helper)
+
+## Option A — Using bakery.sh boot (easiest)
+
+If you have [sysext-bakery](https://github.com/flatcar/sysext-bakery) cloned locally, the `boot` command handles everything — image download, HTTP server, and VM launch — in one step:
+
+```bash
+./bakery.sh boot my-jq.raw
+```
+
+This will:
+1. Download the latest Flatcar Alpha QEMU image (if not already present)
+2. Start a local HTTP server serving `my-jq.raw`
+3. Generate a Butane config that provisions the extension from `http://10.0.2.2:12345/my-jq.raw`
+4. Boot the VM and drop you into an interactive shell
+
+Once inside the VM, verify the extension loaded:
+
+```bash
+systemd-sysext status
+# HIERARCHY EXTENSIONS SINCE
+# /usr      my-jq      Thu 2026-01-01 10:00:00 UTC
+
+which jq
+# /usr/bin/jq
+
+echo '{"hello":"world"}' | jq .
+# {
+#   "hello": "world"
+# }
+```
+
+Shut down the VM:
+
+```bash
+sudo poweroff
+```
+
+## Option B — Manual QEMU setup
+
+If you want full control, do it manually.
+
+### 1. Download a Flatcar QEMU image
+
+```bash
+# For x86-64
+ARCH="amd64"
+BASE="https://alpha.release.flatcar-linux.net/${ARCH}-usr/current"
+
+wget "${BASE}/flatcar_production_qemu_uefi.sh"
+wget "${BASE}/flatcar_production_qemu_uefi_efi_code.qcow2"
+wget "${BASE}/flatcar_production_qemu_uefi_efi_vars.qcow2"
+wget "${BASE}/flatcar_production_qemu_uefi_image.img"
+chmod +x flatcar_production_qemu_uefi.sh
+```
+
+### 2. Serve the extension image over HTTP
+
+`systemd-sysext` loads extensions from the local filesystem, so we need to get `my-jq.raw` into the VM. The simplest approach is to serve it over HTTP and have Ignition download it at first boot:
+
+```bash
+# In a separate terminal — serve the current directory on port 12345
+python3 -m http.server 12345
+```
+
+### 3. Write a Butane config
+
+Create `test-jq.yaml`:
+
+```yaml
+variant: flatcar
+version: 1.0.0
+storage:
+  files:
+    - path: /etc/extensions/my-jq.raw
+      mode: 0644
+      contents:
+        # 10.0.2.2 is QEMU's default gateway — reaches your host machine
+        source: http://10.0.2.2:12345/my-jq.raw
+systemd:
+  units:
+    - name: update-engine.service
+      mask: true
+    - name: locksmithd.service
+      mask: true
+```
+
+Transpile it:
+
+```bash
+cat test-jq.yaml | docker run --rm -i quay.io/coreos/butane:latest > test-jq.json
+```
+
+### 4. Boot the VM
+
+```bash
+./flatcar_production_qemu_uefi.sh \
+  -i test-jq.json \
+  -- -nographic -snapshot
+```
+
+Log in automatically as `core`, then verify:
+
+```bash
+systemd-sysext status
+echo '{"hello":"world"}' | jq .
+```
+
+## Debugging failed merges
+
+### Extension not appearing in `systemd-sysext status`
+
+Enable debug logging and refresh:
+
+```bash
+sudo SYSTEMD_LOG_LEVEL=debug systemd-sysext refresh 2>&1 | less
+```
+
+Common error messages and what they mean:
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Extension "my-jq" is missing required metadata file` | `extension-release.my-jq` file not found | Check the exact filename matches the extension name |
+| `ID field of extension does not match host` | `ID=` in metadata is not `flatcar` | Set `ID=flatcar` |
+| `Version mismatch` | `VERSION_ID=` does not match running Flatcar | Use `SYSEXT_LEVEL=1.0` for static binaries |
+| `Sysext image is for a different architecture` | Wrong binary arch | Download the correct arch variant |
+
+### Inspecting an image without booting
+
+```bash
+# List all files in the image
+sudo systemd-dissect --list my-jq.raw
+
+# Read the metadata file directly
+sudo systemd-dissect --with my-jq.raw \
+  cat usr/lib/extension-release.d/extension-release.my-jq
+
+# Detailed mtree listing (permissions, owners, sizes)
+sudo systemd-dissect --mtree my-jq.raw
+```
+
+### Checking if a binary is truly static
+
+```bash
+file my-jq/usr/bin/jq
+# my-jq/usr/bin/jq: ELF 64-bit LSB executable, x86-64, statically linked
+```
+
+If the output says `dynamically linked`, the binary depends on host libraries. Either find a static build or pin your extension to a specific Flatcar `VERSION_ID`.
+
+## Next
+
+[Part 5 — Production deployment →](../production-deployment/)

--- a/content/docs/latest/sys-ext/tutorial/understanding-sysext.md
+++ b/content/docs/latest/sys-ext/tutorial/understanding-sysext.md
@@ -1,0 +1,122 @@
+---
+title: "Part 1: Understanding systemd-sysext"
+linktitle: "1 — Understanding sysext"
+description: What systemd-sysext is, why Flatcar uses it, and how the three extension types differ.
+weight: 10
+---
+
+## What is systemd-sysext?
+
+Flatcar's root filesystem is **read-only**. You cannot install packages with `apt` or `yum` — there is no package manager. This is intentional: it keeps the OS minimal, reproducible, and easy to update atomically.
+
+`systemd-sysext` is how you layer **additional software on top of that read-only base** without modifying it. It works by mounting an overlay over `/usr` at boot time. Any binaries, libraries, or systemd unit files inside the extension image become available on the running system as if they were part of the OS.
+
+When `systemd-sysext` merges an extension image, the result looks like this:
+
+```
+/usr  ←─── read-only base OS
+  └── overlay ←─── your extension image
+        └── bin/kubectl   (now visible at /usr/bin/kubectl)
+        └── lib/systemd/system/kubelet.service
+```
+
+After a reboot (or `systemctl restart systemd-sysext`), the overlay is gone. The base OS is untouched.
+
+## Why Flatcar uses sysext
+
+Before sysext, the only supported way to run extra binaries on Flatcar was to place them in `/opt/bin` and adjust `$PATH`. That worked but was fragile, hard to version, and not integrated with systemd.
+
+sysext solves all of that:
+
+- Extensions are versioned, signed, and verified
+- Binaries land directly in `/usr/bin` — no `$PATH` tricks
+- systemd unit files are picked up automatically
+- `systemd-sysupdate` can update extensions in the background, just like OS updates
+
+Flatcar has supported user-provided sysext images since version **3185.0.0**.
+
+## The three extension types
+
+This is the most common source of confusion. Flatcar ships three distinct categories of extension, and they work differently.
+
+### Built-in (always present)
+
+These are shipped as part of every Flatcar image and are **always active**. You cannot disable them without explicitly opting out via Ignition.
+
+Examples: `docker-flatcar`, `containerd-flatcar`, OEM-specific extensions (`oem-*`).
+
+To opt out of a built-in extension, create a symlink to `/dev/null` via Butane:
+
+```yaml
+variant: flatcar
+version: 1.0.0
+storage:
+  links:
+    - path: /etc/extensions/docker-flatcar.raw
+      target: /dev/null
+      overwrite: true
+```
+
+### Official / release extensions (opt-in)
+
+These are built and tested by the Flatcar team but are **not active by default**. They are downloaded from Flatcar's release servers at first boot when enabled.
+
+To enable one, add its name to `/etc/flatcar/enabled-sysext.conf`:
+
+```ini
+podman
+zfs
+python
+```
+
+Or via Butane:
+
+```yaml
+variant: flatcar
+version: 1.0.0
+storage:
+  files:
+    - path: /etc/flatcar/enabled-sysext.conf
+      contents:
+        inline: |
+          podman
+          zfs
+```
+
+See the [system extensions reference page](../../) for the full list of available release extensions.
+
+### Community extensions (sysext-bakery)
+
+These are built and published by the community via [sysext-bakery](https://github.com/flatcar/sysext-bakery). They are **not tested in Flatcar's CI** but cover a wide range of tools: Kubernetes, Tailscale, Vault, k3s, Cilium, and many more.
+
+You download them yourself and provision them via Ignition. See [Part 5 — Production deployment](../production-deployment/) for examples.
+
+## How the overlay works
+
+When `systemd-sysext.service` starts, it scans `/etc/extensions/` and `/var/lib/extensions/` for `.raw` image files and directories. It then mounts them as overlay layers over `/usr`.
+
+For an extension to be accepted, it must contain a **metadata file** at:
+
+```
+usr/lib/extension-release.d/extension-release.<NAME>
+```
+
+This file tells `systemd-sysext` what OS version and architecture the extension is compatible with. The minimum required content is:
+
+```ini
+ID=flatcar
+SYSEXT_LEVEL=1.0
+```
+
+If your extension links against Flatcar's own libraries (dynamically linked binaries), you must pin it to a specific Flatcar version:
+
+```ini
+ID=flatcar
+VERSION_ID=3975.2.0
+```
+
+This means the extension stops loading after an OS update — the extension must be rebuilt for the new Flatcar version. **This is why static binaries are strongly preferred**: with static binaries you use `SYSEXT_LEVEL=1.0` and the extension loads regardless of the Flatcar version.
+
+## Next
+
+[Part 2 — Using official extensions →](../using-official-extensions/)

--- a/content/docs/latest/sys-ext/tutorial/using-official-extensions.md
+++ b/content/docs/latest/sys-ext/tutorial/using-official-extensions.md
@@ -1,0 +1,135 @@
+---
+title: "Part 2: Using Official Extensions"
+linktitle: "2 — Using official extensions"
+description: Enable, deploy, and verify official Flatcar release extensions and community bakery extensions.
+weight: 20
+---
+
+## Official release extensions
+
+Flatcar ships several opt-in release extensions. They are tested by the Flatcar team and downloaded from Flatcar's release servers at first boot.
+
+### Enabling via `/etc/flatcar/enabled-sysext.conf`
+
+The simplest way to enable an extension on an existing node is to write its name to `/etc/flatcar/enabled-sysext.conf` and reboot:
+
+```bash
+echo "podman" | sudo tee -a /etc/flatcar/enabled-sysext.conf
+sudo reboot
+```
+
+### Enabling via Butane (recommended for new nodes)
+
+For provisioning new nodes, declare the extensions in your Butane config:
+
+```yaml
+variant: flatcar
+version: 1.0.0
+storage:
+  files:
+    - path: /etc/flatcar/enabled-sysext.conf
+      mode: 0644
+      contents:
+        inline: |
+          podman
+          python
+```
+
+Transpile and pass to your VM or cloud instance as user data.
+
+### Available release extensions
+
+| Name in `enabled-sysext.conf` | Available since | Notes |
+|-------------------------------|-----------------|-------|
+| `podman` | 3941.0.0 | Rootless container runtime |
+| `python` | 4012.0.0 | Python 3 interpreter |
+| `zfs` | 3913.0.0 | ZFS filesystem support |
+| `incus` | 4285.0.0 | Incus container/VM manager |
+| `nvidia-drivers-*` | 4344.0.0 | NVIDIA GPU drivers |
+| `overlaybd` | 4426.0.0 | Overlaybd image streaming |
+
+### Opting out of built-in extensions
+
+Docker and containerd are **enabled by default**. To disable them — for example on a Kubernetes node that uses containerd from a sysext-bakery image instead — use null symlinks:
+
+```yaml
+variant: flatcar
+version: 1.0.0
+storage:
+  links:
+    - path: /etc/extensions/docker-flatcar.raw
+      target: /dev/null
+      overwrite: true
+    - path: /etc/extensions/containerd-flatcar.raw
+      target: /dev/null
+      overwrite: true
+```
+
+## Community extensions (sysext-bakery)
+
+For tools not in the official list, [sysext-bakery](https://github.com/flatcar/sysext-bakery) publishes pre-built images covering Kubernetes, Tailscale, Vault, k3s, Cilium, and more.
+
+### One-off download via Butane
+
+This example provisions the latest `tailscale` bakery extension at first boot:
+
+```yaml
+variant: flatcar
+version: 1.0.0
+storage:
+  files:
+    - path: /etc/extensions/tailscale.raw
+      mode: 0644
+      contents:
+        source: https://extensions.flatcar.org/tailscale.raw
+```
+
+### With auto-updates via systemd-sysupdate
+
+The sysext-bakery repository publishes a `sysupdate` configuration for each extension so `systemd-sysupdate` can keep them up to date automatically. The [sysext-bakery documentation](https://flatcar.github.io/sysext-bakery/) has complete Butane config examples.
+
+## Verifying extension status
+
+Once the node is running, check which extensions are active:
+
+```bash
+systemd-sysext status
+```
+
+Expected output when extensions are merged:
+
+```
+HIERARCHY EXTENSIONS     SINCE
+/opt      none           -
+/usr      podman, python Thu 2026-01-01 10:00:00 UTC
+```
+
+Check that the extension's binaries are in `PATH`:
+
+```bash
+which podman
+# /usr/bin/podman
+
+podman --version
+# podman version 5.x.y
+```
+
+If an extension is listed in the status output but binaries are missing, run:
+
+```bash
+sudo SYSTEMD_LOG_LEVEL=debug systemd-sysext refresh
+```
+
+to see detailed merge diagnostics.
+
+## Reloading extensions at runtime
+
+```bash
+sudo systemctl restart systemd-sysext
+```
+
+This unmounts all extension overlays and re-merges them. In Flatcar, this also triggers `ensure-sysext.service`, which reloads systemd unit files from disk so newly added service units become available immediately.
+
+## Next
+
+[Part 3 — Building your first custom extension →](../building-custom-extension/)


### PR DESCRIPTION
## Summary

This PR adds a comprehensive, hands-on six-part sysext tutorial to the docs, addressing [flatcar/Flatcar#2295](https://github.com/flatcar/Flatcar/issues/2295).

The existing `sys-ext/_index.md` is a solid reference page but does not serve as a learning path. New users especially those coming from traditional Linux distros consistently get confused about three things:

- The difference between built-in, official, and community extensions ([#1476](https://github.com/flatcar/Flatcar/issues/1476))
- How to build and test a custom extension end-to-end
- How to deploy it in production and keep it updated

This tutorial fills that gap with working, copy-paste examples at every step.

---

## New pages

| File | Content |
|------|---------|
| `sys-ext/tutorial/_index.md` | Tutorial landing page with part index |
| `sys-ext/tutorial/understanding-sysext.md` | What sysext is, the three extension types, how overlays work |
| `sys-ext/tutorial/using-official-extensions.md` | Enabling release extensions, opting out of built-ins, bakery extensions, verifying status |
| `sys-ext/tutorial/building-custom-extension.md` | Step-by-step: directory structure, static binary, metadata file, squashfs image, systemd units |
| `sys-ext/tutorial/testing-locally.md` | QEMU testing via `bakery.sh boot`, manual setup, debug table for merge failures |
| `sys-ext/tutorial/production-deployment.md` | Ignition provisioning, checksum verification, `systemd-sysupdate` auto-updates, baking into images |
| `sys-ext/tutorial/contributing-to-bakery.md` | Writing a `create.sh` recipe, smoke tests, PR conventions |

Also adds a "New to sysext?" callout at the top of `sys-ext/_index.md` pointing users to the tutorial.

---

## What each part covers

**Part 1 - Understanding sysext**
Explains the read-only overlay model, why Flatcar uses sysext, and gives a clear side-by-side comparison of the three extension types with concrete examples of when to use each.

**Part 2 - Using official extensions**
Covers `enabled-sysext.conf`, Butane config examples, opting out of built-in docker/containerd, provisioning bakery extensions, `systemd-sysext status`, and runtime reload.

**Part 3 - Building a custom extension**
Full walkthrough packaging `jq` (a static binary) as a sysext: directory layout, downloading the binary, writing the `extension-release` metadata, building the squashfs image with `mksquashfs`, adding systemd units with `Upholds=` drop-ins.

**Part 4 - Testing locally**
One-command testing via `bakery.sh boot`, manual QEMU setup with an HTTP server and Ignition config, and a debugging reference table covering the most common merge errors and how to fix them.

**Part 5 - Production deployment**
Ignition provisioning with SHA-512 checksum verification, deploying multiple extensions, `systemd-sysupdate` configuration for automatic updates, and baking extensions into custom Flatcar images.

**Part 6 - Contributing to sysext-bakery**
Implementing `create.sh`, adding smoke tests, bakery conventions (no `/usr/sbin`, static binaries, `Upholds=` drop-ins), opening a PR, and what happens after merge.

---

Closes flatcar/Flatcar#2295
