### PR TITLE
docs: fix typos and grammar in Kubernetes and container docs

### DIFF
--- a/content/docs/latest/orchestrate/containers/registry-authentication.md
+++ b/content/docs/latest/orchestrate/containers/registry-authentication.md
@@ -92,7 +92,7 @@ $ kubectl create -f credentials.yaml
 secret "my-favorite-registry-secret" created
 ```
 
-You can check that this secret is loaded with with the `kubectl get` command:
+You can check that this secret is loaded with the `kubectl get` command:
 
 ```bash
 $ kubectl get my-favorite-registry-secret

--- a/content/docs/latest/orchestrate/kubernetes/getting-started-with-kubernetes.md
+++ b/content/docs/latest/orchestrate/kubernetes/getting-started-with-kubernetes.md
@@ -14,7 +14,7 @@ This documentation will cover preliminary aspects of operating Kubernetes cluste
 
 ## Supported Kubernetes version
 
-A Kubernetes basic scenario (deploy a simple Nginx) is being tested on Flatcar accross the channels and various CNIs, it mainly ensures that Kubernetes can be correctly installed and can operate in a simple way.
+A Kubernetes basic scenario (deploy a simple Nginx) is being tested on Flatcar across the channels and various CNIs, it mainly ensures that Kubernetes can be correctly installed and can operate in a simple way.
 
 One way to contribute to Flatcar would be to extend the covered CNIs (example: [kubenet][kubenet]) or to provide more complex scenarios (example: [cilium extension][cilium]).
 
@@ -203,7 +203,7 @@ NAME            STATUS     ROLES           AGE     VERSION
 flatcar-node1   NotReady   control-plane   2m10s   v1.33.2
 ```
 
-The control plane will appear has non-ready until a CNI is deployed, here's an example with calico:
+The control plane will appear as non-ready until a CNI is deployed, here's an example with calico:
 ```bash
 kubectl \
   apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.24.1/manifests/calico.yaml
@@ -371,7 +371,7 @@ Finally, tell `kubelet` to use containerd by adding to it the following flags:
 From the official [documentation][capi-documentation]:
 > Cluster API is a Kubernetes sub-project focused on providing declarative APIs and tooling to simplify provisioning, upgrading, and operating multiple Kubernetes clusters.
 
-As it requires to have some tools already installed on the OS to work correcly with CAPI, Flatcar images can be built using the [image-builder][image-builder] project.
+As it requires to have some tools already installed on the OS to work correctly with CAPI, Flatcar images can be built using the [image-builder][image-builder] project.
 
 While CAPI is an evolving project and Flatcar support is in-progress regarding the various providers, here's the current list of supported providers:
 * [AWS][capi-aws]

--- a/content/docs/latest/orchestrate/kubernetes/high-availability-kubernetes.md
+++ b/content/docs/latest/orchestrate/kubernetes/high-availability-kubernetes.md
@@ -32,7 +32,7 @@ properties:
 
 Each control plane node will be responsible for running the regular Kubernetes
 control plane components, as well as HAProxy and Keepalived.  The api-server
-with have a VIP of `192.168.122.30`.  HAProxy and Keepalived can be installed
+will have a VIP of `192.168.122.30`.  HAProxy and Keepalived can be installed
 through various methods, but this article will show you how to install them
 using [Quadlet][Quadlet] through Ignition. 
 
@@ -224,7 +224,7 @@ butane/00_base-k8s-token.yaml:
 	./scripts/generate-k8s-certs.sh
 ```
 
-These lines show us how to to build each ignition file using a container.  We
+These lines show us how to build each ignition file using a container.  We
 also have to specify how to build our token file using a shell script.
 
 ### Token File
@@ -498,7 +498,7 @@ storage:
 <br>
 
 We extend the first config by including it in this config, along with the token
-file.  We also set any environment variales that are shared across hosts, in
+file.  We also set any environment variables that are shared across hosts, in
 this case `K8S_APISERVER_URL`, as well as set up some default podman/crio
 policies.
 
@@ -598,7 +598,7 @@ storage:
               timeout check           10s
 
           #---------------------------------------------------------------------
-          # apiserver frontend which proxys to the control plane nodes
+          # apiserver frontend which proxies to the control plane nodes
           #---------------------------------------------------------------------
           frontend apiserver
               bind 192.168.122.30:6444
@@ -697,7 +697,7 @@ systemd:
 </details>
 <br>
 
-This service defines what to do when intializing the kubernetes cluster.  This
+This service defines what to do when initializing the kubernetes cluster.  This
 only needs to be run on one node.  Essentially we are calling `kubeadm init
 ...` and `cilium install ...`, but its worth pointing out the dependencies
 here. We specify that kubeadm should only start AFTER the haproxy service
@@ -1075,7 +1075,7 @@ Then, running `make new-cluster` should generate our token file and generate
 all the Ignition files from the butane configs.  Finally, running `make ha`
 will create and run each VM.  This involves downloading a base VM image,
 verifying it with GPG, cloning the base image to create a working image, and
-copying the image (and Igntion files) to `/var/lib/libvirt/images/flatcar`.
+copying the image (and Ignition files) to `/var/lib/libvirt/images/flatcar`.
 
 After that, we should have a running kubernetes cluster.  We can shut
 everything down by running `make rm-ha` or connect to a node via `virsh connect


### PR DESCRIPTION
# Fix typos and grammar in Kubernetes and container docs

While reading through the orchestrate section of the documentation, I noticed several spelling and grammatical errors. This PR corrects them to improve readability.

### Overview of the changes
- `high-availability-kubernetes.md`: Fixed typos `with have` -> `will have`, `how to to build` -> `how to build`, `variales` -> `variables`, `proxys` -> `proxies`, `intializing` -> `initializing`, and `Igntion` -> `Ignition`.
- `getting-started-with-kubernetes.md`: Fixed typos `accross` -> `across`, `appear has` -> `appear as`, and `correcly` -> `correctly`.
- `registry-authentication.md`: Fixed typo `with with` -> `with`.

## How to use
N/A - Documentation typo fixes only.

## Testing done
Manually verified the typos in the markdown files and confirmed the corrections fit the context.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.