### PR TITLE
docs: fix GitHub capitalization and grammar across blog and docs

### DIFF
--- a/content/blog/2019-11-07-kinvolk-update-service-and-nebraska-project.md
+++ b/content/blog/2019-11-07-kinvolk-update-service-and-nebraska-project.md
@@ -40,7 +40,7 @@ Here is a summarized list of capabilities:
 *   Update progress overview
 *   Versions evolution timeline
 *   Detailed history per machine
-*   Authentication through Github
+*   Authentication through GitHub
 *   Distribution of updates payload or redirection
 *   Automatic fetch of new packages’ metadata
 *   … (we’ll keep working on more!)
@@ -149,7 +149,7 @@ There are certainly improvements we can do to the Kinvolk Update Service / Nebra
 *   Performance improvements;
 *   UX improvements.
 
-Finally, and as previously mentioned, Nebraska is 100% Open Source and we welcome contributions. If you have a bug fix you want to add, or a feature you want to implement, it is recommendable to first open an issue about it and discuss it in its Github project before writing the code (especially if it is a complex feature).
+Finally, and as previously mentioned, Nebraska is 100% Open Source and we welcome contributions. If you have a bug fix you want to add, or a feature you want to implement, it is recommendable to first open an issue about it and discuss it in its GitHub project before writing the code (especially if it is a complex feature).
 
 The Kinvolk team hopes you enjoy its new product. We’d love to hear your thoughts and feedback - via email ([hello@kinvolk.io](mailto:hello@kinvolk.io)), or Twitter (@kinvolkio).
 

--- a/content/blog/2022-11-07-openssl.md
+++ b/content/blog/2022-11-07-openssl.md
@@ -24,11 +24,11 @@ Source: [Twitter][src-1]
 > So I have tested stable, alpha, and beta,
 all three when I run openssl version are still showing an old version pre 3.0.7
 
-Source: [Github][src-2]
+Source: [GitHub][src-2]
 
 > openssl version should report 3.0.7 the version the two critical CVE's have been fixed
 
-Source: [Github][src-3]
+Source: [GitHub][src-3]
 
 
 The version returned by the CLI is 3.0.2 instead of 3.0.7 but the package version is 3.0.2-r1: this package version

--- a/content/blog/2023-07-25-wrapping-up-my-internship.md
+++ b/content/blog/2023-07-25-wrapping-up-my-internship.md
@@ -33,7 +33,7 @@ Along with my work with adding support to building complex programs into sysext 
 - [add information to ease setting up network configuration][network-configuration]
 - [update the architectures documentation to remove a warning stating that a service is enabled but lacks an install section][architectures-doc]
 - [helped push for TPM2 support. added preliminary clevis support, the team now just has to update our tests to add a TPM2 device][clevis-support]
-- pushed for publishing a container image for sysstat to the Flatcar Github organization (already have a repository on my account, have to just create one on the Flatcar organization)
+- pushed for publishing a container image for sysstat to the Flatcar GitHub organization (already have a repository on my account, have to just create one on the Flatcar organization)
 - [added TLS support to the kernel so if someone wants to TLS software offload to the kernel, they can][tls-support]
 - [removed misleading errors in the SDK since we'd transitioned to the SDK container and the SDK packages were no longer published independenly][sdk-errors] 
 - [fixed race conditions that arise from when the containerd service assumed services are ready as soon as they start running rather than when they actually accept socket request][notify]

--- a/content/docs/latest/deploy/bare-metal/raspberry-pi.md
+++ b/content/docs/latest/deploy/bare-metal/raspberry-pi.md
@@ -93,7 +93,7 @@ sudo reboot
 
 ##### Install `flatcar-install` script
 
-Flatcar provides a simple installer script that helps install Flatcar Container Linux on the target disk. The script is available on [Github](https://raw.githubusercontent.com/flatcar/init/flatcar-master/bin/flatcar-install), and the first step would be to install the script in the host system.
+Flatcar provides a simple installer script that helps install Flatcar Container Linux on the target disk. The script is available on [GitHub](https://raw.githubusercontent.com/flatcar/init/flatcar-master/bin/flatcar-install), and the first step would be to install the script in the host system.
 
 ```bash
 mkdir -p ~/.local/bin

--- a/content/docs/latest/security/cert-auth/generate-self-signed-certificates.md
+++ b/content/docs/latest/security/cert-auth/generate-self-signed-certificates.md
@@ -14,7 +14,7 @@ If you build Flatcar Container Linux cluster on top of public networks it is rec
 
 ## Download cfssl
 
-CloudFlare's distributes [cfssl][cfssl] source code on github page and binaries on [cfssl website][cfssl-bin].
+CloudFlare distributes [cfssl][cfssl] source code on its GitHub page and binaries on [cfssl website][cfssl-bin].
 
 Our documentation assumes that you will run [cfssl][cfssl] on your local x86_64 Linux host.
 

--- a/content/docs/latest/updates-releases/nebraska/authorization.md
+++ b/content/docs/latest/updates-releases/nebraska/authorization.md
@@ -234,9 +234,9 @@ Note: The `oidc-roles-path` argument accepts a JSONPath to fetch roles from the 
 
 ## Preparing Dex with github connector as an OIDC provider for Nebraska
 
-### Setting up a Github App to be used as a connector for Dex
+### Setting up a GitHub App to be used as a connector for Dex
 
-- Create a new organization in Github.
+- Create a new organization in GitHub.
 - Now you need to create an OAuth App, go to `https://github.com/organizations/<your-organization>/settings/applications` (Your Organization Settings > Developer Settings > OAuth Apps) and fill the following fields:
   - `Application name`: just put some fancy name
   - `Homepage URL`: `http://localhost:8000`
@@ -247,7 +247,7 @@ Note: The `oidc-roles-path` argument accepts a JSONPath to fetch roles from the 
   `Client secret`.
 - The OAuth app should already be installed to your org.
 
-### Creating Github Teams
+### Creating GitHub Teams
 
 - In your organization, go to teams.
 - Create two teams in your organization with names `admin` and `viewer`.


### PR DESCRIPTION
Standardizes "Github" to the correct "GitHub" capitalization across 6 files in the blog and docs content, and fixes a grammar/capitalization issue in one additional line. These are the same class of fix as PR #2281 (fix typos, grammar, capitalization and link syntax across documentation files).

Full list of changes:

1. content/blog/2019-11-07-kinvolk-update-service-and-nebraska-project.md
   * Line 43: Standardized "Github" -> "GitHub".
   * Line 152: Standardized "Github" -> "GitHub".

2. content/blog/2022-11-07-openssl.md
   * Line 27: Standardized "Github" -> "GitHub" in link text.
   * Line 31: Standardized "Github" -> "GitHub" in link text.

3. content/blog/2023-07-25-wrapping-up-my-internship.md
   * Line 36: Standardized "Github" -> "GitHub".

4. content/docs/latest/deploy/bare-metal/raspberry-pi.md
   * Line 96: Standardized "Github" -> "GitHub" in link text (URL itself untouched).

5. content/docs/latest/updates-releases/nebraska/authorization.md
   * Line 237: Standardized "Github" -> "GitHub" in heading.
   * Line 239: Standardized "Github" -> "GitHub".
   * Line 250: Standardized "Github" -> "GitHub" in heading.

6. content/docs/latest/security/cert-auth/generate-self-signed-certificates.md
   * Line 17: Fixed grammar and capitalization: "CloudFlare's distributes ... on github page" -> "CloudFlare distributes ... on its GitHub page".

No functional or code changes — documentation and blog content only.

## How to use

This is a documentation-only text change with no functional impact. To validate:
1. Check out this branch, or view the "Files changed" tab.
2. Confirm each diff only changes "Github" -> "GitHub" (or the grammar fix in file 6) and does not alter any URLs, code blocks, or other content.

## Testing done

No build/runtime testing applicable — this PR only changes prose text in Markdown content files (blog posts and docs pages), not code, configuration, or build scripts.

Verified locally that the diff is minimal and contains only the intended text changes:

$ git diff --stat
 content/blog/2019-11-07-kinvolk-update-service-and-nebraska-project.md         | 4 ++--
 content/blog/2022-11-07-openssl.md                                             | 4 ++--
 content/blog/2023-07-25-wrapping-up-my-internship.md                          | 2 +-
 content/docs/latest/deploy/bare-metal/raspberry-pi.md                          | 2 +-
 content/docs/latest/security/cert-auth/generate-self-signed-certificates.md    | 2 +-
 content/docs/latest/updates-releases/nebraska/authorization.md                 | 6 +++---
 6 files changed, 10 insertions(+), 10 deletions(-)

Checklist:

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences...