### PR TITLE
docs: fix typos in devguide, systemd, security, and sysext docs

### DIFF
--- a/content/docs/latest/devguide/sdk-modifying-flatcar.md
+++ b/content/docs/latest/devguide/sdk-modifying-flatcar.md
@@ -110,7 +110,7 @@ Find the latest Alpha release branch:
 $ git branch -r -l | awk -F'/' '/origin\/flatcar-[0-9]+$/ {print $2}' | sort | tail -n1
 ```
 
-If the goal is to reproduce and to fix a bug of a release other than Alpha, it is recommended to base the work on the latest point release of the respective major version instead of Alpha. All currrently "active" major versions can be found at the top of the [releases][flatcar-releases] web page.
+If the goal is to reproduce and to fix a bug of a release other than Alpha, it is recommended to base the work on the latest point release of the respective major version instead of Alpha. All currently "active" major versions can be found at the top of the [releases][flatcar-releases] web page.
 
 For quick reference, to get the latest stable release tag, use:
 ```bash
@@ -224,7 +224,7 @@ You can run `docker run --rm -ti docker.io/arm64v8/alpine` or `docker run --rm -
 At the time of writing the SDK supports two target architectures: AMD64 (x86-64) and ARM64.
 The target architecture can be specified by use of the `--board=` parameter to both `build_packages` and `build_image`:
 * `--board=amd64-usr` will build an x86 image
-* `--board=arm64-usr` will build and ARM64 image
+* `--board=arm64-usr` will build an ARM64 image
 
 If no architecture is specified then AMD64 will be used by default.
 
@@ -728,7 +728,7 @@ For more granular control over testing or when you need to run specific test sui
 #### Requirements
 - IPv4 forwarding enabled: `sudo sysctl -w net.ipv4.ip_forward=1`
 - Firewall configured to allow kola interfaces: `sudo firewall-cmd --zone=nm-shared --add-interface=kola-+`
-- Required packages: `swtmp`, `dnsmasq`, `go`, and `iptables` in `$PATH`
+- Required packages: `swtpm`, `dnsmasq`, `go`, and `iptables` in `$PATH`
 - QEMU: `qemu-system-x86_64` for AMD64 and/or `qemu-system-aarch64` for ARM64
 
 #### Setting up kola

--- a/content/docs/latest/devguide/sdk-tips-and-tricks.md
+++ b/content/docs/latest/devguide/sdk-tips-and-tricks.md
@@ -71,7 +71,7 @@ To quickly test your new package(s), use the following commands:
 To include the new package as a dependency of Flatcar Container Linux, add the package to the end of the `RDEPEND` environment variable in `coreos-base/coreos/coreos-0.0.1.ebuild` then increment the revision of Flatcar Container Linux by renaming the softlink (e.g.):
 
 ```bash
-~/trunk/src/third_party/coreos-overly $ git mv coreos-base/coreos/coreos-0.0.1-r237.ebuild coreos-base/coreos/coreos-0.0.1-r238.ebuild
+~/trunk/src/third_party/coreos-overlay $ git mv coreos-base/coreos/coreos-0.0.1-r237.ebuild coreos-base/coreos/coreos-0.0.1-r238.ebuild
 ```
 
 The new package will now be built and installed as part of the normal build flow when you run `build_packages` again.

--- a/content/docs/latest/os-config/network/overlaybd-artifact-streaming.md
+++ b/content/docs/latest/os-config/network/overlaybd-artifact-streaming.md
@@ -110,7 +110,7 @@ systemd:
             ExecStart=/usr/bin/containerd --config /etc/containerd/config.toml
 ```
 
-After the instance provisioned successfully, accelerated container images can be started in accordance with [upstream's guilde](https://github.com/containerd/accelerated-container-image/blob/main/docs/QUICKSTART.md#run-overlaybd-images):
+After the instance provisioned successfully, accelerated container images can be started in accordance with [upstream's guide](https://github.com/containerd/accelerated-container-image/blob/main/docs/QUICKSTART.md#run-overlaybd-images):
 ```bash
 sudo /opt/overlaybd/snapshotter/ctr rpull -u {user}:{pass} registry.hub.docker.com/overlaybd/redis:6.2.1_obd
 sudo ctr run --net-host --snapshotter=overlaybd --rm -t registry.hub.docker.com/overlaybd/redis:6.2.1_obd demo

--- a/content/docs/latest/os-config/systemd/user-units.md
+++ b/content/docs/latest/os-config/systemd/user-units.md
@@ -9,7 +9,7 @@ aliases:
 
 Flatcar Container Linux supports the use of systemd user units.  These are unit files located in a users home directory, managed by the user, and executed with their permission.
 
-User units are stored in `~/.config/systemd/user/`.  When using Butane to configure these during provisioning you must create this entire path, level by level as demonstrated here.  This is adapated from [documentation for Fedora CoreOS](https://docs.fedoraproject.org/en-US/fedora-coreos/tutorial-user-systemd-unit-on-boot/).
+User units are stored in `~/.config/systemd/user/`.  When using Butane to configure these during provisioning you must create this entire path, level by level as demonstrated here.  This is adapted from [documentation for Fedora CoreOS](https://docs.fedoraproject.org/en-US/fedora-coreos/tutorial-user-systemd-unit-on-boot/).
 
 ```yaml
 variant: flatcar
@@ -55,7 +55,7 @@ storage:
 
 ## Network Access
 
-In some cases the network will not be online when the user units are executed.  This may happen when there is no network requiring component in the boot process.  For example, requiring a network mounted home directory would cause user units to execute after the network was online.  If you have no such requirements or wish to gurantee that the network is online before user units are excuted you can use the following systemd dropin to modify the `systemd-user-sessions.service` to run after the network is online.  This affects all users.
+In some cases the network will not be online when the user units are executed.  This may happen when there is no network requiring component in the boot process.  For example, requiring a network mounted home directory would cause user units to execute after the network was online.  If you have no such requirements or wish to guarantee that the network is online before user units are executed you can use the following systemd dropin to modify the `systemd-user-sessions.service` to run after the network is online.  This affects all users.
 
 ```yaml
 variant: flatcar

--- a/content/docs/latest/security/supply-chain.md
+++ b/content/docs/latest/security/supply-chain.md
@@ -155,7 +155,7 @@ The build process entails:
    1. Add builder ID information during CI builds: [tracking issue](https://github.com/flatcar/Flatcar/issues/813)
    2. Generate additional provenance for the whole image: [tracking issue](https://github.com/flatcar/Flatcar/issues/814)
 4. Signing of artifacts to enable validation of authenticity at provisioning time.
-   Signing also ensures SLSA provenance is non-falisfiable.
+   Signing also ensures SLSA provenance is non-falsifiable.
    1. A verity hash of the OS partition is generated and injected into the initrd so Flatcar can verify tamper-free OS partition at boot time.
    2. There is an extra layer of security for the update image.
       Many Flatcar deployments use automated updates so special care is taken to ensure these are not compromised.

--- a/content/docs/latest/sys-ext/_index.md
+++ b/content/docs/latest/sys-ext/_index.md
@@ -108,7 +108,7 @@ The image can be a plain ext4 or btrfs filesystem image but squashfs images are 
 
 Inside the image or folder structure there must be a file `usr/lib/extension-release.d/extension-release.NAME` with metadata used for version matching.
 The basic matching that needs to be there is `ID=flatcar` plus one of `VERSION_ID` or `SYSEXT_LEVEL`.
-If your binaries link against Flatcar's binaries under `/usr`, you must couple your sysext image to the Flatcar version by specyfing `VERSION_ID=MAJOR.MINOR.PATCH` in `extension-release.NAME` to match the `VERSION_ID` field from `/etc/os-release`.
+If your binaries link against Flatcar's binaries under `/usr`, you must couple your sysext image to the Flatcar version by specifying `VERSION_ID=MAJOR.MINOR.PATCH` in `extension-release.NAME` to match the `VERSION_ID` field from `/etc/os-release`.
 This means that the sysext image won't be loaded anymore after an OS update.
 Therefore, it is recommended that you try to use static binaries which lifts the requirement of having to couple the versions.
 In this case you can specify `SYSEXT_LEVEL=1.0` instead of `VERSION_ID`.


### PR DESCRIPTION
# Fix typos in devguide, systemd, security, and sysext docs

While reading through the documentation, I noticed several spelling errors. This PR corrects them to improve readability.

### Overview of the changes
- `sdk-modifying-flatcar.md`: Fixed typos `currrently` -> `currently`, `build and ARM64` -> `build an ARM64`, and `swtmp` -> `swtpm`.
- `sdk-tips-and-tricks.md`: Fixed typo `coreos-overly` -> `coreos-overlay`.
- `user-units.md`: Fixed typos `adapated` -> `adapted`, `gurantee` -> `guarantee`, and `excuted` -> `executed`.
- `supply-chain.md`: Fixed typo `non-falisfiable` -> `non-falsifiable`.
- `sys-ext/_index.md`: Fixed typo `specyfing` -> `specifying`.
- `overlaybd-artifact-streaming.md`: Fixed typo `guilde` -> `guide`.

## How to use
N/A - Documentation typo fixes only.

## Testing done
Manually verified the typos in the markdown files and confirmed the corrections fit the context.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.