### PR TITLE
docs: fix spelling typos across provisioning docs

### DIFF
--- a/content/docs/latest/fb-provision/butane/configuration.md
+++ b/content/docs/latest/fb-provision/butane/configuration.md
@@ -93,7 +93,7 @@ The Butane Flatcar variant configuration is a YAML document conforming to the fo
         * **_value_** (string): the header contents.
       * **_verification_** (object): options related to the verification of the file contents.
         * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
-    * **_append_** (list of objects): list of contents to be appended to the file. Follows the same stucture as `contents`
+    * **_append_** (list of objects): list of contents to be appended to the file. Follows the same structure as `contents`
       * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
       * **_source_** (string): the URL of the contents to append. Supported schemes are `http`, `https`, `tftp`, `s3`, `gs`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
       * **_inline_** (string): the contents to append. Mutually exclusive with `source` and `local`.

--- a/content/docs/latest/fb-provision/butane/examples.md
+++ b/content/docs/latest/fb-provision/butane/examples.md
@@ -67,7 +67,7 @@ If you choose to use a password instead of an SSH key, generating a safe hash is
 # On Debian/Ubuntu (via the package "whois")
 mkpasswd --method=SHA-512 --rounds=4096
 
-# OpenSSL (note: this will only make md5crypt.  While better than plantext it should not be considered fully secure)
+# OpenSSL (note: this will only make md5crypt.  While better than plaintext it should not be considered fully secure)
 openssl passwd -1
 
 # Python

--- a/content/docs/latest/fb-provision/butane/getting-started.md
+++ b/content/docs/latest/fb-provision/butane/getting-started.md
@@ -46,7 +46,7 @@ While quite similar, there are some changes needed to migrate a Container Linux 
 
 - The `variant` and `version` keys are required.
 - The Butane transpiler has no platform feature for templating with dynamic data. The resulting feature is still available by explicitly loading the metadata variables to reference [dynamic data][dynamic].
-- The high-level sections for `etcd`, `flannel`, `docker`, `update`, and `locksmith` are gone and instead the resulting units or files need to be written explicity. For etcd see the [cluster docs][cluster]. Both the `update` and `locksmith` fields go to `/etc/flatcar/update.conf`.
+- The high-level sections for `etcd`, `flannel`, `docker`, `update`, and `locksmith` are gone and instead the resulting units or files need to be written explicitly. For etcd see the [cluster docs][cluster]. Both the `update` and `locksmith` fields go to `/etc/flatcar/update.conf`.
 - The `networkd` section is gone and instead the files need to be written directly to `/etc/systemd/network/` directory.
 - The `overwrite` field for files is not set to `true` by default anymore, so it needs to be explicitly set to `true` for the old behavior.
 - File entries can't specify filesystems anymore as was done with `filesystem: root` or `filesystem: oem`. Instead, they use the full path, and which filesystem this is depends on whether and how the initrd mount path is set for each specified filesystem.

--- a/content/docs/latest/fb-provision/cl-config/examples.md
+++ b/content/docs/latest/fb-provision/cl-config/examples.md
@@ -63,7 +63,7 @@ If you choose to use a password instead of an SSH key, generating a safe hash is
 # On Debian/Ubuntu (via the package "whois")
 mkpasswd --method=SHA-512 --rounds=4096
 
-# OpenSSL (note: this will only make md5crypt.  While better than plantext it should not be considered fully secure)
+# OpenSSL (note: this will only make md5crypt.  While better than plaintext it should not be considered fully secure)
 openssl passwd -1
 
 # Python

--- a/content/docs/latest/fb-provision/customize-image/customize-the-image.md
+++ b/content/docs/latest/fb-provision/customize-image/customize-the-image.md
@@ -85,7 +85,7 @@ A more convenient way is to use [Docker-in-Docker](https://hub.docker.com/_/dock
 You start by running a Docker-in-Docker container:
 
 ```bash
-# Run docker-in-docker in the backgroud.
+# Run docker-in-docker in the background.
 # We mount local directory as a location to send /var/lib/docker archive
 # Do NOT try to bind a directory to /var/lib/docker directly as this might
 # produce incompatible images (vfs instead of overlay2) depending on your
@@ -120,7 +120,7 @@ You can now unmount `/mnt` and finish preparing your final image.
 
 This section serves as a big warning. If you use a booted image, even if it was only booted by being a chroot or a systemd-nspawn container, you will get a lot of problems.
 Please check the OEM and the root partition section above for a saner way of pre-configuring the image.
-If you try to use Packer to customize the image, or want to use a once booted VMware base VM, or even just accidentially booted the image once for testing, you created an OS state that is hard to get rid off.
+If you try to use Packer to customize the image, or want to use a once booted VMware base VM, or even just accidentally booted the image once for testing, you created an OS state that is hard to get rid of.
 It causes security issues and difficult to debug behavior changes, please use the above mechanisms to modify the image through mounting and copying because this is easier, safer, and faster.
 
 If you still want to continue with customization through booting, here are some common traps, but there can be more depending on the software components that are involved and if you are not an expert on the software components and their respective state files, you should reconsider your choice.

--- a/content/docs/latest/fb-provision/ignition/specification.md
+++ b/content/docs/latest/fb-provision/ignition/specification.md
@@ -111,7 +111,7 @@ podman run -i --rm quay.io/coreos/butane:release --pretty --strict < config.yml 
         - **_value_** (string): the header contents.
       - **_verification_** (object): options related to the verification of the file contents.
         - **_hash_** (string): the hash of the contents, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
-    - **_append_** (list of objects): list of contents to be appended to the file. Follows the same stucture as `contents`
+    - **_append_** (list of objects): list of contents to be appended to the file. Follows the same structure as `contents`
       - **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
       - **_source_** (string): the URL of the contents to append. Supported schemes are `http`, `https`, `tftp`, `s3`, `gs`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
       - **_httpHeaders_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.

--- a/content/docs/latest/fb-provision/infrastructure/_index.md
+++ b/content/docs/latest/fb-provision/infrastructure/_index.md
@@ -30,7 +30,7 @@ It is also advisable to separate the persistent data from the disposable nodes t
 
 ## Generating the Ignition Configuration within Terraform
 
-To convert the Butane Config in YAML to the final Igniton Config in JSON you don't need to run [`butane`][butane-configs] manually. Instead, you can directly do this within Terraform, through the [`terraform-ct-provider`][terraform-ct-provider] (starting from v0.12.0).
+To convert the Butane Config in YAML to the final Ignition Config in JSON you don't need to run [`butane`][butane-configs] manually. Instead, you can directly do this within Terraform, through the [`terraform-ct-provider`][terraform-ct-provider] (starting from v0.12.0).
 Combined with the `template-provider` you can reference Terraform variables in the YAML template.
 
 An alternative is the [`terraform-ignition-provider`][terraform-ignition-provider] that allows to assemble the Ignition Config from Terraform declarations.
@@ -73,7 +73,7 @@ Persistent data should be stored on another partition which should be set to be 
 
 We can also preserve the machine ID by setting it as kernel cmdline parameter (it must not be kept as file on the root filesystem because that prevents the systemd first-boot semantics to enable units through the preset Ignition creates).
 
-This Container Linux Config snippet takes care of reformating the root filesystem and places a reprovisioning helper script on the OEM partition:
+This Container Linux Config snippet takes care of reformatting the root filesystem and places a reprovisioning helper script on the OEM partition:
 
 ```yaml
 storage:

--- a/content/docs/latest/getting-started/learning-series/basics-and-testing.md
+++ b/content/docs/latest/getting-started/learning-series/basics-and-testing.md
@@ -290,7 +290,7 @@ Your ssh public key(s) will be added to the `core` user's `authorized_keys` when
 
 Now we can connect to the Flatcar VM via SSH.
 If you generated keys above, restart the VM to make sure the new SSH keys are injected.
-The wrapper script also helpfully creates a port-froward from the VM's (SSH) port 22 to host port 2222.
+The wrapper script also helpfully creates a port-forward from the VM's (SSH) port 22 to host port 2222.
 
 ```bash
 ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" core@localhost -p 2222

--- a/content/docs/latest/getting-started/learning-series/immutability-updates-rollbacks.md
+++ b/content/docs/latest/getting-started/learning-series/immutability-updates-rollbacks.md
@@ -325,7 +325,7 @@ This file is removed later, after provisioning finished.
 #### System Provisioning runs from the initrd
 
 If first boot is detected in the initrd, the `ignition` provisioning agent is started.
-Ingition fetches vendor specific configuration - think username / ssh key, network configuration etc. that you can set up e.g. via the Azure Portal when launching a VM - and "user data".
+Ignition fetches vendor specific configuration - think username / ssh key, network configuration etc. that you can set up e.g. via the Azure Portal when launching a VM - and "user data".
 User data is expected to be in Ignition JSON format - exactly what we've been transpiling to for our web service and "don't update" configurations.
 
 Ignition initialises storage devices and file systems - which can be customised and modified from user data configuration, as we'll learn in a later session.


### PR DESCRIPTION
# Fix spelling typos across provisioning docs

While reading through the provisioning and getting-started documentation, I noticed several minor spelling typos. This PR fixes them to improve the overall readability of the docs.

### Overview of the changes
- `configuration.md` & `specification.md`: Fixed typo `stucture` -> `structure`
- `examples.md` (butane & cl-config): Fixed typo `plantext` -> `plaintext`
- `getting-started.md`: Fixed typo `explicity` -> `explicitly`
- `infrastructure/_index.md`: Fixed typos `Igniton` -> `Ignition` and `reformating` -> `reformatting`
- `customize-the-image.md`: Fixed typos `backgroud` -> `background`, `accidentially` -> `accidentally`, and `get rid off` -> `get rid of`
- `basics-and-testing.md`: Fixed typo `port-froward` -> `port-forward`
- `immutability-updates-rollbacks.md`: Fixed typo `Ingition` -> `Ignition`

## How to use
N/A - Documentation typo fixes only.

## Testing done
Manually verified the typos in the markdown files and confirmed the corrections fit the context.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.