### PR TITLE
docs: fix duplicate-word typos in 7 documentation files

### DIFF
--- a/content/docs/latest/deploy/cloud/exoscale.md
+++ b/content/docs/latest/deploy/cloud/exoscale.md
@@ -132,7 +132,7 @@ Be sure to specify your SSH key to be able to access the machine. Management of 
   </div>
 </div>
 5. Select your SSH keys.
-6. Add your your optional cloud-config.
+6. Add your optional cloud-config.
 <div class="row">
   <div class="col-lg-8 col-md-10 col-sm-8 col-xs-12">
     <img src="../../img/exoscale-userdata.png" class="screenshot" />

--- a/content/docs/latest/deploy/virt-options/proxmoxve.md
+++ b/content/docs/latest/deploy/virt-options/proxmoxve.md
@@ -83,7 +83,7 @@ What is supported:
 
 Proxmox VE graphical interface does not support setting a custom user-data file. You'll need to use the command line to achieve this.
 
-First of all we need to write the Ignition config as as snippet. Snippets are located at `/var/lib/vz/snippets` on the hypervisor. Write a file named `user-data` containing your Ignition config. Here is an example :
+First of all we need to write the Ignition config as a snippet. Snippets are located at `/var/lib/vz/snippets` on the hypervisor. Write a file named `user-data` containing your Ignition config. Here is an example :
 
 ```bash
 cat /var/lib/vz/snippets/user-data

--- a/content/docs/latest/devguide/sdk-modifying-flatcar.md
+++ b/content/docs/latest/devguide/sdk-modifying-flatcar.md
@@ -124,7 +124,7 @@ $ git checkout [branch-or-tag-from-above]
 ```
 
 Lastly, to verify the version in use, consult the version file.
-This file is updated on each release and reflects the SDK and OS versions corresponding to the the current commit.
+This file is updated on each release and reflects the SDK and OS versions corresponding to the current commit.
 
 ```bash
 $ cat sdk_container/.repo/manifests/version.txt

--- a/content/docs/latest/diagnostics/install-debugging-tools.md
+++ b/content/docs/latest/diagnostics/install-debugging-tools.md
@@ -97,7 +97,7 @@ new session in the background.
 Because `tmux` forks away, we cannot use `wait` in the shell to wait for children but need
 to use `strace` to have a foreground process running that prevents `toolbox` from quitting.
 
-Once this is running you can can attach to the `tmux` session as often as you want from any SSH connection.
+Once this is running you can attach to the `tmux` session as often as you want from any SSH connection.
 
 ```bash
 sudo nsenter -t "$(pidof tmux | cut -d ' ' -f 1)" -a tmux a

--- a/content/docs/latest/orchestrate/kubernetes/high-availability-kubernetes.md
+++ b/content/docs/latest/orchestrate/kubernetes/high-availability-kubernetes.md
@@ -338,7 +338,7 @@ echo "YAML file '$output_yaml' has been successfully overwritten!"
 </details>
 <br>
 
-Now we we can save this script in `scripts/generate-k8s-certs.sh` run `make
+Now we can save this script in `scripts/generate-k8s-certs.sh` run `make
 butane/00_base-k8s-token.yaml` and check out our SSL goodies.  Treat this file
 like a password.  If it gets made public (for anything other than test
 clusters) make sure you recreate them. It's usually recommended to not provide

--- a/content/docs/latest/os-config/storage/adding-disk-space.md
+++ b/content/docs/latest/os-config/storage/adding-disk-space.md
@@ -19,7 +19,7 @@ Amazon doesn't support directly resizing volumes of live machines through the we
 
 ## QEMU (qemu-img)
 
-Even if you are not using Qemu itself the qemu-img tool is the easiest to use. It will work on raw, qcow2, vmdk, and most other formats. The command accepts either an absolute size or a relative size by by adding `+` prefix. Unit suffixes such as `G` or `M` are also supported.
+Even if you are not using Qemu itself the qemu-img tool is the easiest to use. It will work on raw, qcow2, vmdk, and most other formats. The command accepts either an absolute size or a relative size by adding `+` prefix. Unit suffixes such as `G` or `M` are also supported.
 
 ```bash
 # Increase the disk size by 5GB

--- a/content/docs/latest/sys-ext/_index.md
+++ b/content/docs/latest/sys-ext/_index.md
@@ -131,7 +131,7 @@ Upholds=docker.socket
 
 ## Supplying your sysext image from Ignition
 
-The following Butane Config YAML can be be transpiled to Ignition JSON and will download a custom Docker+containerd sysext image on first boot.
+The following Butane Config YAML can be transpiled to Ignition JSON and will download a custom Docker+containerd sysext image on first boot.
 It also takes care of disabling built-in Docker and containerd sysext images (to revert this, you can find the original target of the symlinks in `/usr/share/flatcar/etc/extensions/`).
 
 ```yaml


### PR DESCRIPTION
# Fix duplicate-word typos in documentation

While reading through the documentation, I noticed several minor copy-paste errors where words were duplicated back-to-back. Cleaning these up improves the overall readability and professionalism of the docs.

Removed duplicate words that were clearly typos across 7 different files:
- `exoscale.md`: 'your your' -> 'your'
- `proxmoxve.md`: 'as as snippet' -> 'as a snippet'
- `adding-disk-space.md`: 'by by' -> 'by'
- `install-debugging-tools.md`: 'can can' -> 'can'
- `sys-ext/_index.md`: 'can be be' -> 'can be'
- `sdk-modifying-flatcar.md`: 'the the' -> 'the'
- `high-availability-kubernetes.md`: 'we we' -> 'we'

## How to use
N/A - Documentation typo fixes only.

## Testing done
Manually verified the duplicate words in the markdown files and confirmed the deletions are correct.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.