### PR TITLE
fix: emit per-page canonical URLs and absolute URLs in sitemap and feeds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ run:
 # Like 'run' but builds to disk first so pagefind search works locally.
 # Note: no live-reload; re-run after content changes.
 serve: docs
-	hugo --theme=flatcar --buildFuture
+	hugo --theme=flatcar --buildFuture -b http://localhost:1313/
 	npx -y pagefind@1.4.0 --site public
 	@echo "Static server: http://localhost:1313/"
 	cd public && $(PYTHON) -m http.server 1313

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,9 @@
-baseurl: "/"
+baseurl: "https://www.flatcar.org/"
 title: Flatcar Container Linux
-canonifyurls: true
+# Internal links are emitted relative to the site root so that preview and
+# local builds stay self-contained. Absolute URLs are only used where a
+# consumer requires them: canonical tags, Open Graph, the sitemap and feeds.
+canonifyurls: false
 pagination:
   pagerSize: 8
 theme: flatcar

--- a/themes/flatcar/layouts/404.html
+++ b/themes/flatcar/layouts/404.html
@@ -16,7 +16,7 @@
 
             {{ $js := slice $common | resources.Concat "js/bundle.js" }}
 
-            <script src="{{ $js.Permalink }}"></script>
+            <script src="{{ $js.RelPermalink }}"></script>
         {{ end }}
     </body>
 </html>

--- a/themes/flatcar/layouts/careers/li.html
+++ b/themes/flatcar/layouts/careers/li.html
@@ -1,3 +1,3 @@
 <li>
-    <a href="{{ .Permalink }}">{{ .Title }}</a>
+    <a href="{{ .RelPermalink }}">{{ .Title }}</a>
 </li>

--- a/themes/flatcar/layouts/docs/baseof.html
+++ b/themes/flatcar/layouts/docs/baseof.html
@@ -22,7 +22,7 @@
                 The version of the documentation you are reading is not the latest one!
                 {{ range (partial "docs/getversions" . ) }}
                   {{ if eq (partial "docs/dirversion" .) $latestVersion }}
-                  &nbsp;See the <a href="{{ .Permalink }}">latest version</a>.
+                  &nbsp;See the <a href="{{ .RelPermalink }}">latest version</a>.
                   {{ end }}
                 {{ end }}
               </div>
@@ -94,9 +94,9 @@
     {{ partial "footer.html" . }}
     {{ block "scripts" . }}
     {{- $searchJs := resources.GetMatch "js/fastsearch.js" | resources.Minify -}}
-    <script type="module" src="{{ $searchJs.Permalink }}"></script>
+    <script type="module" src="{{ $searchJs.RelPermalink }}"></script>
     {{- $anchorJs := resources.GetMatch "js/anchor.js" | resources.Minify -}}
-    <script src="{{ $anchorJs.Permalink }}"></script>
+    <script src="{{ $anchorJs.RelPermalink }}"></script>
     {{ end }}
     {{ if .Store.Get "hasMermaid" }}
     <script type="module">

--- a/themes/flatcar/layouts/docs/docsportal_home.html
+++ b/themes/flatcar/layouts/docs/docsportal_home.html
@@ -86,6 +86,6 @@
 
         {{ partial "footer.html" . }}
         {{- $searchJs := resources.GetMatch "js/fastsearch.js" | resources.Minify -}}
-        <script type="module" src="{{ $searchJs.Permalink }}"></script>
+        <script type="module" src="{{ $searchJs.RelPermalink }}"></script>
     </body>
 </html>

--- a/themes/flatcar/layouts/legal/li.html
+++ b/themes/flatcar/layouts/legal/li.html
@@ -1,7 +1,7 @@
 
 <div class="card">
   <div class="card-body">
-    <h2 class="card-title"><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
+    <h2 class="card-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
     <p class="card-text">{{ .Description }}</p>
   </div>
 </div>

--- a/themes/flatcar/layouts/partials/article.html
+++ b/themes/flatcar/layouts/partials/article.html
@@ -30,7 +30,7 @@
           <div class="article-content mx-auto" aria-describedby="blogtitle">
             {{- if .Params.moved_to_flatcar -}}
               {{ .Summary }}
-              <p class="mt-3 text-center"><a href="https://flatcar-linux.org{{ .RelPermalink }}">Continue reading »</a></p>
+              <p class="mt-3 text-center"><a href="{{ .RelPermalink }}">Continue reading »</a></p>
 
             {{- else -}}
               {{ .Content }}
@@ -41,7 +41,7 @@
             {{ partial "authors.html" (dict "message" "WRITTEN BY" "context" . "with_date" true ) }}
             <p class="aside__title">Tags:
               {{ range .Params.tags }}
-                <a href="{{ $.Site.LanguagePrefix | absURL }}tags/{{- . | urlize -}}/">#{{- . -}}</a>
+                <a href="{{ $.Site.LanguagePrefix | relURL }}tags/{{- . | urlize -}}/">#{{- . -}}</a>
               {{ end }}
             </p>
           </div>

--- a/themes/flatcar/layouts/partials/cards-section.html
+++ b/themes/flatcar/layouts/partials/cards-section.html
@@ -34,7 +34,7 @@
                 </div>
                 <div class="mt-auto pt-2 row g-0 w-100 justify-content-center">
                   <a
-                    href="{{ .Permalink }}"
+                    href="{{ .RelPermalink }}"
                     class="btn btn-md btn-black"
                   >
                     Learn More

--- a/themes/flatcar/layouts/partials/contact-us.html
+++ b/themes/flatcar/layouts/partials/contact-us.html
@@ -16,7 +16,7 @@
         </div>
       {{ end }}
       <div class="col-12 {{ if $contact.message }}col-md-6{{ end }} text-center">
-        <a class="btn btn-blue" href="{{ ($.Site.GetPage "contact-us").Permalink }}">{{ default "Contact us" $contact.header }}</a>
+        <a class="btn btn-blue" href="{{ ($.Site.GetPage "contact-us").RelPermalink }}">{{ default "Contact us" $contact.header }}</a>
       </div>
     </div>
   </div>

--- a/themes/flatcar/layouts/partials/docs/docs-portal-card.html
+++ b/themes/flatcar/layouts/partials/docs/docs-portal-card.html
@@ -9,10 +9,10 @@
         {{ $p := . }}
         {{ if (isset .Params.card "anchors") }}
             {{ range .Params.card.anchors }}
-            <li><a href="{{ $p.Permalink }}{{ .anchor }}">{{ .title }}</a></li>
+            <li><a href="{{ $p.RelPermalink }}{{ .anchor }}">{{ .title }}</a></li>
             {{ end }}
         {{ else }}
-            <li><a href={{ .Permalink }}>
+            <li><a href={{ .RelPermalink }}>
             {{ if (isset .Params.card "title") }}{{ .Params.card.title }}{{ else }}{{ .LinkTitle }}{{ end }}
             </a></li>
         {{ end }}

--- a/themes/flatcar/layouts/partials/docs/versionchooser.html
+++ b/themes/flatcar/layouts/partials/docs/versionchooser.html
@@ -7,7 +7,7 @@
   {{ range $versions }}
     {{ $version := partial "docs/dirversion" . }}
     <option
-      value={{ .Permalink }}
+      value="{{ .RelPermalink }}"
       {{ if eq $version $current }}selected{{ end }}
     >
       {{ $version }}

--- a/themes/flatcar/layouts/partials/footer.html
+++ b/themes/flatcar/layouts/partials/footer.html
@@ -49,7 +49,7 @@
               {{ end }}
               {{ $title := or .title $section.Params.title }}
               <div class="footer-column__title">
-                {{ $link := or .link $section.Permalink}}
+                {{ $link := or .link $section.RelPermalink}}
                 {{ if $link }}
                   <a href="{{ $link }}">{{ $title }}</a>
                 {{ else }}
@@ -63,9 +63,9 @@
                     <li class="footer-menu__item">
                       {{ $url := "" }}
                       {{ if .Content }}
-                        {{ $url = .Permalink }}
+                        {{ $url = .RelPermalink }}
                       {{ else }}
-                        {{ $url = print (ref . $section.Section) "#" (anchorize .Params.title) }}
+                        {{ $url = print (relref . $section.Section) "#" (anchorize .Params.title) }}
                       {{ end }}
                       <a href="{{ $url }}" class="footer-menu__link">{{ or (index $footer_settings "title") .Params.Title }}</a>
                     </li>
@@ -81,7 +81,7 @@
                     {{ end }}
                   {{ end }}
                   {{ if not $hide }}
-                    {{ $link := or .link $page.Permalink }}
+                    {{ $link := or .link $page.RelPermalink }}
                     {{ $title := or .title $page.Title }}
                     <li class="footer-menu__item">
                       <a href="{{ $link }}" class="footer-menu__link">{{ $title }}</a>
@@ -95,7 +95,7 @@
     </div>
     <div class="footer__copy p-0">
       <div class="logo footer__logo row text-center justify-content-center">
-        <a href="{{ .Site.BaseURL }}">
+        <a href="{{ "/" | relURL }}">
             {{ partial "logo.html" . }}
         </a>
       </div>
@@ -135,4 +135,4 @@
   <script src="/js/bootstrap.bundle.min.js"></script>
   {{- $common := resources.Get "js/common.js" -}}
   {{- $js := slice $common | resources.Concat "js/common.js" -}}
-  <script src="{{ $js.Permalink }}"></script>
+  <script src="{{ $js.RelPermalink }}"></script>

--- a/themes/flatcar/layouts/partials/head.html
+++ b/themes/flatcar/layouts/partials/head.html
@@ -87,7 +87,7 @@
     <!-- Custom CSS -->
     {{ $options := (dict "targetPath" "/css/style.css" "outputStyle" "compressed" "enableSourceMap" true) }}
     {{ $style := resources.Get "scss/main.scss" | css.Sass $options | fingerprint}}
-    <link rel="stylesheet" href="{{ $style.Permalink }}" integrity="{{ $style.Data.Integrity }}">
+    <link rel="stylesheet" href="{{ $style.RelPermalink }}" integrity="{{ $style.Data.Integrity }}">
 
     <!-- Favicon -->
     <link rel="shortcut icon" href="{{ $.Site.Params.favicon }}" />

--- a/themes/flatcar/layouts/partials/head.html
+++ b/themes/flatcar/layouts/partials/head.html
@@ -6,7 +6,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title>{{ if eq .Kind "term" }}{{ .Data.Singular }} {{ .Title }}{{ else }}{{ .Title }} | {{ $.Site.Title }}{{ end }}</title>
-    <meta name="description" content="Flatcar Linux" />
+    {{- $description := or .Description .Params.tagline (.Summary | plainify | truncate 160) .Site.Params.Description }}
+    {{- $description = $description | plainify | replaceRE `\s+` " " | strings.TrimSpace }}
+    <meta name="description" content="{{ $description }}" />
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -20,7 +22,7 @@
         <meta name="googlebot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
         <meta name="bingbot" content="index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1" />
     {{ end }}
-    <link rel="canonical" href="https://flatcar-linux.org/" />
+    <link rel="canonical" href="{{ or .Params.canonical .Permalink }}" />
     {{ hugo.Generator }}
 
     {{ $postImage := .Params.postimage }}
@@ -35,22 +37,13 @@
             {{- if in (slice "image/jpeg" "image/jpg" "image/png") (string $image.MediaType) -}}
                 {{- $imagePath = ($image.Resize "920x png q100").RelPermalink -}}
             {{- end -}}
-            {{- $baseURL := $.Site.BaseURL -}}
-            {{/* Trim last / */}}
-            {{- if eq (substr $baseURL -1 1) "/" -}}
-                {{- $baseURL = substr $baseURL 0 -1  -}}
-            {{- end -}}
-            {{- if eq $baseURL "" -}}
-                {{- $baseURL = "https://flatcar-linux.org"  -}}
-            {{- end -}}
-
-            {{- $postImage = printf "%s%s" $baseURL $imagePath -}}
+            {{- $postImage = $imagePath | absURL -}}
             {{- $ogImageWidth = 0 -}}
             {{- $ogImageHeight = 0 -}}
         {{- end -}}
     {{ end }}
 
-    {{ $ogImage := default "https://www.flatcar-linux.org/images/social-card.png" $postImage }}
+    {{ $ogImage := default ("/images/social-card.png" | absURL) $postImage }}
 
     {{ $title := .Title }}
 
@@ -59,13 +52,12 @@
     {{- end -}}
 
     {{ $ogTitle := default "Flatcar Container Linux" $title }}
-    {{ $ogDescription := default $ogTitle (default .Params.description .Params.tagline) }}
 
     <!-- Open Graph meta tags -->
     <meta property="og:locale" content="en_US" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="{{ $ogTitle }}" />
-    <meta property="og:description" content="{{ $ogDescription }}" />
+    <meta property="og:description" content="{{ $description }}" />
     <meta property="og:url" content="{{ .Permalink }}" />
     <meta property="og:site_name" content="Flatcar" />
     <meta property="article:modified_time" content="{{ hugo.BuildDate }}" />

--- a/themes/flatcar/layouts/partials/header.html
+++ b/themes/flatcar/layouts/partials/header.html
@@ -30,7 +30,7 @@
       {{/* Use "navbar_class=dark" in the front-matter for the dark theme menus. */}}
       <nav class="w-100 p-0 navbar navbar-expand-md justify-content-md-between {{ default "" .Params.navbar_class }}">
 
-        <a href="{{ .Site.BaseURL }}" class="navbar-brand">
+        <a href="{{ "/" | relURL }}" class="navbar-brand">
             {{ partial "logo.html" . }}
         </a>
 

--- a/themes/flatcar/layouts/partials/open-source-projects.html
+++ b/themes/flatcar/layouts/partials/open-source-projects.html
@@ -8,7 +8,7 @@
   {{ range $items }}
     {{ $hasContent := (len .Content)|lt 1 }}
     <div class="col-12 col-md-{{ $numCols }}">
-      <h4><a href={{ cond $hasContent .Permalink .Params.link }}>{{ or .Params.name .Params.title }}</a></h4>
+      <h4><a href={{ cond $hasContent .RelPermalink .Params.link }}>{{ or .Params.name .Params.title }}</a></h4>
       {{ if $showDescription }}
         <p>{{ .Params.description }}</p>
       {{ end }}

--- a/themes/flatcar/layouts/partials/paginator.html
+++ b/themes/flatcar/layouts/partials/paginator.html
@@ -12,12 +12,12 @@
                     {{- $imagePath = ($image.Resize "500x webp q100").RelPermalink -}}
                 {{- end -}}
                 {{- end -}}
-                <a href="{{ .Permalink }}">
+                <a href="{{ .RelPermalink }}">
                     <img src="{{ $imagePath }}" alt="post image">
                 </a>
             </div>
             <div class="card-body">
-                <a href="{{ .Permalink }}" class="post__title">
+                <a href="{{ .RelPermalink }}" class="post__title">
                     <h4 class="card-title mb-2">{{ .Title }}</h4>
                 </a>
                 <p>

--- a/themes/flatcar/layouts/partials/product/highlight.html
+++ b/themes/flatcar/layouts/partials/product/highlight.html
@@ -25,7 +25,7 @@
           <p>{{ .Description }}</p>
           <div class="w-100 justify-content-center mt-4 section-link">
             <a
-              href="{{ .Permalink }}"
+              href="{{ .RelPermalink }}"
               class="btn btn-md"
               style="background-color: {{ $styles.accent.fgcolor }}"
               {{ if .Params.cta_aria_label }}aria-label="{{ .Params.cta_aria_label }}"{{ end }}

--- a/themes/flatcar/layouts/partials/related-posts.html
+++ b/themes/flatcar/layouts/partials/related-posts.html
@@ -28,7 +28,7 @@
                     {{- $imagePath = ($image.Resize "318x webp q100").RelPermalink -}}
                 {{- end -}}
                 {{- end -}}
-                <a href="{{ .Permalink }}">
+                <a href="{{ .RelPermalink }}">
                     <img src="{{ $imagePath }}" class="card-img-top" alt="post image">
                 </a>
                 <div class="card-body">

--- a/themes/flatcar/layouts/section/blog.html
+++ b/themes/flatcar/layouts/section/blog.html
@@ -31,12 +31,12 @@
                   </div>
                   <div class="col-12 col-lg-6 order-last order-lg-first card post-hero__content p-0 rounded-0">
                     <div class="card-body">
-                      <a href="{{ .Permalink }}" class="card-title post__title" aria-label="Read more about {{ .Title }}">
+                      <a href="{{ .RelPermalink }}" class="card-title post__title" aria-label="Read more about {{ .Title }}">
                         <h2>{{ .Title }}</h2>
                       </a>
                       {{ partial "authors.html" (dict "context" . "with_date" true "message" "By")  }}
                       <p  class="read-more">
-                        <a href="{{ .Permalink }}" aria-label="Read more about {{ .Title }}">Read more
+                        <a href="{{ .RelPermalink }}" aria-label="Read more about {{ .Title }}">Read more
                           <svg class="btn-arrow__icon" viewBox="0 0 12 15">
                             <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="/images/arrow.svg#arrow"></use>
                           </svg>


### PR DESCRIPTION
Fixes flatcar/Flatcar#2367

## What was wrong

Every page emitted the same canonical tag:

```html
<link rel="canonical" href="https://flatcar-linux.org/" />
```

It was hardcoded in `head.html`. The domain redirects to [www.flatcar.org](https://www.flatcar.org/), and it points at the homepage, so all 230 pages claimed to be duplicates of one page.

`baseurl` was also set to `/`. Hugo therefore wrote relative URLs into `sitemap.xml`, the RSS feeds and `og:url`. The sitemap protocol requires absolute URLs in `<loc>`, so none of the 230 entries were valid. RSS links were dead in feed readers.

The meta description was hardcoded to "Flatcar Linux" on every page, even though 81 docs pages already set a `description` in their front matter.

## What changed

Three commits:

1. Internal links and assets now use `RelPermalink`, `relref` and `relURL`. This is a no-op today, but it stops every in-site link from turning absolute in the next commit. Preview builds keep working.
2. `baseurl` is set to `https://www.flatcar.org/` and `canonifyurls` is disabled. `make serve` passes its own base URL since it builds to disk.
3. The canonical tag comes from the page permalink. A `canonical` front matter key is available for pages that need to point elsewhere. The meta description falls back through description, tagline, summary and site description.

## Testing

Built with Hugo Extended 0.163.3 from `.env`. I built `main` in a worktree and diffed all 1020 output files.

- Same file inventory, same 319 pages, same pre-existing warnings.
- The only changes are the four metadata tags, plus 368 alias redirect stubs that now carry absolute canonicals. No internal `href`, asset URL or page body changed.
- Sitemap went from 0/230 to 230/230 absolute. RSS channel, `atom:link` and item links are absolute.
- Built with `-b https://preview-123.example.net/` to confirm previews stay self-contained. Canonical and sitemap follow the override while nav and CSS stay root relative.
- `pagefind` indexes 154 pages and 10317 words, same as before.
- Each commit builds on its own.