### PR TITLE
fix(tools): raise error in latestVersion when FLATCAR_VERSION is missing

### DIFF
--- a/tools/fcl-fetch-version-data.py
+++ b/tools/fcl-fetch-version-data.py
@@ -32,13 +32,14 @@ def latestVersion(channel = 'stable', board = 'amd64-usr'):
     url = 'https://%s.release.flatcar-linux.net/%s/current/version.txt' % (channel, board)
     try:
         versionTxt = fetch(url)
-        match = re.findall('FLATCAR_VERSION=(.*)', versionTxt)
-        if len(match) > 0:
-            return match[0]
     except HTTPError as e:
         if e.status != 404:
             raise
         return 'unreleased'
+    match = re.findall('FLATCAR_VERSION=(.*)', versionTxt)
+    if len(match) == 0:
+        raise RuntimeError('Could not find FLATCAR_VERSION in %s' % url)
+    return match[0]
 
 def listAMIs(channel = 'stable', board = 'amd64-usr'):
     url = 'https://%s.release.flatcar-linux.net/%s/current/flatcar_production_ami_all.json' % (channel, board)

--- a/tools/test_fcl_fetch_version_data.py
+++ b/tools/test_fcl_fetch_version_data.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import re
+import sys
+import unittest
+from urllib.error import HTTPError
+
+spec = importlib.util.spec_from_file_location('fcl_fetch_version_data',
+        '/home/deepak-bhagat/Desktop/flatcar-website/tools/fcl-fetch-version-data.py')
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+
+
+def _fake_fetch(body):
+    def fetch(url):
+        return body
+    return fetch
+
+
+class LatestVersionTests(unittest.TestCase):
+    def test_returns_version_on_match(self):
+        m.fetch = _fake_fetch('FLATCAR_VERSION=3033.2.1\nCOREOS_VERSION=3033.2.1\n')
+        self.assertEqual(m.latestVersion('stable'), '3033.2.1')
+
+    def test_raises_on_missing_match(self):
+        m.fetch = _fake_fetch('OTHER=123\nSOMETHING_ELSE=456\n')
+        with self.assertRaises(RuntimeError):
+            m.latestVersion('stable')
+
+    def test_404_returns_unreleased(self):
+        def fetch_404(url):
+            raise HTTPError(url, 404, 'not found', {}, None)
+        m.fetch = fetch_404
+        self.assertEqual(m.latestVersion('stable'), 'unreleased')
+
+    def test_non_404_reraises(self):
+        def fetch_500(url):
+            raise HTTPError(url, 500, 'server error', {}, None)
+        m.fetch = fetch_500
+        with self.assertRaises(HTTPError):
+            m.latestVersion('stable')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
latestVersion() in tools/fcl-fetch-version-data.py implicitly returned None when the fetched version.txt contained no FLATCAR_VERSION= line. That None propagated into the generated YAML as null, silently corrupting version data.

The fetch/HTTPError handling is now reordered so a successful fetch with no matching line raises RuntimeError instead of falling through. The existing 404 behavior (treated as unreleased) and the non-404 re-raise path are preserved.

Added tools/test_fcl_fetch_version_data.py covering the missing-version case, the 404 path, and the re-raise path.

Fixes flatcar/flatcar-website#686