### PR TITLE
docs: fix broken commands, config examples, and code blocks

### DIFF
--- a/content/docs/latest/deploy/cloud/scaleway.md
+++ b/content/docs/latest/deploy/cloud/scaleway.md
@@ -79,7 +79,7 @@ The `coreos-metadata.service` saves metadata variables to `/run/metadata/flatcar
 Boot the machine with the CLI, referencing the snapshot ID from the import step above and your [Ignition file from Butane][butane-configs]:
 
 ```bash
-$ INSTANCE_ID=$(scw instance server create image=none root-volume=l:"${SNAPSHOT_ID}" cloud-init=@./config.json type=DEV1-S --output=json | jq -r .id)
+$ INSTANCE_ID=$(scw instance server create image=none root-volume=l:"${SNAPSHOT_ID}" cloud-init=@./ignition.json type=DEV1-S --output=json | jq -r .id)
 ```
 
 Your first Flatcar instance should now be running. The only thing left to do is find the IP address and SSH in.

--- a/content/docs/latest/deploy/virt-options/hyper-v.md
+++ b/content/docs/latest/deploy/virt-options/hyper-v.md
@@ -122,7 +122,7 @@ curl.exe -sLO "https://github.com/cloudbase/cloudbase-init-test-resources/blob/m
 
 # create an Openstack config drive folder structure
 mkdir config-drive-metadata/openstack/latest
-echo '{"hostname": "my_flatcar_01.local", "name": "my_flatcar_01", "public_keys": {"userkey": "INSERT_HERE_PUBLIC_SSH_KEY"}' > config-drive-metadata/openstack/latest/meta_data.json
+echo '{"hostname": "my_flatcar_01.local", "name": "my_flatcar_01", "public_keys": {"userkey": "INSERT_HERE_PUBLIC_SSH_KEY"}}' > config-drive-metadata/openstack/latest/meta_data.json
 
 # create the config drive
 & "mkisofs.exe" -o "config-drive.iso" -ignore-error -ldots -allow-lowercase -allow-multidot -l -publisher "cbsl" -quiet -J -r -V "config-2" "config-drive-metadata"

--- a/content/docs/latest/fb-provision/butane/examples.md
+++ b/content/docs/latest/fb-provision/butane/examples.md
@@ -205,7 +205,7 @@ storage:
 
 This example creates a new systemd user unit called `hello.service`, enables it with an explicit symlink (workaround for Ignition) so it will run on boot, and defines the contents to simply echo `"Hello, World!"`.
 
-_Note_: Adding a regular user like "flatcar" to the `systemd-journal` group can be useful if you want to access the journal logs with `journalctl --user --unit hello.service`. You can already access logs with `journactl --user-unit hello.service` from the default `core` user.
+_Note_: Adding a regular user like "flatcar" to the `systemd-journal` group can be useful if you want to access the journal logs with `journalctl --user --unit hello.service`. You can already access logs with `journalctl --user-unit hello.service` from the default `core` user.
 
 ## networkd units
 

--- a/content/docs/latest/getting-started/learning-series/managing-storage.md
+++ b/content/docs/latest/getting-started/learning-series/managing-storage.md
@@ -140,7 +140,7 @@ done
 
 Let's run it!
 ```bash
-./flatcar_production_qemu_uefi.sh -i disks.json -f 12345:80 -- -snapshot -nographic -drive file=mydisk,driver=qcow2,snapshot=on,media=disk,if=virtio
+./flatcar_production_qemu_uefi.sh -i main.json -f 12345:80 -- -snapshot -nographic -drive file=mydisk,driver=qcow2,snapshot=on,media=disk,if=virtio
 ```
 
 Check out if it worked:
@@ -207,7 +207,7 @@ As previously, we need to pass the additional file-backed disk when running the 
 Since we use snapshot mode for the disk, the partition and file system we generated at the previous boot will be gone.
 
 ```bash
-./flatcar_production_qemu_uefi.sh -i disks.json -f 12345:80 -- -snapshot -nographic -drive file=mydisk,driver=qcow2,snapshot=on,media=disk,if=virtio
+./flatcar_production_qemu_uefi.sh -i main.json -f 12345:80 -- -snapshot -nographic -drive file=mydisk,driver=qcow2,snapshot=on,media=disk,if=virtio
 ```
 
 You'll note a considerably longer boot time; this is when the LUKS device is set up.

--- a/content/docs/latest/getting-started/quickstart.md
+++ b/content/docs/latest/getting-started/quickstart.md
@@ -149,7 +149,7 @@ When you boot the image file and apply the Ignition config, the image is set. Yo
 Here is an example of the syntax needed to use this flag:
 
 ```bash
-./flatcar_production_qemu_uefi.sh -i config.ign -p 2224 -- -snapshot -m 4096
+./flatcar_production_qemu_uefi.sh -i ignition.json -p 2224 -- -snapshot -m 4096
 ```
 
 See the [QEMU documentation](https://www.qemu.org/docs/master/system/qemu-manpage.html) for more information.

--- a/content/docs/latest/os-config/systemd/systemctl.md
+++ b/content/docs/latest/os-config/systemd/systemctl.md
@@ -23,7 +23,7 @@ custom-registry.service - Custom Registry Service
    Active: failed (Result: exit-code) since Sun 2013-12-22 12:40:11 UTC; 35s ago
   Process: 10191 ExecStopPost=/usr/bin/etcdctl delete /registry (code=exited, status=0/SUCCESS)
   Process: 10172 ExecStartPost=/usr/bin/etcdctl set /registry index.domain.com:5000 (code=exited, status=0/SUCCESS)
-  Process: 10171 ExecStart=/usr/bin/docker run -rm -p 5555:5000 54.202.26.87:5000/registry /bin/sh /root/boot.sh (code=exited, status=1/FAILURE)
+  Process: 10171 ExecStart=/usr/bin/docker run --rm -p 5555:5000 54.202.26.87:5000/registry /bin/sh /root/boot.sh (code=exited, status=1/FAILURE)
  Main PID: 10171 (code=exited, status=1/FAILURE)
    CGroup: /system.slice/custom-registry.service
 


### PR DESCRIPTION
# Fix broken commands, config examples, and code blocks

While reading through the documentation, I noticed several technical typos in code blocks and command examples that would cause them to fail for users following the tutorials.

### Overview of the changes
- `butane/examples.md`: Fixed typo `journactl` -> `journalctl`
- `systemctl.md`: Fixed invalid docker flag `-rm` -> `--rm`
- `hyper-v.md`: Added missing closing brace `}` in JSON example
- `quickstart.md`: Updated outdated `config.ign` reference to `ignition.json`
- `scaleway.md`: Updated outdated `config.json` reference to `ignition.json`
- `managing-storage.md`: Updated QEMU commands to use `main.json` instead of `disks.json` to match the tutorial flow

## How to use
N/A - Documentation fixes only.

## Testing done
Manually reviewed the specific files and verified the command syntax and JSON structures are now correct.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.