### PR TITLE
Add KVM setup to quickstart.md 

### DIFF
--- a/content/docs/latest/getting-started/quickstart.md
+++ b/content/docs/latest/getting-started/quickstart.md
@@ -45,6 +45,24 @@ mv flatcar_production_qemu_image.img flatcar_production_qemu_image.img.fresh
 cp -i --reflink=auto flatcar_production_qemu_image.img.fresh flatcar_production_qemu_image.img
 ```
 
+## Enable hardware-accelerated virtualization
+
+On Windows/WSL and Ubuntu, QEMU uses KVM for hardware-accelerated virtualization. Your local user needs to be a member of the `kvm` group. You only need to do this once.
+
+Check whether your user is already in the `kvm` group:
+
+```bash
+id
+```
+If `kvm` is not listed in the groups section, add your user: 
+```bash
+sudo usermod -a -G kvm <your-username> 
+```
+The command might prompt you for your user password. Then, to apply the change in the current session, run: 
+```bash 
+newgrp kvm 
+``` 
+
 ## Provision with Butane and Ignition
 
 Now we will provision the VM on first boot through Ignition. Instead of writing the JSON config, we use Butane YAML and transpile it. Save the following Butane YAML file as `cl.yaml` (or another name). It contains directives for setting up a systemd service that runs an NGINX Docker container:

--- a/content/docs/latest/getting-started/quickstart.md
+++ b/content/docs/latest/getting-started/quickstart.md
@@ -45,6 +45,27 @@ mv flatcar_production_qemu_image.img flatcar_production_qemu_image.img.fresh
 cp -i --reflink=auto flatcar_production_qemu_image.img.fresh flatcar_production_qemu_image.img
 ```
 
+## Enable hardware-accelerated virtualization
+
+On Linux-based systems, QEMU uses KVM for hardware-accelerated virtualization. The current user needs to be a member of the `kvm` group.
+
+Check whether your user is already in the `kvm` group:
+
+```bash
+id -nG
+```
+If `kvm` is not listed, please proceed with adding your user to the `kvm` group. Note that adding the user to a group is an one-time configuration step; the membership persists across subsequent login sessions and system reboots.
+
+```bash
+sudo usermod -aG kvm "$USER"
+```
+
+The command might prompt you for your user password. To apply the new group membership to the current shell without logging out, run:
+
+```bash
+newgrp kvm
+```
+
 ## Provision with Butane and Ignition
 
 Now we will provision the VM on first boot through Ignition. Instead of writing the JSON config, we use Butane YAML and transpile it. Save the following Butane YAML file as `cl.yaml` (or another name). It contains directives for setting up a systemd service that runs an NGINX Docker container:


### PR DESCRIPTION
### Add KVM setup instructions to Quickstart

Added instructions for checking and enabling KVM access before starting QEMU on Linux-based systems. 

### Testing done

Tested on Ubuntu by verifying KVM group membership and successfully starting the Flatcar QEMU VM.






- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
