### PR TITLE
fix(tools): catch URLError in latestVersion and listAMIs

### DIFF
--- a/tools/fcl-fetch-version-data.py
+++ b/tools/fcl-fetch-version-data.py
@@ -18,14 +18,14 @@ import sys
 import yaml
 
 from urllib.request import urlopen, Request
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 
 
 def fetch(url):
     # Set a custom User Agent string to avoid Cloudflare blocking.
     headers = {'User-Agent': 'Flatcar Container Linux AMI querying tool for generating documentation'}
     request = Request(url, headers=headers)
-    response = urlopen(request).read().decode('utf-8')
+    response = urlopen(request, timeout=30).read().decode('utf-8')
     return response
 
 def latestVersion(channel = 'stable', board = 'amd64-usr'):
@@ -39,6 +39,8 @@ def latestVersion(channel = 'stable', board = 'amd64-usr'):
         if e.status != 404:
             raise
         return 'unreleased'
+    except URLError as e:
+        raise RuntimeError("Failed to fetch version data for %s/%s: %s" % (channel, board, e.reason)) from e
 
 def listAMIs(channel = 'stable', board = 'amd64-usr'):
     url = 'https://%s.release.flatcar-linux.net/%s/current/flatcar_production_ami_all.json' % (channel, board)
@@ -49,6 +51,8 @@ def listAMIs(channel = 'stable', board = 'amd64-usr'):
         if e.status != 404:
             raise
         return []
+    except URLError as e:
+        raise RuntimeError("Failed to fetch AMI data for %s/%s: %s" % (channel, board, e.reason)) from e
 
 def main(file_to_replace):
     stableAMD = latestVersion('stable')

--- a/tools/test_fcl_fetch_version_data.py
+++ b/tools/test_fcl_fetch_version_data.py
@@ -1,0 +1,64 @@
+import io
+import importlib.util
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+_spec = importlib.util.spec_from_file_location(
+    "fcl_fetch_version_data",
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "fcl-fetch-version-data.py"),
+)
+fcl = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(fcl)
+
+
+class TestLatestVersion(unittest.TestCase):
+
+    def test_returns_version_on_success(self):
+        with mock.patch.object(fcl, 'fetch', return_value='FLATCAR_VERSION=3033.2.2\nFLATCAR_BUILD=2\n'):
+            self.assertEqual(fcl.latestVersion('stable'), '3033.2.2')
+
+    def test_returns_unreleased_on_404(self):
+        err = fcl.HTTPError('https://stable.release.flatcar-linux.net/amd64-usr/current/version.txt', 404, 'Not Found', {}, None)
+        with mock.patch.object(fcl, 'fetch', side_effect=err):
+            self.assertEqual(fcl.latestVersion('stable'), 'unreleased')
+
+    def test_propagates_non_404_http_error(self):
+        err = fcl.HTTPError('https://stable.release.flatcar-linux.net/amd64-usr/current/version.txt', 500, 'Server Error', {}, None)
+        with mock.patch.object(fcl, 'fetch', side_effect=err):
+            with self.assertRaises(fcl.HTTPError):
+                fcl.latestVersion('stable')
+
+    def test_urlerror_raises_runtime_error(self):
+        err = fcl.URLError('Name or service not known')
+        with mock.patch.object(fcl, 'fetch', side_effect=err):
+            with self.assertRaises(RuntimeError) as ctx:
+                fcl.latestVersion('stable')
+            self.assertIn('Name or service not known', str(ctx.exception))
+
+
+class TestListAMIs(unittest.TestCase):
+
+    def test_returns_amis_on_success(self):
+        payload = '{"amis": [{"name": "ami-1", "hvm": true}]}'
+        with mock.patch.object(fcl, 'fetch', return_value=payload):
+            self.assertEqual(fcl.listAMIs('stable'), [{'name': 'ami-1', 'hvm': True}])
+
+    def test_returns_empty_on_404(self):
+        err = fcl.HTTPError('https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_ami_all.json', 404, 'Not Found', {}, None)
+        with mock.patch.object(fcl, 'fetch', side_effect=err):
+            self.assertEqual(fcl.listAMIs('stable'), [])
+
+    def test_urlerror_raises_runtime_error(self):
+        err = fcl.URLError('timed out')
+        with mock.patch.object(fcl, 'fetch', side_effect=err):
+            with self.assertRaises(RuntimeError) as ctx:
+                fcl.listAMIs('stable')
+            self.assertIn('timed out', str(ctx.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Network-level failures (DNS, timeout, connection refused) raise `urllib.error.URLError`, which is **not** a subclass of `HTTPError` and was therefore uncaught. The exception propagated through `main()` and crashed the script before any output file was written.

## Changes
- Import `URLError` and catch it in `latestVersion()` and `listAMIs()`, raising a clear `RuntimeError` with the underlying reason (`e.reason`).
- Add a `timeout=30` to `urlopen` so unreachable hosts fail deterministically instead of hanging indefinitely.
- Add unit tests covering: success, 404 fallback, non-404 HTTPError propagation, and `URLError` -> `RuntimeError` (7/7 passing).

## Verification
```
python3 tools/test_fcl_fetch_version_data.py
.......
Ran 7 tests in 0.005s
OK
```

Fixes flatcar/Flatcar#2364.

Note: this edits `tools/fcl-fetch-version-data.py`, the same file as the open PR flatcar/flatcar-website#688 (flatcar flatcar/Flatcar#2365, which fixed the silent `None` return). The two are independent fixes; one will need a rebase after the other merges to resolve the overlapping `except` block. Happy to rebase on request.